### PR TITLE
Rewrite README: Docker-first, lead with collaboration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,251 +1,88 @@
 # Thoughtbox
 
-**A reasoning ledger and collaboration hub for AI agents.** Thoughtbox is an MCP server that provides structured reasoning tools for individual agents and a coordination layer for multi-agent teams. Agents think step-by-step, branch into alternative explorations, revise earlier conclusions, build a persistent knowledge graph, and collaborate through shared workspaces — all via the Model Context Protocol.
+**Multi-agent collaborative reasoning that's auditable.** Thoughtbox is a Docker-based MCP server where AI agents coordinate through shared workspaces — claiming problems, proposing solutions, reviewing each other's work, and reaching consensus. Every step is recorded as a structured thought in a persistent reasoning ledger that can be visualized, exported, and analyzed.
 
-Unlike ephemeral chain-of-thought prompting, Thoughtbox creates a **durable reasoning chain** — a ledger of thoughts that can be visualized, exported, and analyzed. Each thought is a node in a graph structure supporting forward thinking, backward planning, branching explorations, mid-course revisions, and **autonomous critique via MCP sampling**. The **Hub** extends this to multi-agent scenarios where agents register, claim problems, propose solutions, review each other's work, and reach consensus.
-
-**Local-First:** Thoughtbox runs entirely on your machine. All reasoning data is stored locally at `~/.thoughtbox/` by default — nothing is sent to external servers. Your thought processes remain private and under your control.
-
-## Client Compatibility
-
-> **Note:** Thoughtbox is currently optimized for use with **Claude Code**. We are actively working on supporting additional MCP clients, but due to the wide variation in capability support across the Model Context Protocol ecosystem — server features (prompts, resources, tools), client features (roots, sampling, elicitation), and behaviors like `listChanged` notifications — we're having to implement custom adaptations for many clients. See the [gateway tool](#gateway-tool-always-available) for one such adaptation.
-
-If you're using a client other than Claude Code and encounter issues, please [open an issue](https://github.com/Kastalien-Research/thoughtbox/issues) describing your client and the problem — this helps us prioritize compatibility work.
-
-## Progressive Disclosure
-
-Thoughtbox uses a staged tool disclosure system to guide agents through proper initialization:
-
-| Stage | Tools Available | Trigger |
-|-------|-----------------|---------|
-| **Stage 0** | `init`, `thoughtbox_gateway` | Connection start |
-| **Stage 1** | + `thoughtbox_cipher`, `session`, `deep_analysis` | `init(start_new)` or `init(load_context)` |
-| **Stage 2** | + `thoughtbox`, `notebook`, `knowledge`, `mental_models` | `thoughtbox_cipher` call |
-| **Stage 3** | + `export_reasoning_chain` | Domain activation |
-
-This ensures agents establish proper session context before accessing advanced reasoning tools.
-
-### Gateway Tool (Always Available)
-
-The `thoughtbox_gateway` tool is always enabled and provides a routing mechanism for clients that don't refresh tool lists mid-turn (e.g., Claude Code over streaming HTTP). It routes to all handlers internally while enforcing stage requirements:
-
-```javascript
-// Call operations through gateway without waiting for tool list refresh
-{ operation: "get_state" }                    // → init handler
-{ operation: "start_new", args: {...} }       // → init handler, advances to Stage 1
-{ operation: "cipher" }                       // → cipher content, advances to Stage 2
-{ operation: "thought", args: {...} }         // → thoughtbox handler (requires Stage 2)
-```
-
-The gateway returns clear error messages when operations are called at the wrong stage.
+**Local-First:** Runs entirely on your machine. All data stays at `~/.thoughtbox/` — nothing leaves your network.
 
 ![Thoughtbox Observatory](public/thoughtbox-observatory.png)
 *Observatory UI showing a reasoning session with 14 thoughts and a branch exploration (purple nodes 13-14) forking from thought 5.*
 
-## Core Concepts
+## Multi-Agent Collaboration
 
-### The Reasoning Ledger
+The Hub is the coordination layer. Agents register with role-specific profiles, join shared workspaces, and work through a structured problem-solving workflow — all via the `thoughtbox_hub` MCP tool.
 
