### PR TITLE
chore(ci): automate migration apply and type sync on schema change

### DIFF
--- a/.github/workflows/schema-sync.yml
+++ b/.github/workflows/schema-sync.yml
@@ -1,0 +1,71 @@
+name: Schema Sync
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'supabase/migrations/**'
+
+jobs:
+  sync:
+    name: Apply migrations + sync types
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # commit updated types back to main
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Link project
+        run: supabase link --project-ref akjccuoncxlvrrtkvtno
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+
+      - name: Apply pending migrations
+        run: supabase db push
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+
+      - name: Regenerate types
+        run: |
+          supabase gen types typescript \
+            --project-id akjccuoncxlvrrtkvtno \
+            > src/database.types.ts
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+
+      - name: Commit updated types
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add src/database.types.ts
+          if git diff --cached --quiet; then
+            echo "Types unchanged — nothing to commit"
+          else
+            git commit -m "chore(schema): regenerate database.types.ts [skip ci]"
+            git push
+          fi
+
+      - name: Notify web app
+        run: |
+          curl -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.GH_PAT }}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/Kastalien-Research/thoughtbox-web-two/dispatches \
+            -d '{
+              "event_type": "schema-updated",
+              "client_payload": {
+                "thoughtbox_sha": "${{ github.sha }}",
+                "types_url": "https://raw.githubusercontent.com/Kastalien-Research/thoughtbox/${{ github.sha }}/src/database.types.ts"
+              }
+            }'


### PR DESCRIPTION
On any push to main that touches `supabase/migrations/`:

1. Applies pending migrations to remote Supabase via `supabase db push`
2. Regenerates `src/database.types.ts`
3. Commits updated types back to main (`[skip ci]` prevents retrigger)
4. Fires `repository_dispatch` to `thoughtbox-web-two` with the types URL

**Secrets required in repo settings before this does anything useful:**
- `SUPABASE_ACCESS_TOKEN` — Supabase dashboard → Account → Access tokens
- `SUPABASE_DB_PASSWORD` — database password for the project
- `GH_PAT` — PAT with `repo` scope on `Kastalien-Research/thoughtbox-web-two`

**Web app side:** needs a workflow that handles the `schema-updated` dispatch event.