### PR TITLE
chore: remove bead workflow references from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,9 @@
 
 ## Development Workflow (Source of Truth)
 
-Every unit of work runs through two mandatory skills. Two additional protocols activate conditionally.
+Every unit of work runs through HDD for architectural decisions. Two additional protocols activate conditionally.
 
 ### Mandatory Skills
-
-**`bead-workflow`** — The process for every task, bug, or feature without exception. Enforces claim → hypothesize → implement → test → validate → close. Hooks block violations at the tool level — this is not advisory.
-
-Read `.claude/skills/bead-workflow/SKILL.md` before starting any work.
 
 **`hdd`** — Hypothesis-Driven Development for architectural decisions, new features, protocol implementations, and behavior-changing refactors. Produces a staging ADR + spec pair that must be validated before accepting. Code is an implementation artifact; ADRs are the source of truth.
 
@@ -15,7 +11,7 @@ Read `.claude/skills/hdd/SKILL.md` when the work requires an architectural decis
 
 ### Conditional Protocols
 
-**`ulysses-protocol`** — Activates when 2 consecutive surprises occur on a bead. A surprise-gated debugging framework that prevents hallucinated progress through pre-committed recovery actions and falsifiable hypotheses. The `bead-workflow` enforcer writes the `reflect-required` sentinel; Ulysses clears it.
+**`ulysses-protocol`** — Activates when 2 consecutive surprises occur. A surprise-gated debugging framework that prevents hallucinated progress through pre-committed recovery actions and falsifiable hypotheses.
 
 Invoke only when stuck: `.claude/skills/ulysses-protocol/SKILL.md`
 
@@ -27,14 +23,13 @@ Invoke only for refactoring tasks: `.claude/skills/theseus-protocol/SKILL.md`
 
 1. **Specs go in `.specs/`** (not `specs/`). ADRs use the HDD lifecycle: `.adr/staging/` → `.adr/accepted/` or `.adr/rejected/`.
 2. **Code and spec updates in the same commit.** If you change code that a spec describes, update the spec in the same commit.
-3. **Atomic commits.** One sub-agent = one bead = one unit of work = one commit, made after review validates the work.
-4. **Sub-agent summaries state**: Claims, Hypothesis Alignment, Tests run, Known Gaps, Risks.
+3. **Atomic commits.** One sub-agent = one unit of work = one commit, made after review validates the work.
+4. **Sub-agent summaries state**: Hypothesis Alignment, Tests run, Known Gaps, Risks.
 5. **Default: human is NOT in the loop.** Operate autonomously up to the escalation thresholds defined in `agentic-dev-team/agentic-dev-team-spec.md`. Escalate only when those thresholds are met.
 6. **Orchestrators don't do manual work.** Deploy sub-agents or agent teams. Protect your context window.
 
 ### References
 
-- Bead workflow: `.claude/skills/bead-workflow/SKILL.md`
 - HDD process: `.claude/skills/hdd/SKILL.md`
 - Ulysses protocol: `.claude/skills/ulysses-protocol/SKILL.md`
 - Theseus protocol: `.claude/skills/theseus-protocol/SKILL.md`
@@ -52,13 +47,10 @@ Agent-specific enforcement rules:
    - `fix/X` branches are for fixing X — not for new features
    - `feat/X` branches are for feature X — not for unrelated fixes
    - If scope doesn't match, create a new branch from `main`
-2. **Every branch MUST have a corresponding bead.** Create the bead before creating the branch.
-3. **Branch name MUST match the bead's subject** (e.g., bead "Fix gateway timeout" → `fix/gateway-timeout`).
-4. **After PR is merged: delete the branch** (local + remote). This is not optional.
-5. **Never create branches with timestamps, UUIDs, or auto-generated suffixes.**
-6. **Never commit to `main` directly.**
-7. **Never commit to `beads-sync`.**
-8. **Plans must include branch creation as Step 0** when the work is a new unit.
+2. **After PR is merged: delete the branch** (local + remote). This is not optional.
+3. **Never create branches with timestamps, UUIDs, or auto-generated suffixes.**
+4. **Never commit to `main` directly.**
+5. **Plans must include branch creation as Step 0** when the work is a new unit.
 
 Committing unrelated work to an existing branch pollutes PRs, makes reverts dangerous, creates merge conflicts, and makes git history useless for archaeology. **This is non-negotiable.**
 
