### PR TITLE
feat(notebook): add /tinker skill and api-exploration template for no…

### DIFF
--- a/.claude/skills/tinker/SKILL.md
+++ b/.claude/skills/tinker/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: tinker
+description: Explore APIs and libraries in a notebook before implementing. Validates assumptions with real code, prevents coding blind.
+argument-hint: <API or library to explore>
+user-invocable: true
+---
+
+Explore and validate: $ARGUMENTS
+
+## Purpose
+
+You are the **tinker agent**. Your job is to prevent "coding blind" — the failure mode where an agent writes production code against an API or library it has never actually called. You use Thoughtbox notebooks as a REPL to validate assumptions with real code before any implementation begins.
+
+This addresses a core problem with coding agents: they reach for complex scripts before tinkering at small scale in bottom-up notebooks to make sure they're modeling APIs correctly.
+
+## When to Use
+
+- Before implementing any integration with an external API
+- Before using a library you haven't validated in this project
+- When a spec references API shapes that haven't been tested
+- When you're uncertain about error formats, auth flows, or pagination
+- When the `/workflow` pipeline reaches the implementation stage and untested APIs are involved
+
+## Protocol
+
+### Phase 1: Inventory Assumptions (DO NOT SKIP)
+
+Before writing a single line of code, list every assumption you're making about the target:
+
+```
+thoughtbox_gateway {
+  operation: "thought",
+  args: {
+    thought: "Tinker: inventorying assumptions about [TARGET]. Assumed shapes: [...]. Assumed auth: [...]. Known unknowns: [...]",
+    thoughtType: "assumption_update",
+    nextThoughtNeeded: true,
+    assumptionChange: {
+      text: "API [TARGET] behaves as documented",
+      oldStatus: "unknown",
+      newStatus: "uncertain",
+      trigger: "Pre-implementation exploration"
+    }
+  }
+}
+```
+
+### Phase 2: Create Exploration Notebook
+
+```
+thoughtbox_gateway {
+  operation: "notebook",
+  args: {
+    operation: "create",
+    title: "[TARGET] API Exploration",
+    language: "typescript",
+    template: "api-exploration"
+  }
+}
+```
+
+### Phase 3: Write and Run Cells (The Core Loop)
+
+For each assumption, write the **smallest possible cell** that tests it:
+
+1. **Connectivity cell** — Can you reach the API at all?
+2. **Shape cell** — Does the response match your assumed type?
+3. **Error cell** — What do errors actually look like?
+4. **Edge case cell** — What happens at boundaries?
+
+For each cell:
+```
+thoughtbox_gateway {
+  operation: "notebook",
+  args: { operation: "add_cell", notebookId: "<id>", cellType: "code", content: "<code>", filename: "test-N.ts" }
+}
+```
+
+Then run it:
+```
+thoughtbox_gateway {
+  operation: "notebook",
+  args: { operation: "run_cell", notebookId: "<id>", cellId: "<cellId>" }
+}
+```
+
+**Read the output. Update your assumptions.** If the shape doesn't match, that's the whole point — you caught it before it was buried in production code.
+
+### Phase 4: Record Validated Model
+
+After exploration, record what you actually learned:
+
+```
+thoughtbox_gateway {
+  operation: "thought",
+  args: {
+    thought: "Tinker complete for [TARGET]. Validated: [...]. Refuted: [...]. Discovered: [...]",
+    thoughtType: "belief_snapshot",
+    nextThoughtNeeded: false,
+    beliefs: {
+      entities: [
+        { name: "[TARGET] API", state: "explored — shapes validated via notebook [ID]" }
+      ],
+      constraints: ["Rate limit: N/min", "Auth: Bearer token required"],
+      risks: ["Pagination cursor expires after 1h"]
+    }
+  }
+}
+```
+
+### Phase 5: Export Evidence
+
+```
+thoughtbox_gateway {
+  operation: "notebook",
+  args: { operation: "export", notebookId: "<id>", path: ".tinker/[target]-exploration.src.md" }
+}
+```
+
+This export becomes **implementation evidence** — reviewable proof that the agent validated its assumptions before writing production code.
+
+## Integration with /workflow
+
+When invoked as part of the `/workflow` pipeline (between planning and implementation):
+
+1. Parse the plan for external APIs and unfamiliar libraries
+2. For each untested dependency, run the tinker protocol above
+3. Record a `belief_snapshot` thought for each validated API
+4. Only then proceed to `/workflows-work`
+
+The workflow conductor checks for tinker evidence before advancing to implementation. Missing evidence triggers a sampling-based nudge asking the agent to explore first.
+
+## Rules
+
+1. **Never skip Phase 1.** Writing code before listing assumptions defeats the purpose.
+2. **One cell per assumption.** Don't bundle tests — isolate variables.
+3. **Run cells, read output, iterate.** The notebook is a REPL, not a script.
+4. **Record refuted assumptions.** A wrong assumption caught here saves hours of debugging later.
+5. **Export always.** The notebook is evidence, not scratch paper.
+
+## Anti-Patterns
+
+- Writing a single giant cell that tests everything at once (defeats isolation)
+- Skipping error path testing ("it'll probably work")
+- Not reading cell output before moving on
+- Treating this as documentation (it's experimentation — expect failures)
+- Running tinker on things you've already validated in this session

--- a/.claude/skills/workflow/SKILL.md
+++ b/.claude/skills/workflow/SKILL.md
@@ -18,6 +18,7 @@ You are the **workflow conductor**. You sequence 8 stages, enforce gates between
 | 1 | Ideation | `/workflow-ideation` | User confirms proceed (question 3d is not "confident no") |
 | 2 | Dev-Time Docs | `/hdd --phases=1-2` | Spec exists in `specs/`, ADR exists in `.adr/staging/` |
 | 3 | Planning | `/workflows-plan` | Plan file exists and user has approved it |
+| 3.5 | Tinker | `/tinker` (conditional) | Notebook evidence exists for each untested API/library in the plan, OR plan has no external dependencies |
 | 4 | Implementation | `/workflows-work` | All sub-agent summaries persisted to disk, all tests pass |
 | 5 | Review | `/workflows-review` | All claims verified, no blocking findings |
 | 6 | Revision | `/workflow-revision` | Review passes OR max iterations reached + user accepts |
@@ -59,6 +60,7 @@ Write to `.workflow/state.json`:
     "ideation": { "status": "pending", "completedAt": null, "notes": "" },
     "dev-docs": { "status": "pending", "artifacts": { "spec": null, "adr": null } },
     "planning": { "status": "pending", "artifacts": { "plan": null } },
+    "tinker": { "status": "pending", "artifacts": { "explored": [], "notebooks": [] }, "skipped": false },
     "implementation": { "status": "pending", "artifacts": { "summaries": [], "issues": [] } },
     "review": { "status": "pending", "artifacts": { "findings": [] } },
     "revision": { "status": "pending", "iterations": 0, "maxIterations": 3 },
@@ -89,6 +91,15 @@ If a gate condition is not met after the stage skill returns:
 - Do NOT silently advance past a failed gate
 
 ### Stage Transitions with Special Logic
+
+**Stage 3 → 3.5 → 4 (Planning → Tinker → Implementation)**: After planning completes, scan the plan for references to external APIs, SDKs, or unfamiliar libraries. For each one:
+
+1. Check if a `.tinker/[target]-exploration.src.md` file exists, OR if the current Thoughtbox session contains a `belief_snapshot` thought mentioning the target
+2. If evidence exists: skip tinker for that target
+3. If evidence is missing: dispatch `/tinker [target]` for each untested dependency
+4. Tinker gate passes when ALL external dependencies have notebook evidence, OR the plan has no external dependencies (pure refactoring, internal code, etc.)
+
+This stage is **conditional** — it's skipped entirely if the plan involves no external APIs. The state file tracks it as `"tinker"` stage with artifacts listing explored targets.
 
 **Stage 4 → 5 (Implementation → Review)**: Before dispatching review, run the between-stage check:
 ```bash

--- a/src/gateway/gateway-handler.ts
+++ b/src/gateway/gateway-handler.ts
@@ -208,6 +208,8 @@ export class GatewayHandler {
   private sessionsPrimed = new Set<string>();
   /** Per-session disclosure stage (fix thoughtbox-twu: sub-agents bypass progressive disclosure) */
   private sessionStages = new Map<string, DisclosureStage>();
+  /** Track APIs/libraries that have been explored in notebooks (prevents repeated nudges) */
+  private exploredTargets = new Set<string>();
 
   constructor(config: GatewayHandlerConfig) {
     this.toolRegistry = config.toolRegistry;
@@ -608,6 +610,28 @@ Call \`thoughtbox_gateway\` with operation 'thought' to begin structured reasoni
       agentId: (args.agentId as string | undefined) ?? this.getAgentId(mcpSessionId),
       agentName: (args.agentName as string | undefined) ?? this.getAgentName(mcpSessionId),
     });
+
+    // EXPLORATION NUDGE: Detect implementation thoughts about untested APIs
+    // When a thought mentions implementing/integrating/calling an API but no
+    // notebook evidence exists, append a non-blocking nudge suggesting /tinker.
+    if (!result.isError) {
+      const nudge = this.checkExplorationEvidence(thought, args.thoughtType as string | undefined);
+      if (nudge) {
+        result.content.push({
+          type: 'text',
+          text: nudge,
+        } as ContentBlock);
+      }
+
+      // Auto-mark explored: when a belief_snapshot thought mentions an API target,
+      // suppress future nudges for that target in this session
+      if (args.thoughtType === 'belief_snapshot') {
+        const target = this.extractApiTarget(thought);
+        if (target) {
+          this.markExplored(target);
+        }
+      }
+    }
 
     // SPEC-HUB-002: Append profile priming resource for profiled agents
     // Fix thoughtbox-308: Only prime once per MCP session to avoid token waste
@@ -1131,6 +1155,103 @@ Call \`thoughtbox_gateway\` with operation 'thought' to begin structured reasoni
     }
 
     return this.knowledgeHandler.processOperation(args as any);
+  }
+
+  // ===========================================================================
+  // Exploration Evidence Check (Tinker Nudge System)
+  // ===========================================================================
+
+  /**
+   * Patterns that suggest an agent is about to implement against an external API.
+   * Matched against thought content to detect "coding blind" situations.
+   */
+  private static readonly IMPLEMENTATION_SIGNALS = [
+    /\bimplement(?:ing)?\b.*\b(?:api|endpoint|integration|sdk|client)\b/i,
+    /\bcall(?:ing)?\b.*\b(?:api|endpoint|service)\b/i,
+    /\bintegrat(?:e|ing)\b.*\b(?:with|into)\b/i,
+    /\bfetch(?:ing)?\b.*\bfrom\b/i,
+    /\buse\b.*\b(?:library|package|sdk|module)\b.*\bto\b/i,
+  ];
+
+  /**
+   * Patterns that indicate a thought already involves exploration/tinkering.
+   * If matched, no nudge is needed — the agent is already exploring.
+   */
+  private static readonly EXPLORATION_SIGNALS = [
+    /\btinker\b/i,
+    /\bexplor(?:e|ing|ation)\b/i,
+    /\bnotebook\b/i,
+    /\bvalidat(?:e|ing|ed)\b.*\b(?:assumption|shape|response)\b/i,
+    /\bbelief_snapshot\b/i,
+  ];
+
+  /**
+   * Check whether a thought suggests implementation against untested APIs
+   * and return a nudge message if exploration evidence is missing.
+   *
+   * Returns null if:
+   * - The thought doesn't mention API implementation
+   * - The thought is already about exploration
+   * - The target has been marked as explored
+   * - The thought type is belief_snapshot (already validated)
+   */
+  private checkExplorationEvidence(
+    thought: string,
+    thoughtType?: string,
+  ): string | null {
+    // Don't nudge belief_snapshot or assumption_update — these ARE evidence
+    if (thoughtType === 'belief_snapshot' || thoughtType === 'assumption_update') {
+      return null;
+    }
+
+    // Don't nudge if the thought itself is about exploration
+    if (GatewayHandler.EXPLORATION_SIGNALS.some(re => re.test(thought))) {
+      return null;
+    }
+
+    // Check if the thought signals API implementation
+    const isImplementation = GatewayHandler.IMPLEMENTATION_SIGNALS.some(re => re.test(thought));
+    if (!isImplementation) {
+      return null;
+    }
+
+    // Check if the target has already been explored in this session
+    // (Simple heuristic: extract likely API name from thought)
+    const target = this.extractApiTarget(thought);
+    if (target && this.exploredTargets.has(target.toLowerCase())) {
+      return null;
+    }
+
+    return `\n---\n**Exploration nudge**: This thought mentions implementing against an external API/library, but no notebook evidence was found validating the assumed behavior. Consider running \`/tinker ${target || '[target]'}\` to validate your mental model in a notebook before writing production code. This catches shape mismatches, auth surprises, and undocumented edge cases early.`;
+  }
+
+  /**
+   * Extract a likely API/library target name from thought text.
+   * Simple heuristic — looks for quoted strings, backticked code, or
+   * capitalized proper nouns near API keywords.
+   */
+  private extractApiTarget(thought: string): string | null {
+    // Try backticked code first
+    const backtickMatch = thought.match(/`([^`]+(?:api|sdk|client|service)[^`]*)`/i);
+    if (backtickMatch) return backtickMatch[1];
+
+    // Try quoted strings
+    const quoteMatch = thought.match(/"([^"]+(?:api|sdk|client|service)[^"]*)"/i);
+    if (quoteMatch) return quoteMatch[1];
+
+    // Try capitalized names near API keywords
+    const nameMatch = thought.match(/\b([A-Z][a-zA-Z]+(?:\s+[A-Z][a-zA-Z]+)?)\s+(?:api|sdk|client|service|endpoint)/i);
+    if (nameMatch) return nameMatch[1];
+
+    return null;
+  }
+
+  /**
+   * Mark an API/library target as explored (prevents future nudges).
+   * Called when a belief_snapshot thought is recorded with notebook evidence.
+   */
+  markExplored(target: string): void {
+    this.exploredTargets.add(target.toLowerCase());
   }
 }
 