-Thoughtbox treats reasoning as **data**, not just process. Every thought is:
+**The workflow:** register → create workspace → create problem → claim → work → propose solution → peer review → merge → consensus
 
-- **Numbered**: Logical position in the reasoning chain (supports non-sequential addition)
-- **Timestamped**: When the thought was recorded
-- **Linked**: Connected to previous thoughts, branch origins, or revised thoughts
-- **Persistent**: Stored in sessions that survive across conversations
-- **Exportable**: Full reasoning chains can be exported as JSON or Markdown
+**Workspace primitives:**
 
-This creates an **auditable trail** of how conclusions were reached — invaluable for debugging agent behavior, understanding decision-making, and improving reasoning strategies.
-
-### Thinking Patterns
-
-Thoughtbox supports multiple reasoning strategies out of the box:
-
-| Pattern | Description | Use Case |
-|---------|-------------|----------|
-| **Forward Thinking** | Sequential 1→2→3→N progression | Exploration, discovery, open-ended analysis |
-| **Backward Thinking** | Start at goal (N), work back to start (1) | Planning, system design, working from known goals |
-| **Branching** | Fork into parallel explorations (A, B, C...) | Comparing alternatives, A/B scenarios |
-| **Revision** | Update earlier thoughts with new information | Error correction, refined understanding |
-| **Interleaved** | Alternate reasoning with tool actions | Tool-oriented tasks, adaptive execution |
-
-See the **[Patterns Cookbook](src/resources/docs/thoughtbox-patterns-cookbook.md)** for comprehensive examples.
-
-## Features
-
-### 1. Init Tool — Session Management (Stage 0)
-
-The entry point for establishing session context.
-
-**Operations:**
-- `get_state` — Check current session state
-- `list_sessions` — Browse available sessions (filter by project, task, aspect)
-- `start_new` — Begin a new work session with project/task/aspect scoping
-- `load_context` — Resume an existing session
-- `navigate` — Move between project/task/aspect levels
-- `list_roots` — Query MCP roots from client
-- `bind_root` — Bind a root directory as project scope
-
-### 2. Thoughtbox Cipher — Deep Thinking Primer (Stage 1)
-
-A priming tool that prepares agents for structured reasoning. Calling this tool unlocks Stage 2 tools.
-
-### 3. Session Tool — Persistence & Export (Stage 1)
-
-Manage reasoning sessions with full persistence.
-
-**Operations:**
-- `list` — List all sessions
-- `get` — Retrieve session details
-- `export` — Export session as JSON or Markdown
-- `analyze` — Get session statistics and insights
-
-### 4. Thoughtbox Tool — Structured Reasoning (Stage 2)
-
-The core tool for step-by-step thinking with full graph capabilities.
-
-```javascript
-// Simple forward thinking
-{ thought: "First, let's identify the problem...", thoughtNumber: 1, totalThoughts: 5, nextThoughtNeeded: true }
-
-// Branching to explore alternatives
-{ thought: "Option A: Use PostgreSQL...", thoughtNumber: 3, branchFromThought: 2, branchId: "sql-path", ... }
-
-// Revising an earlier conclusion
-{ thought: "Actually, the root cause is...", thoughtNumber: 7, isRevision: true, revisesThought: 3, ... }
-
-// Request autonomous critique via MCP sampling
-{ thought: "This approach seems optimal...", thoughtNumber: 5, critique: true, ... }
-```
-
-**Parameters:**
-- `thought` (string): The current thinking step
-- `thoughtNumber` (integer): Logical position in the chain
-- `totalThoughts` (integer): Estimated total (adjustable)
-- `nextThoughtNeeded` (boolean): Continue thinking?
-- `branchFromThought` (integer): Fork point for branching
-- `branchId` (string): Branch identifier
-- `isRevision` (boolean): Marks revision of earlier thought
-- `revisesThought` (integer): Which thought is being revised
-- `critique` (boolean): Request autonomous LLM critique via MCP sampling API
-
-**Autonomous Critique:** When `critique: true`, the server uses the MCP `sampling/createMessage` API to request an external LLM analysis of the current thought. The critique is returned in the response and persisted with the thought.
-
-### 5. Observatory — Real-Time Visualization
-
-A built-in web UI for watching reasoning unfold in real-time.
-
-**Features:**
-- **Live Graph**: Watch thoughts appear as they're added
-- **Snake Layout**: Compact left-to-right flow with row wrapping
-- **Hierarchical Branches**: Branches collapse into clickable stub nodes (A, B, C...)
-- **Navigation**: Click stubs to explore branches, back button to return
-- **Detail Panel**: Click any node to view full thought content
-- **Multi-Session**: Switch between active reasoning sessions
-
-**Access:** The Observatory is available at `http://localhost:1729` when the server is running.
-
-### 6. Mental Models — Reasoning Frameworks (Stage 2)
-
-15 structured mental models that provide process scaffolds for different problem types.
-
-**Available Models:**
-- `rubber-duck` — Explain to clarify thinking
-- `five-whys` — Root cause analysis
-- `pre-mortem` — Anticipate failures
-- `steelmanning` — Strengthen opposing arguments
-- `fermi-estimation` — Order-of-magnitude reasoning
-- `trade-off-matrix` — Multi-criteria decisions
-- `decomposition` — Break down complexity
-- `inversion` — Solve by avoiding failure
-- And 7 more...
-
-**Operations:**
-- `get_model` — Retrieve a specific model's prompt
-- `list_models` — List all models (filter by tag)
-- `list_tags` — Available categories (debugging, planning, decision-making, etc.)
-
-### 7. Notebook — Literate Programming (Stage 2)
-
-Interactive notebooks combining documentation with executable JavaScript/TypeScript.
-
-**Features:**
-- Isolated execution environments per notebook
-- Full package.json support with dependency installation
-- Sequential Feynman template for deep learning workflows
-- Export to `.src.md` format
-
-**Operations:** `create`, `add_cell`, `run_cell`, `export`, `list`, `load`, `update_cell`
-
-### 8. Hub — Multi-Agent Collaboration
-
-The Hub is a coordination layer for multiple AI agents working together. Agents register, join workspaces, and coordinate through problems, proposals, consensus, and channels — all via a single `thoughtbox_hub` MCP tool.
-
-**Core Concepts:**
-- **Workspace** — A shared collaboration space containing problems, proposals, consensus markers, and channels
 - **Problem** — A unit of work with dependencies, sub-problems, and status tracking (open → in-progress → resolved → closed)