@@ -68,113 +60,23 @@ Committing unrelated work to an existing branch pollutes PRs, makes reverts dang
 
 **MANDATORY WORKFLOW:**
 
-1. **File issues for ALL remaining work** - Every follow-up, deferred decision, or "next session" item MUST become a bead before the session ends. If an ADR references future work (e.g., "deferred to ADR-010"), create the bead now — the ADR process starts next session, but the tracking starts this one. Prose in handoff JSON is not a substitute for a bead.
+1. **Document remaining work** - Every follow-up, deferred decision, or "next session" item must be captured before the session ends.
 2. **Run quality gates** (if code changed) - Tests, linters, builds
-3. **Update issue status** - Close finished work, update in-progress items
-4. **PUSH TO REMOTE** - This is MANDATORY:
+3. **PUSH TO REMOTE** - This is MANDATORY:
    ```bash
    git pull --rebase
-   bd sync
    git push
    git status  # MUST show "up to date with origin"
    ```
-5. **Clean up** - Clear stashes, prune remote branches
-6. **Verify** - All changes committed AND pushed
-7. **Hand off** - Provide context for next session
+4. **Clean up** - Clear stashes, prune remote branches
+5. **Verify** - All changes committed AND pushed
+6. **Hand off** - Provide context for next session
 
 **CRITICAL RULES:**
 - Work is NOT complete until `git push` succeeds
 - NEVER stop before pushing - that leaves work stranded locally
 - NEVER say "ready to push when you are" - YOU must push
 - If push fails, resolve and retry until it succeeds
-
-<!-- BEGIN BEADS INTEGRATION -->
-## Issue Tracking with bd (beads)
-
-**IMPORTANT**: This project uses **bd (beads)** for ALL issue tracking. Do NOT use markdown TODOs, task lists, or other tracking methods.
-
-### Why bd?
-
-- Dependency-aware: Track blockers and relationships between issues
-- Git-friendly: Auto-syncs to JSONL for version control
-- Agent-optimized: JSON output, ready work detection, discovered-from links
-- Prevents duplicate tracking systems and confusion
-
-### Quick Start
-
-**Check for ready work:**
-
-```bash
-bd ready --json
-```
-
-**Create new issues:**
-
-```bash
-bd create "Issue title" --description="Detailed context" -t bug|feature|task -p 0-4 --json
-bd create "Issue title" --description="What this issue is about" -p 1 --deps discovered-from:bd-123 --json
-```
-
-**Claim and update:**
-
-```bash
-bd update bd-42 --status in_progress --json
-bd update bd-42 --priority 1 --json
-```
-
-**Complete work:**
-
-```bash
-bd close bd-42 --reason "Completed" --json
-```
-
-### Issue Types
-
-- `bug` - Something broken
-- `feature` - New functionality
-- `task` - Work item (tests, docs, refactoring)
-- `epic` - Large feature with subtasks
-- `chore` - Maintenance (dependencies, tooling)
-
-### Priorities
-
-- `0` - Critical (security, data loss, broken builds)
-- `1` - High (major features, important bugs)
-- `2` - Medium (default, nice-to-have)
-- `3` - Low (polish, optimization)
-- `4` - Backlog (future ideas)
-
-### Workflow for AI Agents
-
-1. **Check ready work**: `bd ready` shows unblocked issues
-2. **Claim your task**: `bd update <id> --status in_progress`
-3. **Work on it**: Implement, test, document
-4. **Discover new work?** Create linked issue:
-   - `bd create "Found bug" --description="Details about what was found" -p 1 --deps discovered-from:<parent-id>`
-5. **Complete**: `bd close <id> --reason "Done"`
-
-### Auto-Sync
-
-bd automatically syncs with git:
-
-- Exports to `.beads/issues.jsonl` after changes (5s debounce)
-- Imports from JSONL when newer (e.g., after `git pull`)
-- No manual export/import needed!
-
-### Important Rules
-
-- ✅ Use bd for ALL task tracking
-- ✅ Always use `--json` flag for programmatic use
-- ✅ Link discovered work with `discovered-from` dependencies
-- ✅ Check `bd ready` before asking "what should I work on?"
-- ❌ Do NOT create markdown TODO lists
-- ❌ Do NOT use external issue trackers
-- ❌ Do NOT duplicate tracking systems
-
-For more details, see README.md and docs/QUICKSTART.md.
-
-<!-- END BEADS INTEGRATION -->
-
 
 ## Local Agent Asset Bridge (`.claude/` and `.gemini/`)
 
