### PR TITLE
fix: Add smithery.config.js to preserve import.meta.url in ESM bundles

### DIFF
--- a/smithery.config.js
+++ b/smithery.config.js
@@ -1,0 +1,7 @@
+// Smithery build configuration
+// Override default CommonJS format to ESM to preserve import.meta.url
+export default {
+  esbuild: {
+    format: "esm"
+  }
+}


### PR DESCRIPTION
Fixes template system "Invalid URL" error by overriding Smithery CLI's default CommonJS bundling format to ESM.

Root cause: Smithery CLI bundles to CJS by default, which transforms import.meta into an empty object {}, breaking our URL-based template path resolution in src/notebook/state.ts:95-96.

Solution: Configure esbuild to output ESM format, which preserves import.meta.url semantics needed for dynamic template loading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)