### PR TITLE
chore: add LICENSE to npm package files array

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "LICENSE"
   ],
   "scripts": {
     "dev": "smithery dev",


### PR DESCRIPTION
Ensure LICENSE file is included in npm package distribution so Smithery can detect it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)