### PR TITLE
feat: Expand cipher as protocol layer with domain vocabulary

### DIFF
--- a/src/resources/thoughtbox-cipher-content.ts
+++ b/src/resources/thoughtbox-cipher-content.ts
@@ -1,14 +1,49 @@
 /**
- * Thoughtbox Compression Cipher
+ * Thoughtbox Cipher Protocol
  *
- * A notation system for token-efficient reasoning. Agents can retrieve this
- * cipher via the `thoughtbox_cipher` tool and use it to reduce context window
- * consumption during extended reasoning chains.
+ * A formal protocol layer for structured reasoning. The cipher enables
+ * deterministic server-side parsing of thought structure—the server extracts
+ * IDs, types, references, and relationships without inference.
+ *
+ * The cipher is to Thoughtbox what HTTP verbs are to REST: a contract that
+ * enables protocol-compliant processing without intelligence on the server side.
  */
 
 export const THOUGHTBOX_CIPHER = `# Thoughtbox Compression Cipher
 
-A notation system for token-efficient reasoning. Agents can retrieve this cipher via the \`thoughtbox_cipher\` tool and use it to reduce context window consumption during extended reasoning chains.
+A formal protocol for structured reasoning. The cipher is not merely a compression format—it is a **protocol layer** that enables deterministic server-side processing of thought structure.
+
+---
+
+## The Cipher as Protocol
+
+The cipher sits in the same conceptual space as MCP itself:
+
+\`\`\`
+┌─────────────────────────────────┐
+│  Natural language intent        │  ← Intelligence (client/agent)
+├─────────────────────────────────┤
+│  Thoughtbox Cipher              │  ← Protocol (formal contract)
+├─────────────────────────────────┤
+│  MCP (tool calls, responses)    │  ← Protocol
+├─────────────────────────────────┤
+│  HTTP/Transport                 │  ← Protocol
+└─────────────────────────────────┘
+\`\`\`
+
+**Why this matters:**
+- Intelligence transforms intent into cipher (agent's job)
+- Everything below is protocol processing (deterministic)
+- Server can parse cipher without inference—just contract fulfillment
+- Using cipher = speaking the native protocol of Thoughtbox
+
+When you write \`S47|H|S45|API latency ↑ bc db regression\`, you are encoding structure explicitly. The server extracts thought number, type, references, and relationships through parsing, not interpretation.
+
+**The cipher enables:**
+- Auto-inference of thought structure (no manual tracking of thoughtNumber, totalThoughts)
+- Automatic link building from \`[SN]\` references
+- Revision detection from \`^[SN]\` markers
+- Relationship graphs from typed references
 
 ---
 
@@ -107,35 +142,84 @@ Append to any statement to indicate certainty level.
 
 High-frequency reasoning words compressed to short forms.
 
+### Logical Connectives
 | Abbrev | Expansion |
 |--------|-----------|
 | \`bc\` | because |
 | \`tf\` | therefore |
 | \`hw\` | however |
 | \`impl\` | implies/implication |
+| \`b/c\` | because |
+
+### Reasoning Terms
+| Abbrev | Expansion |
+|--------|-----------|
+| \`hyp\` | hypothesis |
+| \`ev\` | evidence |
+| \`assm\` | assume/assumption |
+| \`obs\` | observe/observation |
+| \`conf\` | confirm/confirmed |
+| \`contra\` | contradicts/contradiction |
+| \`rsn\` | reasoning/reason |
+| \`synth\` | synthesis/synthesize |
+| \`ptn\` | pattern |
+
+### State & Validation
+| Abbrev | Expansion |
+|--------|-----------|
 | \`req\` | requires/requirement |
 | \`dep\` | depends/dependency |
 | \`val\` | valid/validate |
 | \`inv\` | invalid/invalidate |
-| \`conf\` | confirm/confirmed |
-| \`contra\` | contradicts/contradiction |
-| \`assm\` | assume/assumption |
-| \`obs\` | observe/observation |
-| \`hyp\` | hypothesis |
-| \`ev\` | evidence |
 | \`prob\` | probability/problem |
 | \`sol\` | solution |
-| \`alt\` | alternative |
-| \`ctx\` | context |
+
+### Temporal & Position
+| Abbrev | Expansion |
+|--------|-----------|
 | \`prev\` | previous |
 | \`curr\` | current |
 | \`init\` | initial |
 | \`fin\` | final |
 | \`pt\` | point |
+| \`ctx\` | context |
+
+### Agent & System Terms
+| Abbrev | Expansion |
+|--------|-----------|
+| \`agt\` | agent |
+| \`cog\` | cognitive/cognition |
+| \`emb\` | embodiment/embodied |
+| \`cap\` | capability |
+| \`cfg\` | configuration |
+| \`sess\` | session |
+| \`mech\` | mechanism |
+| \`behav\` | behavior |
+| \`exp\` | experience |
+| \`struct\` | structure |
+| \`integ\` | integration |
+| \`trans\` | transition |
+
+### Comparisons & Modality
+| Abbrev | Expansion |
+|--------|-----------|
+| \`alt\` | alternative |
+| \`eg\` | example (e.g.) |
+| \`sim\` | similar |
+| \`diff\` | different |
+| \`spec\` | specific |
+| \`gen\` | general |
+| \`btwn\` | between |
+| \`w/in\` | within |
+| \`poss\` | possible |
+| \`nec\` | necessary |
+
+### Qualifiers
+| Abbrev | Expansion |
+|--------|-----------|
 | \`re:\` | regarding |
 | \`w/\` | with |
 | \`w/o\` | without |
-| \`b/c\` | because |
 | \`esp\` | especially |
 | \`approx\` | approximately |
 | \`sig\` | significant |

--- a/src/tool-descriptions.ts
+++ b/src/tool-descriptions.ts
@@ -67,15 +67,19 @@ Domain selection enables mental_models with structured reasoning frameworks filt
  * Cipher tool descriptions by stage
  */
 export const CIPHER_DESCRIPTIONS: Partial<Record<DisclosureStage, string>> = {
-  [DisclosureStage.STAGE_1_INIT_COMPLETE]: `Returns Thoughtbox's notation system for token-efficient reasoning.
+  [DisclosureStage.STAGE_1_INIT_COMPLETE]: `Returns Thoughtbox's formal protocol for structured reasoning.
 
-IMPORTANT: Call this tool BEFORE using thoughtbox. The notation system significantly reduces token usage during multi-step reasoning.
+The cipher is not just compression—it is a **protocol layer** that enables deterministic server-side processing. When you use the cipher correctly, the server can parse thought structure (IDs, types, references, revisions) without inference.
+
+IMPORTANT: Call this tool BEFORE using thoughtbox. The cipher is the native language of Thoughtbox.
 
 After calling this tool, the main thoughtbox reasoning tool will become available.
 
 NOTE: If newly unlocked tools don't appear, use the 'thoughtbox_gateway' tool instead - it's always available and routes to the same handlers.`,
 