--- a/src/notebook/operations.ts
+++ b/src/notebook/operations.ts
@@ -34,8 +34,8 @@ export const NOTEBOOK_OPERATIONS: OperationDefinition[] = [
         },
         template: {
           type: "string",
-          enum: ["sequential-feynman"],
-          description: "Optional: Load a pre-structured template. 'sequential-feynman' provides guided structure for deep learning workflows with Feynman Technique.",
+          enum: ["sequential-feynman", "api-exploration"],
+          description: "Optional: Load a pre-structured template. 'sequential-feynman' provides guided structure for deep learning workflows with Feynman Technique. 'api-exploration' provides structured API tinkering: validate shapes, test edge cases, and build evidence before implementing.",
         },
       },
       required: ["title", "language"],

--- a/src/notebook/templates.generated.ts
+++ b/src/notebook/templates.generated.ts
@@ -5,6 +5,200 @@
  */
 
 export const TEMPLATES = {
+  'api-exploration': `<!-- srcbook:{"language":"[LANGUAGE]"} -->
+
+# API Exploration: [TOPIC]
+
+**Target**: \`[TOPIC]\`
+**Started**: [DATE]
+**Status**: Exploring
+
+---
+
+## Exploration Checklist
+
+- [ ] Phase 1: Identify API surface and assumptions
+- [ ] Phase 2: Validate request/response shapes
+- [ ] Phase 3: Test edge cases and error paths
+- [ ] Phase 4: Document validated mental model
+- [ ] Phase 5: Export evidence for implementation
+
+---
+
+# Phase 1: Assumptions Inventory
+
+*Before writing any code, list what you THINK is true about this API:*
+
+### Assumed Request Shapes
+
+| Endpoint / Method | Expected Input | Expected Output | Confidence |
+|-------------------|---------------|-----------------|------------|
+|                   |               |                 |            |
+|                   |               |                 |            |
+
+### Assumed Behavior
+
+1. **Auth**: How do you think auth works?
+2. **Rate limits**: What are the expected constraints?
+3. **Error format**: What shape do errors come in?
+4. **Pagination**: How does it paginate (if applicable)?
+5. **Idempotency**: Safe to retry?
+
+### Known Unknowns
+
+*What do you know you don't know?*
+
+1.
+2.
+3.
+
+---
+
+# Phase 2: Shape Validation
+
+*Test each assumption with the smallest possible code cell.*
+
+## Cell 1: Basic Connectivity
+
+*Can you reach the API at all? What does a minimal request look like?*
+
+\`\`\`typescript
+// Minimal request — just prove connectivity and see raw response shape
+// Replace with actual API call
+
+const response = await fetch("https://api.example.com/v1/health");
+console.log("Status:", response.status);
+console.log("Headers:", Object.fromEntries(response.headers.entries()));
+const body = await response.json();
+console.log("Body shape:", JSON.stringify(body, null, 2));
+\`\`\`
+
+---
+
+## Cell 2: Primary Operation
+
+*Test the main thing you'll actually use in production code.*
+
+\`\`\`typescript
+// The primary API call your implementation depends on
+// Validate: does the response match your assumed shape?
+
+// After running, fill in:
+// ACTUAL shape: { ... }
+// MATCHES assumption? YES / NO / PARTIAL
+// Surprises:
+\`\`\`
+
+---
+
+## Cell 3: Secondary Operation
+
+*Test the second most important operation.*
+
+\`\`\`typescript
+// Secondary API call
+// Validate the response shape matches assumptions
+\`\`\`
+
+---
+
+# Phase 3: Edge Cases
+
+*Now break it intentionally.*
+
+## Cell 4: Error Handling
+
+*What happens with bad input? Auth failures? Missing fields?*
+
+\`\`\`typescript
+// Send malformed request — what does the error look like?
+// Test: missing required field, invalid type, expired token, etc.
+
+// ACTUAL error shape: { ... }
+// Error codes seen:
+// Retry-safe?
+\`\`\`
+
+---
+
+## Cell 5: Boundary Conditions
+
+*Test limits, empty sets, large payloads, special characters.*
+
+\`\`\`typescript
+// Test: empty list, max page size, unicode, null values
+// What does the API do at its boundaries?
+
+// Findings:
+\`\`\`
+
+---
+
+# Phase 4: Validated Mental Model
+
+*Based on actual cell outputs, document what you NOW know:*
+
+## Confirmed Facts
+
+| Claim | Evidence (cell #) | Notes |
+|-------|-------------------|-------|
+|       |                   |       |
+|       |                   |       |
+
+## Refuted Assumptions
+
+| Original Assumption | Actual Behavior | Impact on Implementation |
+|---------------------|-----------------|--------------------------|
+|                     |                 |                          |
+
+## Discovered Unknowns
+
+*Things you found during exploration that you didn't even know to ask about:*
+
+1.
+2.
+
+## API Shape Reference
+
+\`\`\`typescript
+// Paste actual TypeScript types derived from real responses
+// These become your source of truth for implementation
+
+interface ExampleResponse {
+  // Fill from actual cell outputs
+}
+\`\`\`
+
+---
+
+# Phase 5: Implementation Readiness
+
+## Evidence Summary
+
+*For each key implementation decision, cite the cell that validated it:*
+
+1. **Auth approach**: [Validated in Cell N] — [summary]
+2. **Error handling strategy**: [Validated in Cell N] — [summary]
+3. **Response parsing**: [Validated in Cell N] — [summary]
+4. **Edge case handling**: [Validated in Cell N] — [summary]
+
+## Remaining Risks
+
+*What couldn't be validated in the notebook? What needs production testing?*
+
+1.
+2.
+
+## Ready to Implement?
+
+- [ ] All primary operations validated with real responses
+- [ ] Error shapes documented from actual errors
+- [ ] At least one edge case tested per operation
+- [ ] TypeScript types derived from real data (not docs)
+- [ ] No unresolved blocking unknowns
+
+If all boxes checked: **Exploration complete — proceed to implementation**
+`,
   'sequential-feynman': `<!-- srcbook:{"language":"[LANGUAGE]"} -->
 
 # 🧠 Sequential Feynman Learning: [TOPIC]
@@ -654,6 +848,7 @@ If all boxes are checked: **Understanding validated ✅**`,
 export type TemplateName = keyof typeof TEMPLATES;
 
 export const AVAILABLE_TEMPLATES: readonly TemplateName[] = [
+  'api-exploration',
   'sequential-feynman',
 ] as const;
 

--- a/src/sampling/handler.ts
+++ b/src/sampling/handler.ts
@@ -1,11 +1,35 @@
 /**
- * Sampling Handler - Manages autonomous LLM sampling for critique loops
+ * Sampling Handler - Manages autonomous LLM sampling for critique and exploration loops
  *
  * Implements the MCP `sampling/createMessage` primitive to request
  * external LLM analysis of reasoning steps without user intervention.
+ *
+ * Extended with `requestExploration` to support server-initiated tinkering:
+ * when Thoughtbox detects an agent is about to implement against an untested
+ * API, it uses sampling to ask the agent to explore in a notebook first.
  */
 
 import type { ThoughtData } from "../persistence/types.js";
+
+const EXPLORATION_SYSTEM_PROMPT = `You are a careful software engineer about to implement code that depends on external APIs or libraries.
+
+Before writing production code, you MUST validate your assumptions by tinkering in a notebook. This means:
+
+1. Create a Thoughtbox notebook using the api-exploration template
+2. Write small, isolated cells testing each assumption about the API
+3. Run cells, read output, iterate until the actual behavior matches your mental model
+4. Record validated findings as a belief_snapshot thought
+5. Export the notebook as evidence
+
+Do NOT proceed to implementation until you have validated:
+- Request/response shapes with real calls
+- Error formats from actual error responses
+- At least one edge case per primary operation
+
+Use the thoughtbox_gateway tool with operation "notebook" to create and run cells.
+Use thoughtbox_gateway with operation "thought" to record findings.
+
+This exploration is not optional — it prevents the costly failure mode of coding blind against undocumented or misunderstood APIs.`;
 
 const CRITIC_SYSTEM_PROMPT = `You are a critical thinking expert tasked with analyzing reasoning steps.
 
@@ -144,6 +168,73 @@ export class SamplingHandler {
         },
       },
     ];
+  }
+
+  /**
+   * Request that the agent explore an API/library in a notebook before implementing.
+   *
+   * This is the server-initiated tinkering primitive. When Thoughtbox detects that
+   * an agent is about to implement against an untested API (no notebook evidence
+   * found), it uses this method to ask the agent's LLM to run an exploration first.
+   *
+   * @param target - The API or library that needs exploration (e.g., "Stripe charges API")
+   * @param assumptions - List of assumptions the agent appears to be making
+   * @param context - Recent thoughts for context
+   * @returns The agent's exploration plan/acknowledgment
+   * @throws Error if sampling fails or is not supported
+   */
+  async requestExploration(
+    target: string,
+    assumptions: string[],
+    context: ThoughtData[]
+  ): Promise<string> {
+    const assumptionList = assumptions.length > 0
+      ? `\n\nAssumptions detected (validate ALL of these):\n${assumptions.map((a, i) => `${i + 1}. ${a}`).join("\n")}`
+      : "";
+
+    const contextText = context.slice(-3)
+      .map((t) => `Thought ${t.thoughtNumber}: ${t.thought}`)
+      .join("\n\n");
+
+    const message = `${contextText ? contextText + "\n\n" : ""}You are about to implement code that depends on: ${target}
+
+No notebook evidence was found validating your assumptions about this dependency.${assumptionList}
+
+Create a Thoughtbox notebook using the api-exploration template and validate your mental model before proceeding. Start with: thoughtbox_gateway { operation: "notebook", args: { operation: "create", title: "${target} Exploration", language: "typescript", template: "api-exploration" } }`;
+
+    try {
+      const result = (await this.protocol.request(
+        {
+          method: "sampling/createMessage",
+          params: {
+            messages: [{
+              role: "user" as const,
+              content: {
+                type: "text" as const,
+                text: message,
+              },
+            }],
+            systemPrompt: EXPLORATION_SYSTEM_PROMPT,
+            modelPreferences: {
+              hints: [{ name: "claude-sonnet-4-5-20250929" }],
+              intelligencePriority: 0.8,
+              costPriority: 0.4,
+            },
+            includeContext: "thisServer",
+            maxTokens: 2000,
+          } as SamplingParams,
+        },
+        null as any
+      )) as SamplingResult;
+
+      return result.content.text;
+    } catch (error: any) {
+      if (error.code === -32601) {
+        // Client doesn't support sampling — degrade gracefully
+        throw error;
+      }
+      throw new Error(`Exploration sampling request failed: ${error.message}`);
+    }
   }
 
   // NOTE: Sampling capability detection happens automatically during MCP initialization

--- a/templates/api-exploration-template.src.md
+++ b/templates/api-exploration-template.src.md
@@ -1,0 +1,193 @@
+<!-- srcbook:{"language":"[LANGUAGE]"} -->
+
+# API Exploration: [TOPIC]
+
+**Target**: `[TOPIC]`
+**Started**: [DATE]
+**Status**: Exploring
+
+---
+
+## Exploration Checklist
+
+- [ ] Phase 1: Identify API surface and assumptions
+- [ ] Phase 2: Validate request/response shapes
+- [ ] Phase 3: Test edge cases and error paths
+- [ ] Phase 4: Document validated mental model
+- [ ] Phase 5: Export evidence for implementation
+
+---
+
+# Phase 1: Assumptions Inventory
+
+*Before writing any code, list what you THINK is true about this API:*
+
+### Assumed Request Shapes
+
+| Endpoint / Method | Expected Input | Expected Output | Confidence |
+|-------------------|---------------|-----------------|------------|
+|                   |               |                 |            |
+|                   |               |                 |            |
+
+### Assumed Behavior
+
+1. **Auth**: How do you think auth works?
+2. **Rate limits**: What are the expected constraints?
+3. **Error format**: What shape do errors come in?
+4. **Pagination**: How does it paginate (if applicable)?
+5. **Idempotency**: Safe to retry?
+
+### Known Unknowns
+
+*What do you know you don't know?*
+
+1.
+2.
+3.
+
+---
+
+# Phase 2: Shape Validation
+
+*Test each assumption with the smallest possible code cell.*
+
+## Cell 1: Basic Connectivity
+
+*Can you reach the API at all? What does a minimal request look like?*
+
+```typescript
+// Minimal request — just prove connectivity and see raw response shape
+// Replace with actual API call
+
+const response = await fetch("https://api.example.com/v1/health");
+console.log("Status:", response.status);
+console.log("Headers:", Object.fromEntries(response.headers.entries()));
+const body = await response.json();
+console.log("Body shape:", JSON.stringify(body, null, 2));
+```
+
+---
+
+## Cell 2: Primary Operation
+
+*Test the main thing you'll actually use in production code.*
+
+```typescript
+// The primary API call your implementation depends on
+// Validate: does the response match your assumed shape?
+
+// After running, fill in:
+// ACTUAL shape: { ... }
+// MATCHES assumption? YES / NO / PARTIAL
+// Surprises:
+```
+
+---
+
+## Cell 3: Secondary Operation
+
+*Test the second most important operation.*
+
+```typescript
+// Secondary API call
+// Validate the response shape matches assumptions
+```
+
+---
+
+# Phase 3: Edge Cases
+
+*Now break it intentionally.*
+
+## Cell 4: Error Handling
+
+*What happens with bad input? Auth failures? Missing fields?*
+
+```typescript
+// Send malformed request — what does the error look like?
+// Test: missing required field, invalid type, expired token, etc.
+
+// ACTUAL error shape: { ... }
+// Error codes seen:
+// Retry-safe?
+```
+
+---
+
+## Cell 5: Boundary Conditions
+
+*Test limits, empty sets, large payloads, special characters.*
+
+```typescript
+// Test: empty list, max page size, unicode, null values
+// What does the API do at its boundaries?
+
+// Findings:
+```
+
+---
+
+# Phase 4: Validated Mental Model
+
+*Based on actual cell outputs, document what you NOW know:*
+
+## Confirmed Facts
+
+| Claim | Evidence (cell #) | Notes |
+|-------|-------------------|-------|
+|       |                   |       |
+|       |                   |       |
+
+## Refuted Assumptions
+
+| Original Assumption | Actual Behavior | Impact on Implementation |
+|---------------------|-----------------|--------------------------|
+|                     |                 |                          |
+
+## Discovered Unknowns
+
+*Things you found during exploration that you didn't even know to ask about:*
+
+1.
+2.
+
+## API Shape Reference
+
+```typescript
+// Paste actual TypeScript types derived from real responses
+// These become your source of truth for implementation
+
+interface ExampleResponse {
+  // Fill from actual cell outputs
+}
+```
+
+---
+
+# Phase 5: Implementation Readiness
+
+## Evidence Summary
+
+*For each key implementation decision, cite the cell that validated it:*
+
+1. **Auth approach**: [Validated in Cell N] — [summary]
+2. **Error handling strategy**: [Validated in Cell N] — [summary]
+3. **Response parsing**: [Validated in Cell N] — [summary]
+4. **Edge case handling**: [Validated in Cell N] — [summary]
+
+## Remaining Risks
+
+*What couldn't be validated in the notebook? What needs production testing?*
+
+1.
+2.
+
+## Ready to Implement?
+
+- [ ] All primary operations validated with real responses
+- [ ] Error shapes documented from actual errors
+- [ ] At least one edge case tested per operation
+- [ ] TypeScript types derived from real data (not docs)
+- [ ] No unresolved blocking unknowns
+
+If all boxes checked: **Exploration complete — proceed to implementation**


### PR DESCRIPTION
…tebook-first workflows

Addresses the "coding blind" problem where agents implement against APIs they've never actually called. Adds three interconnected features:

1. **api-exploration template**: Structured notebook template with phases for assumption inventory, shape validation, edge case testing, and evidence export.

2. **/tinker skill**: Guides agents through notebook-based API exploration before implementation. Records validated mental models as belief_snapshot thoughts.

3. **Server-initiated exploration via sampling**: SamplingHandler.requestExploration() uses MCP sampling/createMessage to ask the agent's LLM to explore untested APIs in a notebook. The gateway appends non-blocking nudges when it detects implementation thoughts about unvalidated APIs.

4. **Workflow integration**: /workflow pipeline now includes a conditional Stage 3.5 (Tinker) between Planning and Implementation that gates on notebook evidence.

Inspired by @lateinteraction's observation that coding agents should tinker at small scale in notebooks before writing complex scripts.

https://claude.ai/code/session_012WEeqRaye2Exoc6cURRyex