### PR TITLE
refactor: Move test files from src/ to tests/unit/

### DIFF
--- a/tests/unit/config-loader.test.ts
+++ b/tests/unit/config-loader.test.ts
@@ -3,7 +3,7 @@
  * Unit tests for Benchmark Suite Configuration Loader
  * SPEC: SIL-002
  *
- * Run with: npx tsx benchmarks/config-loader.test.ts
+ * Run with: npx tsx tests/unit/config-loader.test.ts
  */
 
 import {
@@ -16,7 +16,7 @@ import {
   getProctoringStatus,
   BenchmarkConfigSchema,
   type BenchmarkConfig,
-} from "./config-loader.js";
+} from "../../benchmarks/config-loader.js";
 import { writeFileSync, unlinkSync, mkdirSync, rmSync } from "fs";
 import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";

--- a/tests/unit/contamination.test.ts
+++ b/tests/unit/contamination.test.ts
@@ -1,0 +1,502 @@
+#!/usr/bin/env npx tsx
+/**
+ * Unit tests for Contamination Detection
+ * SPEC: SIL-009
+ *
+ * Run with: npx tsx tests/unit/contamination.test.ts
+ */
+
+import {
+  ContaminationDetector,
+  resetContaminationDetector,
+  DEFAULT_CONTAMINATION_CONFIG,
+  EXPECTED_SOLVE_TIMES,
+  type TestCase,
+  type KnownSolution,
+} from "../../benchmarks/contamination.js";
+
+// =============================================================================
+// Test Utilities
+// =============================================================================
+
+let testsPassed = 0;
+let testsFailed = 0;
+let currentTest = "";
+
+function test(name: string, fn: () => void | Promise<void>): void {
+  currentTest = name;
+  Promise.resolve(fn())
+    .then(() => {
+      testsPassed++;
+      console.log(`  \u2713 ${name}`);
+    })
+    .catch((err) => {
+      testsFailed++;
+      console.error(`  \u2717 ${name}`);
+      console.error(`    Error: ${err.message}`);
+    });
+}
+
+function assert(condition: boolean, message?: string): void {
+  if (!condition) {
+    throw new Error(message || `Assertion failed in "${currentTest}"`);
+  }
+}
+
+function assertEqual<T>(actual: T, expected: T, message?: string): void {
+  if (actual !== expected) {
+    throw new Error(
+      message ||
+        `Expected "${expected}" but got "${actual}" in "${currentTest}"`
+    );
+  }
+}
+
+function assertApproxEqual(
+  actual: number,
+  expected: number,
+  tolerance: number,
+  message?: string
+): void {
+  if (Math.abs(actual - expected) > tolerance) {
+    throw new Error(
+      message ||
+        `Expected ~${expected} (±${tolerance}) but got ${actual} in "${currentTest}"`
+    );
+  }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+async function runTests(): Promise<void> {
+  console.log("\nContamination Detection Tests\n");
+
+  // Reset singleton before tests
+  resetContaminationDetector();
+
+  // -------------------------------------------------------------------------
+  // R1: Similarity Checking Tests
+  // -------------------------------------------------------------------------
+
+  console.log("R1: Similarity Checking Tests:");
+
+  test("detects high similarity to known solution", () => {
+    const detector = new ContaminationDetector();
+    const knownSolution = "function add(a, b) { return a + b; }";
+    detector.addToTrainingSet("test-1", knownSolution);
+
+    const result = detector.checkContamination(
+      "function add(a, b) { return a + b; }",
+      { id: "test-1", name: "Add", difficulty: "easy" }
+    );
+
+    assert(result.contaminated === true, "Should detect identical solution as contaminated");
+    assert(result.checks.similarity !== undefined, "Should have similarity check");
+    assert(result.checks.similarity!.contaminated === true, "Similarity check should flag contamination");
+  });
+
+  test("passes novel solutions with low similarity", () => {
+    const detector = new ContaminationDetector();
+    detector.addToTrainingSet(
+      "test-1",
+      "function add(a, b) { return a + b; }"
+    );
+
+    const result = detector.checkContamination(
+      "const multiply = (x, y) => x * y;",
+      { id: "test-1", name: "Add", difficulty: "easy" }
+    );
+
+    // Novel solution should not be contaminated
+    assert(
+      result.checks.similarity?.contaminated === false,
+      "Novel solution should not be flagged"
+    );
+  });
+
+  test("checkSimilarity returns correct values", () => {
+    const detector = new ContaminationDetector();
+    const known = "The quick brown fox jumps over the lazy dog";
+
+    const identical = detector.checkSimilarity(known, known);
+    assertApproxEqual(identical.similarity, 1.0, 0.01);
+
+    const different = detector.checkSimilarity(
+      "A completely different sentence with no overlap",
+      known
+    );
+    assert(different.similarity < 0.5, `Expected low similarity but got ${different.similarity}`);
+  });
+
+  test("similarity threshold is configurable", () => {
+    const strictDetector = new ContaminationDetector({ similarityThreshold: 0.5 });
+    const lenientDetector = new ContaminationDetector({ similarityThreshold: 0.99 });
+
+    const known = "The quick brown fox jumps over the lazy dog";
+    const similar = "The quick brown fox leaps over the lazy dog"; // slightly different
+
+    strictDetector.addToTrainingSet("test-1", known);
+    lenientDetector.addToTrainingSet("test-1", known);
+
+    const strictResult = strictDetector.checkContamination(similar, {
+      id: "test-1",
+      name: "Test",
+      difficulty: "easy",
+    });
+    const lenientResult = lenientDetector.checkContamination(similar, {
+      id: "test-1",
+      name: "Test",
+      difficulty: "easy",
+    });
+
+    // Same input, different thresholds should give different results
+    assert(
+      strictResult.checks.similarity!.threshold !== lenientResult.checks.similarity!.threshold,
+      "Thresholds should differ"
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // R2: Timing Analysis Tests
+  // -------------------------------------------------------------------------
+
+  console.log("\nR2: Timing Analysis Tests:");
+
+  test("detects suspiciously fast solve time", () => {
+    const detector = new ContaminationDetector();
+
+    const result = detector.checkContamination("solution here", {
+      id: "test-2",
+      name: "Test",
+      difficulty: "hard",
+      solveTime: 5000, // 5 seconds for a "hard" problem (expected 15 min)
+    });
+
+    assert(result.checks.timing !== undefined, "Should have timing check");
+    assert(result.checks.timing!.contaminated === true, "Should flag suspiciously fast solve");
+    assert(result.contaminated === true, "Overall should be contaminated");
+  });
+
+  test("passes reasonable solve times", () => {
+    const detector = new ContaminationDetector();
+
+    const result = detector.checkContamination("solution here", {
+      id: "test-2",
+      name: "Test",
+      difficulty: "medium",
+      solveTime: 200000, // 200 seconds (expected 5 min = 300s)
+    });
+
+    assert(
+      result.checks.timing?.contaminated === false,
+      "Reasonable solve time should not be flagged"
+    );
+  });
+
+  test("checkTiming uses correct expected times by difficulty", () => {
+    const detector = new ContaminationDetector();
+
+    const easyResult = detector.checkTiming({
+      id: "t1",
+      name: "Easy",
+      difficulty: "easy",
+      solveTime: 30000, // 30s
+    });
+    assertEqual(easyResult.expectedTime, EXPECTED_SOLVE_TIMES.easy);
+
+    const hardResult = detector.checkTiming({
+      id: "t2",
+      name: "Hard",
+      difficulty: "hard",
+      solveTime: 60000, // 1min
+    });
+    assertEqual(hardResult.expectedTime, EXPECTED_SOLVE_TIMES.hard);
+  });
+
+  test("fast solve threshold is configurable", () => {
+    const strictDetector = new ContaminationDetector({ fastSolveThreshold: 0.5 });
+
+    const result = strictDetector.checkTiming({
+      id: "t1",
+      name: "Test",
+      difficulty: "medium",
+      solveTime: 120000, // 2 min (40% of expected 5 min)
+    });
+
+    assert(result.contaminated === true, "40% should be flagged with 50% threshold");
+  });
+
+  // -------------------------------------------------------------------------
+  // R3: Reasoning Chain Analysis Tests
+  // -------------------------------------------------------------------------
+
+  console.log("\nR3: Reasoning Chain Analysis Tests:");
+
+  test("detects reasoning chain that jumps to solution", () => {
+    const detector = new ContaminationDetector();
+    const knownSolution = "The answer is to use map and filter to transform the array";
+    detector.addToTrainingSet("test-3", knownSolution);
+
+    // Jump detection checks the first third of thoughts
+    // With 6 thoughts, first third is thoughts 0-1, so solution in position 1 gets detected
+    const result = detector.checkContamination(knownSolution, {
+      id: "test-3",
+      name: "Test",
+      difficulty: "medium",
+      thoughtChain: [
+        "Let me look at this problem",
+        "The answer is to use map and filter to transform the array", // In first third (1 of 6)
+        "Some more thinking",
+        "Additional consideration",
+        "Further analysis",
+        "Done",
+      ],
+    });
+
+    assert(result.checks.reasoning !== undefined, "Should have reasoning check");
+    assert(
+      result.checks.reasoning!.jumpsToSolution === true,
+      "Should detect jump to solution"
+    );
+  });
+
+  test("passes clean reasoning with exploration", () => {
+    const detector = new ContaminationDetector();
+
+    const result = detector.checkContamination("A novel solution approach", {
+      id: "novel-test",
+      name: "Novel",
+      difficulty: "medium",
+      solveTime: 200000,
+      thoughtChain: [
+        "Let me understand the problem first",
+        "One approach could be using recursion",
+        "But alternatively, I could use iteration",
+        "Actually, what if I combine both approaches?",
+        "Hmm, let me think about edge cases",
+        "Considering the requirements again",
+        "Here is my final solution",
+      ],
+    });
+
+    assert(
+      result.checks.reasoning?.jumpsToSolution === false,
+      "Clean reasoning should not be flagged"
+    );
+    assert(
+      result.checks.reasoning!.explorationDepth >= 3,
+      `Expected exploration depth >= 3 but got ${result.checks.reasoning!.explorationDepth}`
+    );
+  });
+
+  test("analyzeReasoning counts exploration patterns", () => {
+    const detector = new ContaminationDetector();
+
+    const result = detector.analyzeReasoning([
+      "Let me think about this",
+      "What if we try a different approach?",
+      "Alternatively, we could...",
+      "But wait, there's another way",
+      "Actually, I should reconsider",
+    ]);
+
+    assert(result.explorationDepth >= 4, `Expected depth >= 4 but got ${result.explorationDepth}`);
+    assertEqual(result.thoughtCount, 5);
+  });
+
+  test("analyzeReasoning detects suspicious early claims", () => {
+    const detector = new ContaminationDetector();
+
+    const result = detector.analyzeReasoning([
+      "I already know the answer",
+      "The solution is...",
+    ]);
+
+    assert(
+      result.suspiciousPatterns.some((p) => p.includes("immediate knowledge")),
+      "Should detect early knowledge claims"
+    );
+  });
+
+  test("analyzeReasoning flags short chains", () => {
+    const detector = new ContaminationDetector();
+
+    const result = detector.analyzeReasoning(["Here's the answer"]);
+
+    assert(
+      result.suspiciousPatterns.some((p) => p.includes("short")),
+      "Should flag very short chains"
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // R4: Training Set Fingerprinting Tests
+  // -------------------------------------------------------------------------
+
+  console.log("\nR4: Training Set Fingerprinting Tests:");
+
+  test("addToTrainingSet adds solutions correctly", () => {
+    const detector = new ContaminationDetector();
+
+    detector.addToTrainingSet("case-1", "Solution A");
+    detector.addToTrainingSet("case-2", "Solution B");
+
+    assertEqual(detector.getTrainingSetSize(), 2);
+  });
+
+  test("isInTrainingSet detects exact matches", () => {
+    const detector = new ContaminationDetector();
+    const solution = "Exact solution text";
+
+    detector.addToTrainingSet("case-1", solution);
+
+    assert(detector.isInTrainingSet(solution) === true, "Should find exact match");
+    assert(
+      detector.isInTrainingSet("Different text") === false,
+      "Should not find different text"
+    );
+  });
+
+  test("isInTrainingSet normalizes whitespace", () => {
+    const detector = new ContaminationDetector();
+
+    detector.addToTrainingSet("case-1", "solution   with   spaces");
+
+    assert(
+      detector.isInTrainingSet("solution with spaces") === true,
+      "Should match with normalized whitespace"
+    );
+  });
+
+  test("loadTrainingSet loads multiple solutions", () => {
+    const detector = new ContaminationDetector();
+
+    const solutions: KnownSolution[] = [
+      {
+        testCaseId: "test-1",
+        solution: "Solution 1",
+        hash: "hash1",
+        addedToTraining: "2026-01-01",
+      },
+      {
+        testCaseId: "test-2",
+        solution: "Solution 2",
+        hash: "hash2",
+        addedToTraining: "2026-01-01",
+      },
+    ];
+
+    detector.loadTrainingSet(solutions);
+
+    assertEqual(detector.getTrainingSetSize(), 2);
+    assert(detector.isInTrainingSet("Solution 1") === true, "Should find loaded solution");
+  });
+
+  test("clearTrainingSet removes all solutions", () => {
+    const detector = new ContaminationDetector();
+
+    detector.addToTrainingSet("case-1", "Solution");
+    detector.clearTrainingSet();
+
+    assertEqual(detector.getTrainingSetSize(), 0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Confidence Calculation Tests
+  // -------------------------------------------------------------------------
+
+  console.log("\nConfidence Calculation Tests:");
+
+  test("confidence is calculated based on check results", () => {
+    const detector = new ContaminationDetector();
+    const knownSolution = "Known solution text for this test case";
+    detector.addToTrainingSet("test-1", knownSolution);
+
+    // Contaminated case - high similarity, fast solve, short chain
+    const contaminated = detector.checkContamination(knownSolution, {
+      id: "test-1",
+      name: "Test",
+      difficulty: "hard",
+      solveTime: 1000, // Very fast
+      thoughtChain: [knownSolution], // Short chain
+    });
+
+    // Clean case - novel solution, reasonable time, good reasoning
+    const clean = detector.checkContamination("Completely different novel solution", {
+      id: "unknown-test",
+      name: "Unknown",
+      difficulty: "easy",
+      solveTime: 50000, // Reasonable
+      thoughtChain: [
+        "Let me think about this",
+        "What if I try this approach?",
+        "Alternatively, I could...",
+        "After considering, here's my answer",
+      ],
+    });
+
+    // Both should have reasonable confidence (0-1 range)
+    assert(
+      contaminated.confidence >= 0 && contaminated.confidence <= 1,
+      `Contaminated confidence should be 0-1, got ${contaminated.confidence}`
+    );
+    assert(
+      clean.confidence >= 0 && clean.confidence <= 1,
+      `Clean confidence should be 0-1, got ${clean.confidence}`
+    );
+
+    // Contaminated case should flag contamination
+    assert(contaminated.contaminated === true, "Should detect contamination");
+    // Clean case should not flag contamination
+    assert(clean.contaminated === false, "Should not flag clean case");
+  });
+
+  // -------------------------------------------------------------------------
+  // Default Configuration Tests
+  // -------------------------------------------------------------------------
+
+  console.log("\nDefault Configuration Tests:");
+
+  test("DEFAULT_CONTAMINATION_CONFIG has expected values", () => {
+    assertEqual(DEFAULT_CONTAMINATION_CONFIG.similarityThreshold, 0.95);
+    assertEqual(DEFAULT_CONTAMINATION_CONFIG.fastSolveThreshold, 0.1);
+    assertEqual(DEFAULT_CONTAMINATION_CONFIG.minExplorationDepth, 3);
+  });
+
+  test("EXPECTED_SOLVE_TIMES has values for all difficulties", () => {
+    assert(EXPECTED_SOLVE_TIMES.easy > 0, "Should have easy time");
+    assert(EXPECTED_SOLVE_TIMES.medium > 0, "Should have medium time");
+    assert(EXPECTED_SOLVE_TIMES.hard > 0, "Should have hard time");
+    assert(
+      EXPECTED_SOLVE_TIMES.easy < EXPECTED_SOLVE_TIMES.medium,
+      "Easy should be faster than medium"
+    );
+    assert(
+      EXPECTED_SOLVE_TIMES.medium < EXPECTED_SOLVE_TIMES.hard,
+      "Medium should be faster than hard"
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Wait and Report
+  // -------------------------------------------------------------------------
+
+  await new Promise((resolve) => setTimeout(resolve, 200));
+
+  console.log("\n" + "=".repeat(50));
+  console.log(`Tests Passed: ${testsPassed}`);
+  console.log(`Tests Failed: ${testsFailed}`);
+  console.log("=".repeat(50));
+
+  if (testsFailed > 0) {
+    process.exit(1);
+  }
+}
+
+// Run tests
+runTests().catch((err) => {
+  console.error("Test runner error:", err);
+  process.exit(1);
+});

--- a/tests/unit/improvement-tracker.test.ts
+++ b/tests/unit/improvement-tracker.test.ts
@@ -3,12 +3,12 @@
  * Unit tests for ImprovementTracker
  * SPEC: SIL-001
  *
- * Run with: npx tsx src/observatory/improvement-tracker.test.ts
+ * Run with: npx tsx tests/unit/improvement-tracker.test.ts
  */
 
-import { ImprovementTracker, improvementTracker } from "./improvement-tracker.js";
-import { ThoughtEmitter } from "./emitter.js";
-import type { ImprovementEvent } from "./emitter.js";
+import { ImprovementTracker, improvementTracker } from "../../src/observatory/improvement-tracker.js";
+import { ThoughtEmitter } from "../../src/observatory/emitter.js";
+import type { ImprovementEvent } from "../../src/observatory/emitter.js";
 
 // =============================================================================
 // Test Utilities

--- a/tests/unit/proctor.test.ts
+++ b/tests/unit/proctor.test.ts
@@ -1,0 +1,465 @@
+#!/usr/bin/env npx tsx
+/**
+ * Unit tests for Proctored Execution Environment
+ * SPEC: SIL-007
+ *
+ * Run with: npx tsx tests/unit/proctor.test.ts
+ */
+
+import {
+  ProctoredExecutor,
+  getProctoredExecutor,
+  resetProctoredExecutor,
+  DEFAULT_SANDBOX_CONFIG,
+  type TestCase,
+  type ExecutionLogs,
+  type ProctoredResult,
+} from "../../benchmarks/proctor.js";
+
+// =============================================================================
+// Test Utilities
+// =============================================================================
+
+let testsPassed = 0;
+let testsFailed = 0;
+let currentTest = "";
+
+function test(name: string, fn: () => void | Promise<void>): void {
+  currentTest = name;
+  Promise.resolve(fn())
+    .then(() => {
+      testsPassed++;
+      console.log(`  ✓ ${name}`);
+    })
+    .catch((err) => {
+      testsFailed++;
+      console.error(`  ✗ ${name}`);
+      console.error(`    Error: ${err.message}`);
+    });
+}
+
+function assert(condition: boolean, message?: string): void {
+  if (!condition) {
+    throw new Error(message || `Assertion failed in "${currentTest}"`);
+  }
+}
+
+function assertEqual<T>(actual: T, expected: T, message?: string): void {
+  if (actual !== expected) {
+    throw new Error(
+      message ||
+        `Expected "${expected}" but got "${actual}" in "${currentTest}"`
+    );
+  }
+}
+
+// =============================================================================
+// Test Fixtures
+// =============================================================================
+
+const mockTestCase: TestCase = {
+  id: "test-001",
+  name: "simple-test",
+  code: 'console.log("Hello, test!")',
+  expectedDuration: 100, // 100ms for simple code (avoids timing anomaly for fast execution)
+  difficulty: "easy",
+};
+
+const slowTestCase: TestCase = {
+  id: "test-002",
+  name: "slow-test",
+  code: "// slow computation",
+  expectedDuration: 60000, // 1 minute
+  difficulty: "hard",
+};
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+async function runTests(): Promise<void> {
+  console.log("\nProctored Executor Tests\n");
+
+  // Reset singleton before tests
+  resetProctoredExecutor();
+
+  // -------------------------------------------------------------------------
+  // Initialization Tests
+  // -------------------------------------------------------------------------
+
+  console.log("Initialization Tests:");
+
+  test("creates executor with default config", () => {
+    const executor = new ProctoredExecutor();
+    const config = executor.getConfig();
+
+    assertEqual(config.image, DEFAULT_SANDBOX_CONFIG.image);
+    assertEqual(config.networkDisabled, DEFAULT_SANDBOX_CONFIG.networkDisabled);
+    assertEqual(config.memoryLimitMb, DEFAULT_SANDBOX_CONFIG.memoryLimitMb);
+    assertEqual(config.timeoutSeconds, DEFAULT_SANDBOX_CONFIG.timeoutSeconds);
+  });
+
+  test("creates executor with custom config", () => {
+    const executor = new ProctoredExecutor({
+      timeoutSeconds: 60,
+      memoryLimitMb: 256,
+    });
+    const config = executor.getConfig();
+
+    assertEqual(config.timeoutSeconds, 60);
+    assertEqual(config.memoryLimitMb, 256);
+    // Other values should be defaults
+    assertEqual(config.networkDisabled, DEFAULT_SANDBOX_CONFIG.networkDisabled);
+  });
+
+  test("singleton pattern works", () => {
+    resetProctoredExecutor();
+
+    const exec1 = getProctoredExecutor({ timeoutSeconds: 100 });
+    const exec2 = getProctoredExecutor();
+
+    // Should be same instance
+    assertEqual(exec1.getConfig().timeoutSeconds, exec2.getConfig().timeoutSeconds);
+  });
+
+  test("setConfig updates configuration", () => {
+    const executor = new ProctoredExecutor();
+    executor.setConfig({ memoryLimitMb: 1024 });
+
+    assertEqual(executor.getConfig().memoryLimitMb, 1024);
+  });
+
+  // -------------------------------------------------------------------------
+  // Execution Tests
+  // -------------------------------------------------------------------------
+
+  console.log("\nExecution Tests:");
+
+  test("executes simple code successfully", async () => {
+    const executor = new ProctoredExecutor({ useProcessMode: true });
+
+    // Use a test case with 1ms expected duration to avoid timing anomaly for instant code
+    const quickTestCase: TestCase = {
+      ...mockTestCase,
+      expectedDuration: 1, // 1ms expected - instant code won't trigger timing anomaly
+    };
+
+    const result = await executor.executeProctored(
+      'console.log("Hello from sandbox")',
+      quickTestCase
+    );
+
+    // With 1ms expected, even 0ms actual = 0 ratio, but timing check uses threshold
+    // For very quick test cases, we just check markers and exit code
+    assert(result.logs.exitCode === 0, "Exit code should be 0");
+    assert(result.logs.stdout.includes("Hello from sandbox"), "Should include output");
+    assert(result.logs.stdout.includes("TEST_START:"), "Should include start marker");
+    assert(result.logs.stdout.includes("TEST_END:"), "Should include end marker");
+  });
+
+  test("captures test markers in output", async () => {
+    const executor = new ProctoredExecutor({ useProcessMode: true });
+
+    const result = await executor.executeProctored(
+      'console.log("test output")',
+      mockTestCase
+    );
+
+    assert(
+      result.logs.stdout.includes(`TEST_START:${mockTestCase.name}`),
+      "Should include start marker"
+    );
+    assert(
+      result.logs.stdout.includes(`TEST_END:${mockTestCase.name}`),
+      "Should include end marker"
+    );
+  });
+
+  test("captures duration in output", async () => {
+    const executor = new ProctoredExecutor({ useProcessMode: true });
+
+    const result = await executor.executeProctored(
+      'console.log("quick")',
+      mockTestCase
+    );
+
+    assert(
+      result.logs.stdout.includes("DURATION:"),
+      "Should include duration marker"
+    );
+  });
+
+  test("handles execution errors gracefully", async () => {
+    const executor = new ProctoredExecutor({ useProcessMode: true });
+
+    const result = await executor.executeProctored(
+      'throw new Error("Test error")',
+      mockTestCase
+    );
+
+    assert(result.passed === false, "Should fail for throwing code");
+    assert(result.logs.exitCode === 1, "Exit code should be 1");
+    assert(result.logs.stderr.includes("Test error"), "Should capture error message");
+  });
+
+  // -------------------------------------------------------------------------
+  // Verification Tests
+  // -------------------------------------------------------------------------
+
+  console.log("\nVerification Tests:");
+
+  test("detects missing start marker", () => {
+    const executor = new ProctoredExecutor();
+
+    const logs: ExecutionLogs = {
+      stdout: `TEST_END:${mockTestCase.name}\nDURATION:100`,
+      stderr: "",
+      exitCode: 0,
+      startTime: new Date().toISOString(),
+      endTime: new Date().toISOString(),
+      resourceUsage: { cpuUsed: 0, memoryPeakMb: 10, diskReadBytes: 0, diskWriteBytes: 0 },
+    };
+
+    const verification = executor.verifyExecution(logs, mockTestCase);
+
+    assert(verification.consistent === false, "Should be inconsistent");
+    assert(
+      verification.flags.some((f) => f.type === "missing_start"),
+      "Should flag missing start"
+    );
+  });
+
+  test("detects missing end marker", () => {
+    const executor = new ProctoredExecutor();
+
+    const logs: ExecutionLogs = {
+      stdout: `TEST_START:${mockTestCase.name}\nDURATION:100`,
+      stderr: "",
+      exitCode: 0,
+      startTime: new Date().toISOString(),
+      endTime: new Date().toISOString(),
+      resourceUsage: { cpuUsed: 0, memoryPeakMb: 10, diskReadBytes: 0, diskWriteBytes: 0 },
+    };
+
+    const verification = executor.verifyExecution(logs, mockTestCase);
+
+    assert(verification.consistent === false, "Should be inconsistent");
+    assert(
+      verification.flags.some((f) => f.type === "missing_end"),
+      "Should flag missing end"
+    );
+  });
+
+  test("passes verification with all markers present", () => {
+    const executor = new ProctoredExecutor();
+
+    const logs: ExecutionLogs = {
+      stdout: `TEST_START:${mockTestCase.name}\noutput\nTEST_END:${mockTestCase.name}\nDURATION:1000`,
+      stderr: "",
+      exitCode: 0,
+      startTime: new Date().toISOString(),
+      endTime: new Date().toISOString(),
+      resourceUsage: { cpuUsed: 0, memoryPeakMb: 10, diskReadBytes: 0, diskWriteBytes: 0 },
+    };
+
+    const verification = executor.verifyExecution(logs, mockTestCase);
+
+    assert(verification.consistent === true, "Should be consistent");
+    assert(
+      !verification.flags.some((f) => f.type === "missing_start"),
+      "Should not flag missing start"
+    );
+    assert(
+      !verification.flags.some((f) => f.type === "missing_end"),
+      "Should not flag missing end"
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Timing Analysis Tests
+  // -------------------------------------------------------------------------
+
+  console.log("\nTiming Analysis Tests:");
+
+  test("detects suspiciously fast execution", () => {
+    const executor = new ProctoredExecutor();
+
+    const logs: ExecutionLogs = {
+      stdout: `TEST_START:${slowTestCase.name}\nTEST_END:${slowTestCase.name}\nDURATION:100`, // 100ms vs 60000ms expected
+      stderr: "",
+      exitCode: 0,
+      startTime: new Date().toISOString(),
+      endTime: new Date().toISOString(),
+      resourceUsage: { cpuUsed: 0, memoryPeakMb: 10, diskReadBytes: 0, diskWriteBytes: 0 },
+    };
+
+    const timingAnalysis = executor.analyzeTime(logs, slowTestCase);
+
+    assert(timingAnalysis.suspicious === true, "Should flag suspicious timing");
+    assert(timingAnalysis.ratio < 0.1, `Ratio should be < 0.1, got ${timingAnalysis.ratio}`);
+    assert(timingAnalysis.anomalyScore > 0, "Anomaly score should be positive");
+  });
+
+  test("passes reasonable execution time", () => {
+    const executor = new ProctoredExecutor();
+
+    const logs: ExecutionLogs = {
+      stdout: `TEST_START:${mockTestCase.name}\nTEST_END:${mockTestCase.name}\nDURATION:50`, // 50ms vs 100ms expected = 50%
+      stderr: "",
+      exitCode: 0,
+      startTime: new Date().toISOString(),
+      endTime: new Date().toISOString(),
+      resourceUsage: { cpuUsed: 0, memoryPeakMb: 10, diskReadBytes: 0, diskWriteBytes: 0 },
+    };
+
+    const timingAnalysis = executor.analyzeTime(logs, mockTestCase);
+
+    assert(timingAnalysis.suspicious === false, "Should not flag reasonable timing");
+    assert(timingAnalysis.ratio >= 0.1, `Ratio should be >= 0.1, got ${timingAnalysis.ratio}`);
+  });
+
+  test("timing analysis extracts duration from logs", () => {
+    const executor = new ProctoredExecutor();
+
+    const logs: ExecutionLogs = {
+      stdout: "TEST_START:test\nDURATION:12345\nTEST_END:test",
+      stderr: "",
+      exitCode: 0,
+      startTime: new Date().toISOString(),
+      endTime: new Date().toISOString(),
+      resourceUsage: { cpuUsed: 0, memoryPeakMb: 10, diskReadBytes: 0, diskWriteBytes: 0 },
+    };
+
+    const timingAnalysis = executor.analyzeTime(logs, mockTestCase);
+
+    assertEqual(timingAnalysis.actualDuration, 12345);
+    assertEqual(timingAnalysis.expectedDuration, mockTestCase.expectedDuration);
+  });
+
+  // -------------------------------------------------------------------------
+  // Resource Anomaly Tests
+  // -------------------------------------------------------------------------
+
+  console.log("\nResource Anomaly Tests:");
+
+  test("flags suspiciously low memory usage", () => {
+    const executor = new ProctoredExecutor();
+
+    const logs: ExecutionLogs = {
+      stdout: `TEST_START:${mockTestCase.name}\nTEST_END:${mockTestCase.name}\nDURATION:1000`,
+      stderr: "",
+      exitCode: 0,
+      startTime: new Date().toISOString(),
+      endTime: new Date().toISOString(),
+      resourceUsage: { cpuUsed: 0, memoryPeakMb: 0.1, diskReadBytes: 0, diskWriteBytes: 0 },
+    };
+
+    const verification = executor.verifyExecution(logs, mockTestCase);
+
+    assert(
+      verification.flags.some((f) => f.type === "resource_anomaly"),
+      "Should flag resource anomaly"
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Timeout Tests
+  // -------------------------------------------------------------------------
+
+  console.log("\nTimeout Tests:");
+
+  test("enforces timeout for long-running code", async () => {
+    const executor = new ProctoredExecutor({
+      useProcessMode: true,
+      timeoutSeconds: 1, // 1 second timeout
+    });
+
+    const longRunningCode = `
+      let start = Date.now();
+      while (Date.now() - start < 10000) {
+        // Spin for 10 seconds
+      }
+    `;
+
+    try {
+      await executor.executeProctored(longRunningCode, {
+        ...mockTestCase,
+        code: longRunningCode,
+      });
+      assert(false, "Should have thrown timeout error");
+    } catch (err) {
+      assert(
+        (err as Error).message.includes("timeout"),
+        `Expected timeout error, got: ${(err as Error).message}`
+      );
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Integration Tests
+  // -------------------------------------------------------------------------
+
+  console.log("\nIntegration Tests:");
+
+  test("full execution flow with verification", async () => {
+    const executor = new ProctoredExecutor({ useProcessMode: true });
+
+    // Use 1ms expected duration to prevent timing anomaly for fast code
+    const quickTestCase: TestCase = {
+      ...mockTestCase,
+      expectedDuration: 1,
+    };
+
+    const result = await executor.executeProctored(
+      `
+        let sum = 0;
+        for (let i = 0; i < 1000; i++) {
+          sum += i;
+        }
+        console.log("Sum: " + sum);
+      `,
+      quickTestCase
+    );
+
+    // Should have valid logs
+    assert(result.logs.stdout.includes("Sum:"), "Should have computation output");
+    assert(result.logs.exitCode === 0, "Should have exit code 0");
+
+    // Should have valid verification structure
+    assert(
+      typeof result.verification.timingAnalysis.actualDuration === "number",
+      "Should have timing"
+    );
+
+    // Markers should be present (consistent)
+    assert(
+      result.logs.stdout.includes("TEST_START:"),
+      "Should include start marker"
+    );
+    assert(
+      result.logs.stdout.includes("TEST_END:"),
+      "Should include end marker"
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Wait and Report
+  // -------------------------------------------------------------------------
+
+  await new Promise((resolve) => setTimeout(resolve, 500));
+
+  console.log("\n" + "=".repeat(50));
+  console.log(`Tests Passed: ${testsPassed}`);
+  console.log(`Tests Failed: ${testsFailed}`);
+  console.log("=".repeat(50));
+
+  if (testsFailed > 0) {
+    process.exit(1);
+  }
+}
+
+// Run tests
+runTests().catch((err) => {
+  console.error("Test runner error:", err);
+  process.exit(1);
+});

--- a/tests/unit/sampler.test.ts
+++ b/tests/unit/sampler.test.ts
@@ -1,0 +1,612 @@
+#!/usr/bin/env npx tsx
+/**
+ * Unit tests for Benchmark Anchor Point Sampler
+ * SPEC: SIL-003
+ *
+ * Run with: npx tsx tests/unit/sampler.test.ts
+ */
+
+import {
+  BenchmarkSampler,
+  DEFAULT_ANCHOR_CONFIG,
+  type Issue,
+  type AnchorPointConfig,
+  type SamplerState,
+} from "../../benchmarks/sampler.js";
+
+// =============================================================================
+// Test Utilities
+// =============================================================================
+
+let testsPassed = 0;
+let testsFailed = 0;
+let currentTest = "";
+
+function test(name: string, fn: () => void | Promise<void>): void {
+  currentTest = name;
+  Promise.resolve(fn())
+    .then(() => {
+      testsPassed++;
+      console.log(`  \u2713 ${name}`);
+    })
+    .catch((err) => {
+      testsFailed++;
+      console.error(`  \u2717 ${name}`);
+      console.error(`    Error: ${err.message}`);
+    });
+}
+
+function assert(condition: boolean, message?: string): void {
+  if (!condition) {
+    throw new Error(message || `Assertion failed in "${currentTest}"`);
+  }
+}
+
+function assertEqual<T>(actual: T, expected: T, message?: string): void {
+  if (actual !== expected) {
+    throw new Error(
+      message ||
+        `Expected "${expected}" but got "${actual}" in "${currentTest}"`
+    );
+  }
+}
+
+function assertApproxEqual(
+  actual: number,
+  expected: number,
+  tolerance: number,
+  message?: string
+): void {
+  if (Math.abs(actual - expected) > tolerance) {
+    throw new Error(
+      message ||
+        `Expected ~${expected} (±${tolerance}) but got ${actual} in "${currentTest}"`
+    );
+  }
+}
+
+// =============================================================================
+// Test Fixtures
+// =============================================================================
+
+function createTestIssues(count: number): Issue[] {
+  const difficulties: Array<"easy" | "medium" | "hard"> = [
+    "easy",
+    "medium",
+    "hard",
+  ];
+  return Array.from({ length: count }, (_, i) => ({
+    id: `issue-${i + 1}`,
+    repo: "test/repo",
+    number: i + 1,
+    title: `Test issue ${i + 1}`,
+    body: `This is the body of test issue ${i + 1}`,
+    difficulty: difficulties[i % 3],
+    solution: i % 2 === 0 ? `Solution for issue ${i + 1}` : undefined,
+  }));
+}
+
+function createStratifiedIssues(): Issue[] {
+  // 30 easy, 60 medium, 10 hard = 100 issues
+  const issues: Issue[] = [];
+
+  for (let i = 0; i < 30; i++) {
+    issues.push({
+      id: `easy-${i}`,
+      repo: "test/repo",
+      number: i,
+      title: `Easy issue ${i}`,
+      body: `Easy body ${i}`,
+      difficulty: "easy",
+    });
+  }
+
+  for (let i = 0; i < 60; i++) {
+    issues.push({
+      id: `medium-${i}`,
+      repo: "test/repo",
+      number: 30 + i,
+      title: `Medium issue ${i}`,
+      body: `Medium body ${i}`,
+      difficulty: "medium",
+    });
+  }
+
+  for (let i = 0; i < 10; i++) {
+    issues.push({
+      id: `hard-${i}`,
+      repo: "test/repo",
+      number: 90 + i,
+      title: `Hard issue ${i}`,
+      body: `Hard body ${i}`,
+      difficulty: "hard",
+    });
+  }
+
+  return issues;
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+async function runTests(): Promise<void> {
+  console.log("\nBenchmark Sampler Tests\n");
+
+  // -------------------------------------------------------------------------
+  // R1: Stratified Sampling Tests
+  // -------------------------------------------------------------------------
+
+  console.log("R1: Stratified Sampling Tests:");
+
+  test("selectAnchorPoints returns empty array for empty input", () => {
+    const sampler = new BenchmarkSampler();
+    const anchors = sampler.selectAnchorPoints([]);
+    assertEqual(anchors.length, 0);
+  });
+
+  test("selectAnchorPoints with random selection", () => {
+    const config: AnchorPointConfig = {
+      ...DEFAULT_ANCHOR_CONFIG,
+      selection: "random",
+      sampleRate: 0.1, // 10%
+    };
+    const sampler = new BenchmarkSampler(config);
+    const issues = createTestIssues(100);
+    const anchors = sampler.selectAnchorPoints(issues);
+
+    // With 10% rate on 100 issues, expect ~10 samples
+    assert(anchors.length >= 5 && anchors.length <= 20, `Expected ~10 anchors but got ${anchors.length}`);
+  });
+
+  test("selectAnchorPoints with stratified selection covers all strata", () => {
+    const config: AnchorPointConfig = {
+      ...DEFAULT_ANCHOR_CONFIG,
+      selection: "stratified",
+      sampleRate: 0.1, // 10%
+    };
+    const sampler = new BenchmarkSampler(config);
+    const issues = createStratifiedIssues();
+    const anchors = sampler.selectAnchorPoints(issues);
+
+    // Should have at least one from each difficulty
+    const difficulties = new Set(anchors.map((a) => a.difficulty));
+    assert(difficulties.has("easy"), "Should include easy issues");
+    assert(difficulties.has("medium"), "Should include medium issues");
+    assert(difficulties.has("hard"), "Should include hard issues");
+  });
+
+  test("selectAnchorPoints respects sample rate proportionally per stratum", () => {
+    const config: AnchorPointConfig = {
+      ...DEFAULT_ANCHOR_CONFIG,
+      selection: "stratified",
+      sampleRate: 0.1, // 10%
+    };
+    const sampler = new BenchmarkSampler(config);
+    const issues = createStratifiedIssues(); // 30 easy, 60 medium, 10 hard
+
+    // Run multiple times and average to account for randomness
+    let totalEasy = 0;
+    let totalMedium = 0;
+    let totalHard = 0;
+    const runs = 50;
+
+    for (let i = 0; i < runs; i++) {
+      const anchors = sampler.selectAnchorPoints(issues);
+      totalEasy += anchors.filter((a) => a.difficulty === "easy").length;
+      totalMedium += anchors.filter((a) => a.difficulty === "medium").length;
+      totalHard += anchors.filter((a) => a.difficulty === "hard").length;
+    }
+
+    const avgEasy = totalEasy / runs;
+    const avgMedium = totalMedium / runs;
+    const avgHard = totalHard / runs;
+
+    // 10% of 30 = 3, 10% of 60 = 6, 10% of 10 = 1 (minimum)
+    assertApproxEqual(avgEasy, 3, 2, `Expected ~3 easy but got ${avgEasy}`);
+    assertApproxEqual(avgMedium, 6, 2, `Expected ~6 medium but got ${avgMedium}`);
+    // Hard has minimum of 1
+    assert(avgHard >= 1, `Expected at least 1 hard but got ${avgHard}`);
+  });
+
+  test("selectAnchorPoints ensures at least 1 per stratum", () => {
+    const config: AnchorPointConfig = {
+      ...DEFAULT_ANCHOR_CONFIG,
+      selection: "stratified",
+      sampleRate: 0.001, // Very low rate
+    };
+    const sampler = new BenchmarkSampler(config);
+    const issues = createStratifiedIssues();
+    const anchors = sampler.selectAnchorPoints(issues);
+
+    // Even with tiny rate, should have at least 1 from each
+    const difficulties = new Set(anchors.map((a) => a.difficulty));
+    assertEqual(difficulties.size, 3);
+  });
+
+  // -------------------------------------------------------------------------
+  // R2: Correlation Validation Tests
+  // -------------------------------------------------------------------------
+
+  console.log("\nR2: Correlation Validation Tests:");
+
+  test("validateCorrelation returns 1.0 for identical arrays", () => {
+    const sampler = new BenchmarkSampler();
+    const x = [1, 2, 3, 4, 5];
+    const y = [1, 2, 3, 4, 5];
+    const result = sampler.validateCorrelation(x, y);
+    assertApproxEqual(result.correlation, 1.0, 0.001);
+    assert(result.valid, "Should be valid for perfect correlation");
+  });
+
+  test("validateCorrelation returns -1.0 for perfectly negatively correlated", () => {
+    const sampler = new BenchmarkSampler();
+    const x = [1, 2, 3, 4, 5];
+    const y = [5, 4, 3, 2, 1];
+    const result = sampler.validateCorrelation(x, y);
+    assertApproxEqual(result.correlation, -1.0, 0.001);
+    assert(!result.valid, "Should not be valid for negative correlation");
+  });
+
+  test("validateCorrelation returns ~0 for uncorrelated data", () => {
+    const sampler = new BenchmarkSampler();
+    const x = [1, 2, 3, 4, 5];
+    const y = [3, 3, 3, 3, 3]; // Constant - no correlation
+    const result = sampler.validateCorrelation(x, y);
+    assertEqual(result.correlation, 0);
+    assert(!result.valid, "Should not be valid for no correlation");
+  });
+
+  test("validateCorrelation handles empty arrays", () => {
+    const sampler = new BenchmarkSampler();
+    const result = sampler.validateCorrelation([], []);
+    assertEqual(result.correlation, 0);
+    assert(!result.valid, "Should not be valid for empty arrays");
+  });
+
+  test("validateCorrelation handles mismatched array lengths", () => {
+    const sampler = new BenchmarkSampler();
+    const result = sampler.validateCorrelation([1, 2, 3], [1, 2]);
+    assertEqual(result.correlation, 0);
+    assert(!result.valid, "Should not be valid for mismatched lengths");
+  });
+
+  test("validateCorrelation uses configurable threshold", () => {
+    const config: AnchorPointConfig = {
+      ...DEFAULT_ANCHOR_CONFIG,
+      validation: {
+        enabled: true,
+        correlationThreshold: 0.95,
+        validationRuns: 3,
+      },
+    };
+    const sampler = new BenchmarkSampler(config);
+    const x = [1, 2, 3, 4, 5];
+    const y = [1.1, 2.1, 2.9, 4.1, 4.9]; // High but not perfect correlation
+    const result = sampler.validateCorrelation(x, y);
+    // This should be around 0.99, above 0.9 but check against 0.95
+    assert(result.correlation > 0.95, `Expected correlation > 0.95 but got ${result.correlation}`);
+    assert(result.valid, "Should be valid above threshold");
+  });
+
+  // -------------------------------------------------------------------------
+  // R3: Rotation Management Tests
+  // -------------------------------------------------------------------------
+
+  console.log("\nR3: Rotation Management Tests:");
+
+  test("getCurrentRotation returns a Date", () => {
+    const sampler = new BenchmarkSampler();
+    const rotation = sampler.getCurrentRotation();
+    assert(rotation instanceof Date, "Should return a Date");
+  });
+
+  test("getHeldOutSet returns copy of held-out set", () => {
+    const sampler = new BenchmarkSampler();
+    const heldOut = sampler.getHeldOutSet();
+    assert(Array.isArray(heldOut), "Should return an array");
+  });
+
+  test("getTrainingSet returns copy of training set", () => {
+    const sampler = new BenchmarkSampler();
+    const training = sampler.getTrainingSet();
+    assert(Array.isArray(training), "Should return an array");
+  });
+
+  test("rotateHeldOutSet populates held-out from fresh issues", () => {
+    // Create a sampler with a past rotation date to force rotation
+    const config: AnchorPointConfig = {
+      ...DEFAULT_ANCHOR_CONFIG,
+      rotationPeriod: "monthly",
+    };
+    const sampler = new BenchmarkSampler(config);
+
+    // Manually set a past rotation by importing state
+    const pastDate = new Date();
+    pastDate.setMonth(pastDate.getMonth() - 2);
+    sampler.importState({
+      trainingSet: [],
+      heldOutSet: [],
+      currentRotation: pastDate.toISOString(),
+      fingerprints: {},
+    });
+
+    const freshIssues = createTestIssues(50);
+    sampler.rotateHeldOutSet(freshIssues);
+
+    const heldOut = sampler.getHeldOutSet();
+    assert(heldOut.length > 0, "Held-out set should be populated after rotation");
+  });
+
+  test("rotateHeldOutSet moves old held-out to training", () => {
+    const config: AnchorPointConfig = {
+      ...DEFAULT_ANCHOR_CONFIG,
+      rotationPeriod: "monthly",
+    };
+    const sampler = new BenchmarkSampler(config);
+
+    // Set up initial state with held-out issues
+    const pastDate = new Date();
+    pastDate.setMonth(pastDate.getMonth() - 2);
+    const oldHeldOut = createTestIssues(10);
+
+    sampler.importState({
+      trainingSet: [],
+      heldOutSet: oldHeldOut,
+      currentRotation: pastDate.toISOString(),
+      fingerprints: {},
+    });
+
+    const freshIssues = createTestIssues(50);
+    sampler.rotateHeldOutSet(freshIssues);
+
+    const training = sampler.getTrainingSet();
+    // Old held-out should now be in training
+    assert(
+      training.length >= oldHeldOut.length,
+      `Training should contain old held-out issues (got ${training.length}, expected >= ${oldHeldOut.length})`
+    );
+  });
+
+  test("rotateHeldOutSet does nothing if rotation period not passed", () => {
+    const sampler = new BenchmarkSampler();
+    const initialState = sampler.exportState();
+
+    const freshIssues = createTestIssues(50);
+    sampler.rotateHeldOutSet(freshIssues);
+
+    const finalState = sampler.exportState();
+    assertEqual(
+      finalState.currentRotation,
+      initialState.currentRotation,
+      "Rotation should not change if period not passed"
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // R4: Issue Fingerprinting Tests
+  // -------------------------------------------------------------------------
+
+  console.log("\nR4: Issue Fingerprinting Tests:");
+
+  test("createFingerprint creates valid fingerprint", () => {
+    const sampler = new BenchmarkSampler();
+    const issue = createTestIssues(1)[0];
+    const fingerprint = sampler.createFingerprint(issue);
+
+    assertEqual(fingerprint.issue_id, issue.id);
+    assert(fingerprint.content_hash.length === 16, "Content hash should be 16 chars");
+    assert(fingerprint.created_at.length > 0, "Created at should be set");
+    assertEqual(fingerprint.added_to_training, null);
+  });
+
+  test("createFingerprint generates solution hash when solution exists", () => {
+    const sampler = new BenchmarkSampler();
+    const issue: Issue = {
+      id: "test-1",
+      repo: "test/repo",
+      number: 1,
+      title: "Test",
+      body: "Body",
+      difficulty: "easy",
+      solution: "This is the solution",
+    };
+    const fingerprint = sampler.createFingerprint(issue);
+
+    assert(
+      fingerprint.solution_hash.length === 16,
+      "Solution hash should be 16 chars"
+    );
+  });
+
+  test("createFingerprint generates empty solution hash when no solution", () => {
+    const sampler = new BenchmarkSampler();
+    const issue: Issue = {
+      id: "test-1",
+      repo: "test/repo",
+      number: 1,
+      title: "Test",
+      body: "Body",
+      difficulty: "easy",
+    };
+    const fingerprint = sampler.createFingerprint(issue);
+
+    assertEqual(fingerprint.solution_hash, "");
+  });
+
+  test("getFingerprint retrieves created fingerprint", () => {
+    const sampler = new BenchmarkSampler();
+    const issue = createTestIssues(1)[0];
+    sampler.createFingerprint(issue);
+
+    const retrieved = sampler.getFingerprint(issue.id);
+    assert(retrieved !== undefined, "Should retrieve fingerprint");
+    assertEqual(retrieved!.issue_id, issue.id);
+  });
+
+  test("getFingerprint returns undefined for unknown issue", () => {
+    const sampler = new BenchmarkSampler();
+    const fingerprint = sampler.getFingerprint("nonexistent");
+    assertEqual(fingerprint, undefined);
+  });
+
+  test("getAllFingerprints returns all fingerprints", () => {
+    const sampler = new BenchmarkSampler();
+    const issues = createTestIssues(5);
+    for (const issue of issues) {
+      sampler.createFingerprint(issue);
+    }
+
+    const all = sampler.getAllFingerprints();
+    assertEqual(all.size, 5);
+  });
+
+  test("fingerprint content_hash is deterministic", () => {
+    const sampler = new BenchmarkSampler();
+    const issue = createTestIssues(1)[0];
+
+    const fp1 = sampler.createFingerprint(issue);
+    const fp2 = sampler.createFingerprint(issue);
+
+    assertEqual(fp1.content_hash, fp2.content_hash);
+  });
+
+  test("fingerprint content_hash differs for different content", () => {
+    const sampler = new BenchmarkSampler();
+    const issue1: Issue = {
+      id: "test-1",
+      repo: "test/repo",
+      number: 1,
+      title: "Title A",
+      body: "Body A",
+      difficulty: "easy",
+    };
+    const issue2: Issue = {
+      id: "test-2",
+      repo: "test/repo",
+      number: 2,
+      title: "Title B",
+      body: "Body B",
+      difficulty: "easy",
+    };
+
+    const fp1 = sampler.createFingerprint(issue1);
+    const fp2 = sampler.createFingerprint(issue2);
+
+    assert(fp1.content_hash !== fp2.content_hash, "Different content should have different hashes");
+  });
+
+  // -------------------------------------------------------------------------
+  // State Persistence Tests
+  // -------------------------------------------------------------------------
+
+  console.log("\nState Persistence Tests:");
+
+  test("exportState returns serializable state", () => {
+    const sampler = new BenchmarkSampler();
+    const issues = createTestIssues(5);
+    for (const issue of issues) {
+      sampler.createFingerprint(issue);
+    }
+
+    const state = sampler.exportState();
+    assert(typeof state.currentRotation === "string", "currentRotation should be string");
+    assert(Array.isArray(state.trainingSet), "trainingSet should be array");
+    assert(Array.isArray(state.heldOutSet), "heldOutSet should be array");
+    assert(typeof state.fingerprints === "object", "fingerprints should be object");
+  });
+
+  test("importState restores sampler state", () => {
+    const sampler1 = new BenchmarkSampler();
+    const issues = createTestIssues(5);
+    for (const issue of issues) {
+      sampler1.createFingerprint(issue);
+    }
+    const exportedState = sampler1.exportState();
+
+    const sampler2 = new BenchmarkSampler();
+    sampler2.importState(exportedState);
+
+    const fingerprints1 = sampler1.getAllFingerprints();
+    const fingerprints2 = sampler2.getAllFingerprints();
+    assertEqual(fingerprints1.size, fingerprints2.size);
+  });
+
+  test("state round-trips through JSON serialization", () => {
+    const sampler = new BenchmarkSampler();
+    const issues = createTestIssues(5);
+    for (const issue of issues) {
+      sampler.createFingerprint(issue);
+    }
+
+    const state = sampler.exportState();
+    const json = JSON.stringify(state);
+    const parsed = JSON.parse(json) as SamplerState;
+
+    const sampler2 = new BenchmarkSampler();
+    sampler2.importState(parsed);
+
+    assertEqual(sampler2.getAllFingerprints().size, 5);
+  });
+
+  // -------------------------------------------------------------------------
+  // Configuration Tests
+  // -------------------------------------------------------------------------
+
+  console.log("\nConfiguration Tests:");
+
+  test("DEFAULT_ANCHOR_CONFIG has expected values", () => {
+    assertEqual(DEFAULT_ANCHOR_CONFIG.sampleRate, 0.01);
+    assertEqual(DEFAULT_ANCHOR_CONFIG.selection, "stratified");
+    assertEqual(DEFAULT_ANCHOR_CONFIG.stratificationKey, "difficulty");
+    assertEqual(DEFAULT_ANCHOR_CONFIG.rotationPeriod, "monthly");
+    assertEqual(DEFAULT_ANCHOR_CONFIG.validation.enabled, true);
+    assertEqual(DEFAULT_ANCHOR_CONFIG.validation.correlationThreshold, 0.9);
+  });
+
+  test("BenchmarkSampler accepts custom config", () => {
+    const customConfig: AnchorPointConfig = {
+      sampleRate: 0.05,
+      selection: "random",
+      stratificationKey: "difficulty",
+      rotationPeriod: "weekly",
+      validation: {
+        enabled: false,
+        correlationThreshold: 0.8,
+        validationRuns: 5,
+      },
+    };
+    const sampler = new BenchmarkSampler(customConfig);
+
+    // Verify config is used by checking random selection behavior
+    const issues = createStratifiedIssues();
+    const anchors = sampler.selectAnchorPoints(issues);
+
+    // Random selection with 5% rate on 100 issues = ~5 samples
+    assert(
+      anchors.length >= 2 && anchors.length <= 15,
+      `Expected ~5 anchors with 5% rate but got ${anchors.length}`
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Wait and Report
+  // -------------------------------------------------------------------------
+
+  await new Promise((resolve) => setTimeout(resolve, 200));
+
+  console.log("\n" + "=".repeat(50));
+  console.log(`Tests Passed: ${testsPassed}`);
+  console.log(`Tests Failed: ${testsFailed}`);
+  console.log("=".repeat(50));
+
+  if (testsFailed > 0) {
+    process.exit(1);
+  }
+}
+
+// Run tests
+runTests().catch((err) => {
+  console.error("Test runner error:", err);
+  process.exit(1);
+});

--- a/tests/unit/tiered-evaluator.test.ts
+++ b/tests/unit/tiered-evaluator.test.ts
@@ -1,0 +1,351 @@
+#!/usr/bin/env npx tsx
+/**
+ * Unit tests for Tiered Evaluation Pipeline
+ * SPEC: SIL-004
+ *
+ * Run with: npx tsx tests/unit/tiered-evaluator.test.ts
+ */
+
+import {
+  TieredEvaluator,
+  createMockExecutor,
+  resetTieredEvaluator,
+  type CodeModification,
+  type TierExecutor,
+  type TierResult,
+} from "../../benchmarks/tiered-evaluator.js";
+import { ImprovementTracker } from "../../src/observatory/improvement-tracker.js";
+
+// =============================================================================
+// Test Utilities
+// =============================================================================
+
+let testsPassed = 0;
+let testsFailed = 0;
+let currentTest = "";
+
+function test(name: string, fn: () => void | Promise<void>): void {
+  currentTest = name;
+  Promise.resolve(fn())
+    .then(() => {
+      testsPassed++;
+      console.log(`  \u2713 ${name}`);
+    })
+    .catch((err) => {
+      testsFailed++;
+      console.error(`  \u2717 ${name}`);
+      console.error(`    Error: ${err.message}`);
+    });
+}
+
+function assert(condition: boolean, message?: string): void {
+  if (!condition) {
+    throw new Error(message || `Assertion failed in "${currentTest}"`);
+  }
+}
+
+function assertEqual<T>(actual: T, expected: T, message?: string): void {
+  if (actual !== expected) {
+    throw new Error(
+      message ||
+        `Expected "${expected}" but got "${actual}" in "${currentTest}"`
+    );
+  }
+}
+
+// =============================================================================
+// Test Fixtures
+// =============================================================================
+
+const mockModification: CodeModification = {
+  id: "mod-1",
+  type: "fix",
+  files: ["src/test.ts"],
+  diff: "--- a/src/test.ts\n+++ b/src/test.ts\n@@ -1,1 +1,1 @@\n-old\n+new",
+};
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+async function runTests(): Promise<void> {
+  console.log("\nTiered Evaluator Tests\n");
+
+  // Reset singleton before tests
+  resetTieredEvaluator();
+  ImprovementTracker.resetInstance();
+
+  // -------------------------------------------------------------------------
+  // Initialization Tests
+  // -------------------------------------------------------------------------
+
+  console.log("Initialization Tests:");
+
+  test("TieredEvaluator loads default config", () => {
+    const evaluator = new TieredEvaluator({ trackingEnabled: false });
+    const config = evaluator.getConfig();
+    assert(config.name === "thoughtbox-improvement", `Expected name "thoughtbox-improvement" but got "${config.name}"`);
+    assert(config.tiers.length > 0, "Should have tiers defined");
+  });
+
+  test("TieredEvaluator registers default executors", () => {
+    const evaluator = new TieredEvaluator({ trackingEnabled: false });
+    const tiers = evaluator.getRegisteredTiers();
+    assert(tiers.includes("smoke-test"), "Should have smoke-test executor");
+    assert(tiers.includes("regression"), "Should have regression executor");
+    assert(tiers.includes("real-world"), "Should have real-world executor");
+  });
+
+  // -------------------------------------------------------------------------
+  // Evaluation Tests
+  // -------------------------------------------------------------------------
+
+  console.log("\nEvaluation Tests:");
+
+  test("evaluate passes all tiers when all executors return passing scores", async () => {
+    const evaluator = new TieredEvaluator({ trackingEnabled: false });
+
+    // Register mock executors that all pass
+    evaluator.registerExecutor(createMockExecutor("smoke-test", 1.0, 0.1));
+    evaluator.registerExecutor(createMockExecutor("regression", 0.98, 1.0));
+    evaluator.registerExecutor(createMockExecutor("real-world", 0.85, 10.0));
+
+    const result = await evaluator.evaluate(mockModification);
+
+    assert(result.passed === true, "Should pass when all tiers pass");
+    assertEqual(result.failedAt, null);
+    assert(result.passedTiers.length === 3, `Expected 3 passed tiers but got ${result.passedTiers.length}`);
+  });
+
+  test("evaluate terminates early on first tier failure", async () => {
+    const evaluator = new TieredEvaluator({ trackingEnabled: false });
+
+    // Smoke test fails
+    evaluator.registerExecutor(createMockExecutor("smoke-test", 0.5, 0.1));
+    evaluator.registerExecutor(createMockExecutor("regression", 1.0, 1.0));
+    evaluator.registerExecutor(createMockExecutor("real-world", 1.0, 10.0));
+
+    const result = await evaluator.evaluate(mockModification);
+
+    assert(result.passed === false, "Should fail when first tier fails");
+    assertEqual(result.failedAt, "smoke-test");
+    assertEqual(result.tierResults.length, 1); // Only smoke-test ran
+    assertEqual(result.passedTiers.length, 0);
+  });
+
+  test("evaluate terminates early on middle tier failure", async () => {
+    const evaluator = new TieredEvaluator({ trackingEnabled: false });
+
+    // Smoke passes, regression fails
+    evaluator.registerExecutor(createMockExecutor("smoke-test", 1.0, 0.1));
+    evaluator.registerExecutor(createMockExecutor("regression", 0.5, 1.0));
+    evaluator.registerExecutor(createMockExecutor("real-world", 1.0, 10.0));
+
+    const result = await evaluator.evaluate(mockModification);
+
+    assert(result.passed === false, "Should fail when middle tier fails");
+    assertEqual(result.failedAt, "regression");
+    assertEqual(result.tierResults.length, 2); // smoke-test and regression ran
+    assertEqual(result.passedTiers.length, 1);
+    assert(result.passedTiers.includes("smoke-test"), "Should include smoke-test in passed tiers");
+  });
+
+  // -------------------------------------------------------------------------
+  // Cost Tracking Tests
+  // -------------------------------------------------------------------------
+
+  console.log("\nCost Tracking Tests:");
+
+  test("evaluate tracks total cost across all tiers", async () => {
+    const evaluator = new TieredEvaluator({ trackingEnabled: false });
+
+    evaluator.registerExecutor(createMockExecutor("smoke-test", 1.0, 0.1));
+    evaluator.registerExecutor(createMockExecutor("regression", 1.0, 1.0));
+    evaluator.registerExecutor(createMockExecutor("real-world", 1.0, 10.0));
+
+    const result = await evaluator.evaluate(mockModification);
+
+    // Total cost should be 0.1 + 1.0 + 10.0 = 11.1
+    assertEqual(result.totalCost, 11.1);
+  });
+
+  test("evaluate tracks partial cost on early termination", async () => {
+    const evaluator = new TieredEvaluator({ trackingEnabled: false });
+
+    // Fail at smoke test
+    evaluator.registerExecutor(createMockExecutor("smoke-test", 0.5, 0.1));
+    evaluator.registerExecutor(createMockExecutor("regression", 1.0, 1.0));
+    evaluator.registerExecutor(createMockExecutor("real-world", 1.0, 10.0));
+
+    const result = await evaluator.evaluate(mockModification);
+
+    // Only smoke test cost should be tracked
+    assertEqual(result.totalCost, 0.1);
+  });
+
+  test("evaluate tracks duration for each tier", async () => {
+    const evaluator = new TieredEvaluator({ trackingEnabled: false });
+
+    evaluator.registerExecutor(createMockExecutor("smoke-test", 1.0, 0.1));
+    evaluator.registerExecutor(createMockExecutor("regression", 1.0, 1.0));
+    evaluator.registerExecutor(createMockExecutor("real-world", 1.0, 10.0));
+
+    const result = await evaluator.evaluate(mockModification);
+
+    assert(result.totalDuration_ms >= 0, "Should have non-negative duration");
+    for (const tier of result.tierResults) {
+      assert(tier.duration_ms >= 0, `Tier ${tier.tierId} should have non-negative duration`);
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Threshold Tests
+  // -------------------------------------------------------------------------
+
+  console.log("\nThreshold Tests:");
+
+  test("evaluate uses config thresholds for pass/fail", async () => {
+    const evaluator = new TieredEvaluator({ trackingEnabled: false });
+
+    // Regression tier requires 95% pass rate (0.95)
+    // Return score just below threshold
+    evaluator.registerExecutor(createMockExecutor("smoke-test", 1.0, 0.1));
+    evaluator.registerExecutor({
+      name: "regression",
+      execute: async (): Promise<TierResult> => ({
+        tier: "Regression",
+        tierId: "regression",
+        score: 0.94, // Just below 0.95 threshold
+        passed: true, // Will be recalculated
+        cost: 1.0,
+        duration_ms: 100,
+      }),
+    });
+
+    const result = await evaluator.evaluate(mockModification);
+
+    assert(result.passed === false, "Should fail when score below threshold");
+    assertEqual(result.failedAt, "regression");
+  });
+
+  // -------------------------------------------------------------------------
+  // Custom Executor Tests
+  // -------------------------------------------------------------------------
+
+  console.log("\nCustom Executor Tests:");
+
+  test("registerExecutor allows custom executors", async () => {
+    const evaluator = new TieredEvaluator({ trackingEnabled: false });
+
+    const customExecutor: TierExecutor = {
+      name: "smoke-test",
+      execute: async (): Promise<TierResult> => ({
+        tier: "Custom Smoke",
+        tierId: "smoke-test",
+        score: 0.99,
+        passed: true,
+        cost: 0.05,
+        duration_ms: 50,
+        details: { custom: true },
+      }),
+    };
+
+    evaluator.registerExecutor(customExecutor);
+    evaluator.registerExecutor(createMockExecutor("regression", 1.0, 1.0));
+    evaluator.registerExecutor(createMockExecutor("real-world", 1.0, 10.0));
+
+    const result = await evaluator.evaluate(mockModification);
+
+    const smokeResult = result.tierResults.find((r) => r.tierId === "smoke-test");
+    assertEqual(smokeResult?.cost, 0.05);
+    assertEqual(smokeResult?.details?.custom, true);
+  });
+
+  test("executor errors are handled gracefully", async () => {
+    const evaluator = new TieredEvaluator({ trackingEnabled: false });
+
+    const throwingExecutor: TierExecutor = {
+      name: "smoke-test",
+      execute: async (): Promise<TierResult> => {
+        throw new Error("Executor failed!");
+      },
+    };
+
+    evaluator.registerExecutor(throwingExecutor);
+
+    const result = await evaluator.evaluate(mockModification);
+
+    assert(result.passed === false, "Should fail when executor throws");
+    assertEqual(result.failedAt, "smoke-test");
+    assert(
+      result.tierResults[0].details?.error !== undefined,
+      "Should capture error in details"
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Result Details Tests
+  // -------------------------------------------------------------------------
+
+  console.log("\nResult Details Tests:");
+
+  test("evaluate includes reason on failure", async () => {
+    const evaluator = new TieredEvaluator({ trackingEnabled: false });
+
+    evaluator.registerExecutor(createMockExecutor("smoke-test", 0.3, 0.1));
+
+    const result = await evaluator.evaluate(mockModification);
+
+    assert(result.reason !== undefined, "Should have failure reason");
+    assert(result.reason!.includes("Failed smoke-test"), "Reason should mention failed tier");
+  });
+
+  test("evaluate has no reason on success", async () => {
+    const evaluator = new TieredEvaluator({ trackingEnabled: false });
+
+    evaluator.registerExecutor(createMockExecutor("smoke-test", 1.0, 0.1));
+    evaluator.registerExecutor(createMockExecutor("regression", 1.0, 1.0));
+    evaluator.registerExecutor(createMockExecutor("real-world", 1.0, 10.0));
+
+    const result = await evaluator.evaluate(mockModification);
+
+    assertEqual(result.reason, undefined);
+  });
+
+  // -------------------------------------------------------------------------
+  // Mock Executor Helper Tests
+  // -------------------------------------------------------------------------
+
+  console.log("\nMock Executor Helper Tests:");
+
+  test("createMockExecutor creates executor with correct values", async () => {
+    const executor = createMockExecutor("test-tier", 0.75, 5.0);
+
+    assertEqual(executor.name, "test-tier");
+
+    const result = await executor.execute(mockModification);
+    assertEqual(result.score, 0.75);
+    assertEqual(result.cost, 5.0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Wait and Report
+  // -------------------------------------------------------------------------
+
+  await new Promise((resolve) => setTimeout(resolve, 200));
+
+  console.log("\n" + "=".repeat(50));
+  console.log(`Tests Passed: ${testsPassed}`);
+  console.log(`Tests Failed: ${testsFailed}`);
+  console.log("=".repeat(50));
+
+  if (testsFailed > 0) {
+    process.exit(1);
+  }
+}
+
+// Run tests
+runTests().catch((err) => {
+  console.error("Test runner error:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Architectural cleanup: Move test files from source directories to `tests/unit/` following project conventions.

## Changes

**Files Moved**:
- benchmarks/config-loader.test.ts → tests/unit/config-loader.test.ts
- src/observatory/improvement-tracker.test.ts → tests/unit/improvement-tracker.test.ts

**New Tests Added** to tests/unit/:
- contamination.test.ts (SIL-009 - 21 tests)
- proctor.test.ts (SIL-007 - 17 tests)
- sampler.test.ts (SIL-003 - 30 tests)
- tiered-evaluator.test.ts (SIL-004 - 14 tests)

## Rationale

Tests should be external to server implementation code:
- ✅ Cleaner src/ directory structure
- ✅ Clear separation: src/ = implementation, tests/ = verification
- ✅ Easier to exclude tests from production builds
- ✅ Standard Node.js project layout

## Impact

No functional changes - pure refactoring.

## Related

- Follows architectural decision documented in dgm-specs/implementation-status.json