### PR TITLE
feat: add filesystem sync for mental models

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -334,6 +334,12 @@ export default function createServer({
   const notebookServer = new NotebookServer();
   const mentalModelsServer = new MentalModelsServer();
 
+  // Sync mental models to filesystem for inspection
+  // URI: thoughtbox://mental-models/{tag}/{model} → ~/.thoughtbox/mental-models/{tag}/{model}.md
+  mentalModelsServer.syncToFilesystem().catch((err) => {
+    console.error("Failed to sync mental models to filesystem:", err);
+  });
+
   // Note: NotebookServer uses lazy initialization - temp directories created on first use
 
   server.setRequestHandler(ListToolsRequestSchema, async () => ({


### PR DESCRIPTION
## Summary

Adds filesystem synchronization for mental models, writing them to `~/.thoughtbox/mental-models/{tag}/{model}.md`. This mirrors the URI hierarchy and allows:
- Human inspection of models
- Docker volume persistence
- Integration with external tools

### Changes
- Added `syncToFilesystem()` method to MentalModelsServer
- Writes models organized by tag at server startup
- Updated .gitignore to exclude .thoughtbox directory

## Test plan

- [ ] Start server and verify models written to ~/.thoughtbox/mental-models/
- [ ] Verify directory structure matches tag hierarchy
- [ ] Verify model content is correct markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)