-- **Proposal** — A proposed solution to a problem, with a source branch reference and review workflow
+- **Proposal** — A proposed solution with a source branch reference and review workflow
 - **Consensus** — A decision marker tied to a thought reference for traceability
-- **Channel** — A message stream scoped to a problem for discussion and coordination
-
-**27 Operations across 7 categories:**
-
-| Category | Operations | Stage |
-|----------|-----------|-------|
-| **Identity** (3) | `register`, `quick_join`, `list_workspaces` | 0 |
-| **Agent** (4) | `whoami`, `create_workspace`, `join_workspace`, `get_profile_prompt` | 1 |
-| **Problems** (9) | `create_problem`, `claim_problem`, `update_problem`, `list_problems`, `add_dependency`, `remove_dependency`, `ready_problems`, `blocked_problems`, `create_sub_problem` | 2 |
-| **Proposals** (4) | `create_proposal`, `review_proposal`, `merge_proposal`, `list_proposals` | 2 |
-| **Consensus** (3) | `mark_consensus`, `endorse_consensus`, `list_consensus` | 2 |
-| **Channels** (3) | `post_message`, `read_channel`, `post_system_message` | 2 |
-| **Status** (2) | `workspace_status`, `workspace_digest` | 2 |
+- **Channel** — A message stream scoped to a problem for discussion
 
 **Agent Profiles:** `MANAGER`, `ARCHITECT`, `DEBUGGER`, `SECURITY`, `RESEARCHER`, `REVIEWER` — each provides domain-specific mental models and behavioral priming.
 
