### PR TITLE
chore(local): add scratchpad folder guard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,8 @@ local-docs/
 smithery-docs/
 mcp-specs/
 sdk/
+local/
+!local/.keep
 
 # Improvement opps
 improvement-recs/

--- a/local/.keep
+++ b/local/.keep
@@ -1,0 +1,2 @@
+local scratchpad (intentionally empty)
+local scratchpad (intentionally empty)


### PR DESCRIPTION
## Summary
- add a gitignored local scratch directory with tracked sentinel file
- keep local references nearby without polluting git status

## Test plan
- not run (repo hygiene change)