### PR TITLE
fix(gateway): read_thoughts range/last queries now include branch thoughts

### DIFF
--- a/src/gateway/gateway-handler.ts
+++ b/src/gateway/gateway-handler.ts
@@ -582,22 +582,22 @@ Call \`thoughtbox_gateway\` with operation 'thought' to begin structured reasoni
         thoughts = await this.storage.getBranch(sessionId, branchId);
         queryDescription = `all thoughts from branch '${branchId}'`;
       }
-      // Query mode: last N thoughts
+      // Query mode: last N thoughts (main chain + branches)
       else if (last !== undefined) {
-        const allThoughts = await this.storage.getThoughts(sessionId);
+        const allThoughts = await this.storage.getAllThoughts(sessionId);
         thoughts = allThoughts.slice(-last);
         queryDescription = `last ${last} thoughts`;
       }
-      // Query mode: range of thoughts
+      // Query mode: range of thoughts (main chain + branches)
       else if (range !== undefined && Array.isArray(range) && range.length === 2) {
         const [start, end] = range;
-        const allThoughts = await this.storage.getThoughts(sessionId);
+        const allThoughts = await this.storage.getAllThoughts(sessionId);
         thoughts = allThoughts.filter(t => t.thoughtNumber >= start && t.thoughtNumber <= end);
         queryDescription = `thoughts ${start} to ${end}`;
       }
-      // No query parameters - return recent context
+      // No query parameters - return recent context (main chain + branches)
       else {
-        const allThoughts = await this.storage.getThoughts(sessionId);
+        const allThoughts = await this.storage.getAllThoughts(sessionId);
         thoughts = allThoughts.slice(-5);  // Default: last 5
         queryDescription = 'last 5 thoughts (default)';
       }

--- a/src/gateway/gateway-handler.ts
+++ b/src/gateway/gateway-handler.ts
@@ -957,10 +957,10 @@ Operations:
 - thought (structured reasoning)
 - read_thoughts (retrieve previous thoughts mid-session for re-reading)
 - get_structure (get reasoning graph topology without content)
-- notebook (literate programming)
-- session (session management)
-- mental_models (reasoning frameworks)
-- deep_analysis (session pattern analysis)
+- notebook (literate programming — read thoughtbox://notebook/operations for args)
+- session (session management — args: { operation: 'list'|'get'|'delete'|'analyze'|'export', ... })
+- mental_models (reasoning frameworks — read thoughtbox://mental-models for operations and models)
+- deep_analysis (session pattern analysis — args: { sessionId?, analysisType: 'patterns'|'cognitive_load'|'full' })
 - knowledge (knowledge graph memory - Phase 1)
 
 read_thoughts usage (Stage 2 required):


### PR DESCRIPTION
## Summary

- **Root cause**: `read_thoughts` range, last N, and default queries used `getThoughts()` (main chain only). Branch thoughts were invisible despite `get_structure` and `deep_analysis` being fixed in PR #99.
- **Fix**: Changed all three query paths to use `getAllThoughts()` (main chain + branches), matching the fix already applied to `get_structure` and `deep_analysis`.

## Test plan

- [x] 4 new tests: range with branches, branch-only range, main-only range, last N with branches
- [x] All 22 gateway tests pass (no regressions)
- [x] All 13 branch-retrieval tests pass
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)