-**Quick join example:**
-```javascript
-{ operation: "quick_join", args: { name: "Architect", workspaceId: "ws-abc123", profile: "ARCHITECT" } }
-```
+**27 operations** across identity, workspace management, problems, proposals, consensus, channels, and status reporting.
 
-**Typical workflow:** register → create_workspace → create_problem → claim_problem → work → create_proposal → review_proposal → merge_proposal → mark_consensus
+## Auditable Reasoning
 
-### 9. Knowledge Graph — Persistent Memory (Stage 2)
+Every thought is a node in a graph — numbered, timestamped, linked to its predecessors, and persisted across sessions. This creates an auditable trail of how conclusions were reached.
 
-A structured knowledge graph for capturing insights, concepts, workflows, and decisions that persist across sessions. Accessed via the `knowledge` gateway operation.
+Agents can think forward, plan backward, branch into parallel explorations, revise earlier conclusions, and request autonomous critique via MCP sampling. Each pattern is a first-class operation:
 
-**7 Operations across 2 categories:**
+| Pattern | Description | Use Case |
+|---------|-------------|----------|
+| **Forward** | Sequential 1→2→3→N progression | Exploration, discovery, open-ended analysis |
+| **Backward** | Start at goal (N), work back to start (1) | Planning, system design, working from known goals |
+| **Branching** | Fork into parallel explorations (A, B, C...) | Comparing alternatives, A/B scenarios |
+| **Revision** | Update earlier thoughts with new information | Error correction, refined understanding |
+| **Critique** | Autonomous LLM review via MCP sampling | Self-checking, quality gates |
 
-| Category | Operations |
-|----------|-----------|
-| **Entity Management** | `create_entity`, `get_entity`, `list_entities`, `add_observation` |
-| **Graph Structure** | `create_relation`, `query_graph`, `stats` |
+See the **[Patterns Cookbook](src/resources/docs/thoughtbox-patterns-cookbook.md)** for comprehensive examples.
 
-**Entity types:** `Insight`, `Concept`, `Workflow`, `Decision`, `Agent`
+## Real-Time Observability
 
-**Relation types:** `RELATES_TO`, `BUILDS_ON`, `CONTRADICTS`, `EXTRACTED_FROM`, `APPLIED_IN`, `LEARNED_BY`, `DEPENDS_ON`, `SUPERSEDES`, `MERGED_FROM`
+The **Observatory** is a built-in web UI at `http://localhost:1729` for watching reasoning unfold live.
 
-**Visibility levels:** `public`, `agent-private`, `user-private`, `team-private`
+- **Live Graph** — thoughts appear as nodes in real-time via WebSocket
+- **Branch Navigation** — branches collapse into clickable stubs; drill in and back out
+- **Detail Panel** — click any node to view full thought content
+- **Multi-Session** — switch between active reasoning sessions
+- **Deep Analysis** — analyze sessions for reasoning patterns, cognitive load, and decision points
 
-### 10. Deep Analysis — Session Intelligence (Stage 1)
+The full observability stack includes OpenTelemetry tracing, Prometheus metrics, and Grafana dashboards.
 
-Analyze reasoning sessions for patterns, cognitive load, and decision points.
+## Knowledge & Reasoning Tools
 
-**Analysis types:**
-- `patterns` — Identify reasoning patterns across the session
-- `cognitive_load` — Measure complexity and context-switching burden
-- `decision_points` — Extract key decision moments and their alternatives
-- `full` — Comprehensive analysis combining all types
+**Knowledge Graph** — Persistent memory across sessions. Capture insights, concepts, workflows, and decisions as typed entities with typed relations (`BUILDS_ON`, `CONTRADICTS`, `SUPERSEDES`, etc.) and visibility controls (`public`, `agent-private`, `team-private`).
 