-  [DisclosureStage.STAGE_2_CIPHER_LOADED]: `Returns Thoughtbox's notation system for token-efficient reasoning.
+  [DisclosureStage.STAGE_2_CIPHER_LOADED]: `Returns Thoughtbox's formal protocol for structured reasoning.
+
+The cipher is a protocol layer—like MCP itself. Using it enables automatic structure inference: thought numbers, references, revisions, and relationships are parsed deterministically from your cipher-encoded content.
 
 Reference material - you have already loaded this. Use for refreshing notation conventions during long sessions.`,
 };


### PR DESCRIPTION
## Summary
- Frame the cipher as a **protocol layer** (not just compression) that enables deterministic server-side parsing
- Add protocol stack diagram showing cipher sits alongside MCP in the conceptual stack
- Expand abbreviated vocabulary with domain-specific terms from actual reasoning traces

## Changes

### Cipher as Protocol Documentation
Added new section explaining that the cipher is a formal contract enabling protocol-compliant processing without intelligence on the server side. IDs, types, references, and relationships are extracted through parsing, not inference.

```
┌─────────────────────────────────┐
│  Natural language intent        │  ← Intelligence (client/agent)
├─────────────────────────────────┤
│  Thoughtbox Cipher              │  ← Protocol (formal contract)
├─────────────────────────────────┤
│  MCP (tool calls, responses)    │  ← Protocol
├─────────────────────────────────┤
│  HTTP/Transport                 │  ← Protocol
└─────────────────────────────────┘
```

### New Vocabulary (from reasoning trace analysis)
- **Agent & System Terms**: agt, cog, emb, cap, cfg, sess, mech, behav, exp, struct, integ, trans
- **Reasoning Terms**: rsn, synth, ptn
- **Comparisons & Modality**: eg, sim, diff, spec, gen, btwn, w/in, poss, nec

## Test plan
- [x] Docker container builds successfully
- [x] Server starts and responds on port 1731
- [x] Cipher content accessible via `thoughtbox_cipher` tool

🤖 Generated with [Claude Code](https://claude.ai/code)