@@ -197,8 +99,8 @@ Notes:
 
 If the user invokes one of these names, or the task clearly matches one, open the matching local file and follow it directly:
 
-- **Mandatory workflow**: `bead-workflow` (every task), `hdd` (architectural decisions and new features)
-- **Conditional protocols**: `ulysses-protocol` (2+ consecutive surprises on a bead), `theseus-protocol` (refactoring tasks)
+- **Mandatory workflow**: `hdd` (architectural decisions and new features)
+- **Conditional protocols**: `ulysses-protocol` (2+ consecutive surprises), `theseus-protocol` (refactoring tasks)
 - **Implementation**: `implement`
 - **Research and knowledge**: `research-task`, `knowledge`, `synthesize`, `distill`, `capture-learning`, `session-review`, `assumptions`, `eval`, `taste`, `diagram`
 - **Coordination and autonomy**: `team`, `hub-collab`, `deploy-team-hub`, `experiment`, `ulc-loop`, `loop-status`, `status`, `escalate`, `claude-prompt`
@@ -235,11 +137,11 @@ Codex cannot auto-register `.claude/settings.json`, `.gemini/settings.json`, or 
 Hook intent by event:
 
 - `PreToolUse` / `BeforeTool`: apply command safety checks before running risky shell commands. Block direct pushes to protected branches, force pushes, branch deletion, dangerous `rm -rf`, and unrequested writes to `.env`-style files.
-- `PostToolUse` / `AfterTool`: treat file access and tool side effects as auditable. Keep track of files touched, note meaningful state changes, and prefer leaving a clear trail in commit messages, beads, specs, and handoff artifacts.
+- `PostToolUse` / `AfterTool`: treat file access and tool side effects as auditable. Keep track of files touched, note meaningful state changes, and prefer leaving a clear trail in commit messages, specs, and handoff artifacts.
 - `PermissionRequest`: preserve the repo's git safety policy when escalating. Default to caution on branch-destructive operations and anything that bypasses normal review flow.
 - `UserPromptSubmit`: if a prompt implies assumptions, risks, or session context worth preserving, record them in the right project artifact instead of keeping them implicit.
 - `SessionStart`: check whether `.claude/session-handoff.json`, `.claude/rules/`, or relevant state files should shape the current task.
-- `SessionEnd` / `Stop`: before considering work complete, capture handoff context, update specs/ADRs/issues, and follow the repo's landing-the-plane steps.
+- `SessionEnd` / `Stop`: before considering work complete, capture handoff context, update specs/ADRs, and follow the repo's landing-the-plane steps.
 - `PreCompact`: before large context shifts, preserve the minimal durable context needed for safe continuation.
 - `Notification`: assume important async events should be surfaced clearly in commentary rather than silently ignored.
 - `SubagentStop`: when using agents, persist their outputs in durable artifacts immediately if the surrounding workflow expects that.


### PR DESCRIPTION
## Summary
- Removes the bead-workflow mandatory skill section and all `bd` command references
- Removes the entire `<!-- BEGIN BEADS INTEGRATION -->` block
- Removes branch rules tied to beads (every branch needs a bead, branch names match bead subjects, no commits to `beads-sync`)
- Cleans up Landing the Plane procedure (`bd sync` removed)
- HDD remains the primary mandatory skill for architectural decisions

👾 Generated with [Letta Code](https://letta.com)