-**Options:** Include timelines, compare across sessions.
+**Mental Models** — 15 structured reasoning frameworks (five-whys, pre-mortem, steelmanning, trade-off matrix, decomposition, and more) that provide process scaffolds for different problem types.
+
+**Notebooks** — Interactive literate programming combining documentation with executable JavaScript/TypeScript in isolated environments.
+
+## Client Compatibility
+
+> Thoughtbox is currently optimized for **Claude Code**. We are actively working on supporting additional MCP clients. Due to variation in capability support across the MCP ecosystem — server features (prompts, resources, tools), client features (roots, sampling, elicitation), and behaviors like `listChanged` notifications — we implement custom adaptations for many clients.
+
+If you're using a client other than Claude Code and encounter issues, please [open an issue](https://github.com/Kastalien-Research/thoughtbox/issues) describing your client and the problem.
 
 ## Installation
+
+Thoughtbox runs as a Docker-based MCP server. It requires Docker and Docker Compose.
 
 ### Quick Start
 
 ```bash
-npx -y @kastalien-research/thoughtbox
+git clone https://github.com/Kastalien-Research/thoughtbox.git
+cd thoughtbox
+docker compose up --build
 ```
 
+This starts Thoughtbox and the full observability stack. The MCP server listens on port `1731` and the Observatory UI is available at `http://localhost:1729`.
+
 ### MCP Client Configuration
+
+Since Thoughtbox uses HTTP transport, configure your MCP client to connect via URL.
 
 #### Claude Code
 
@@ -255,8 +92,19 @@ Add to your `~/.claude/settings.json` or project `.claude/settings.json`:
 {
   "mcpServers": {
     "thoughtbox": {
-      "command": "npx",
-      "args": ["-y", "@kastalien-research/thoughtbox"]
+      "url": "http://localhost:1731/mcp"
+    }
+  }
+}
+```
+
+To connect through the observability sidecar (adds OpenTelemetry tracing):
+
+```json
+{
+  "mcpServers": {
+    "thoughtbox": {
+      "url": "http://localhost:4000/mcp"
     }
   }
 }
@@ -270,8 +118,7 @@ Add to your MCP settings or `.vscode/mcp.json`:
 {
   "servers": {
     "thoughtbox": {
-      "command": "npx",
-      "args": ["-y", "@kastalien-research/thoughtbox"]
+      "url": "http://localhost:1731/mcp"
     }
   }
 }
@@ -338,48 +185,27 @@ Thought 6: [SYNTHESIS] "Use PostgreSQL for transactions, MongoDB for analytics"
 
 ## Development
 
+For local development (requires Node.js 22+):
+
 ```bash
-# Install dependencies
 npm install
-
-# Build
 npm run build
-
-# Development with hot reload
-npm run dev
-
-# Run the server
-npm start
+npm run dev      # Development with hot reload
 ```
 
 ### Testing
 
-Thoughtbox uses a combination of unit tests and agentic test scripts:
-
 ```bash
-# Unit tests (vitest)
-npx vitest run
-
-# Agentic tests — full suite (build + run)
-npm test
-
-# Agentic tests — tool-level only (build + run)
-npm run test:tool
-
-# Agentic tests — quick (no build)
-npm run test:quick
-
-# Behavioral contract tests
-npm run test:behavioral
+npx vitest run          # Unit tests
+npm test                # Agentic tests — full suite (build + run)
+npm run test:tool       # Agentic tests — tool-level only
+npm run test:quick      # Agentic tests — quick (no build)
+npm run test:behavioral # Behavioral contract tests
 ```
 
 ### Docker Compose
 
-A `docker-compose.yml` is included to run the full observability stack:
-
-```bash
-docker compose up --build
-```
+`docker compose up --build` starts the full stack:
 
 | Service | Port | Description |
 |---------|------|-------------|


### PR DESCRIPTION
## Summary

- Rewrites the README to lead with what Thoughtbox actually is: multi-agent collaborative reasoning that's auditable
- Replaces npx/npm installation with Docker Compose — Thoughtbox is a Docker-based MCP server, not an npm package you run directly
- MCP client configs now point at HTTP URLs instead of npx commands
- Restructures features from 10 numbered tools-by-stage into 4 capability sections: Collaboration, Auditable Reasoning, Real-Time Observability, Knowledge & Reasoning Tools
- Removes implementation details (progressive disclosure, gateway, init tool) from the pitch
- 465 → 294 lines

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Confirm Docker Compose quick start instructions work
- [ ] Confirm MCP client URL configs connect successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)