### PR TITLE
fix(ci): retry on transient Letta errors, block on UNKNOWN verdict

### DIFF
--- a/.github/workflows/adversarial-review.yml
+++ b/.github/workflows/adversarial-review.yml
@@ -90,13 +90,29 @@ jobs:
             cat .github/prompts/adversarial-review-prompt.md
           } > /tmp/adversarial-prompt.txt
 
-          # Pipe prompt via stdin -- letta -p with no arg reads from stdin
-          RESULT=$(cat /tmp/adversarial-prompt.txt | letta \
-            -a "${{ secrets.ADVERSARIAL_REVIEWER_AGENT_ID }}" \
-            --new \
-            --yolo \
-            --output-format json \
-            -p 2>&1) || true
+          # Pipe prompt via stdin with retry -- transient Letta Cloud errors are common
+          MAX_ATTEMPTS=3
+          ATTEMPT=0
+          RESULT=""
+          while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
+            ATTEMPT=$((ATTEMPT + 1))
+            echo "Attempt $ATTEMPT of $MAX_ATTEMPTS..."
+            RESULT=$(cat /tmp/adversarial-prompt.txt | letta \
+              -a "${{ secrets.ADVERSARIAL_REVIEWER_AGENT_ID }}" \
+              --new \
+              --yolo \
+              --output-format json \
+              -p 2>&1) || true
+            # Break early if we got a verdict
+            if echo "$RESULT" | grep -q 'ADVERSARIAL_VERDICT'; then
+              echo "Got verdict on attempt $ATTEMPT"
+              break
+            fi
+            if [ $ATTEMPT -lt $MAX_ATTEMPTS ]; then
+              echo "No verdict on attempt $ATTEMPT, retrying in 15s..."
+              sleep 15
+            fi
+          done
 
           echo "$RESULT" > /tmp/review-result.json
 
@@ -154,7 +170,8 @@ jobs:
           echo "::error::Adversarial review found violations. See PR comment for details."
           exit 1
 
-      - name: Warn on unknown verdict
+      - name: Fail on unknown verdict
         if: steps.review.outputs.verdict == 'UNKNOWN'
         run: |
-          echo "::warning::Adversarial reviewer did not return a parseable verdict. Investigate the review comment."
+          echo "::error::Adversarial reviewer did not return a parseable verdict (agent error or transient failure). Check the review comment and re-run."
+          exit 1

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -12,6 +12,19 @@ case "$branch" in
     ;;
 esac
 
-# Block force pushes (check for --force or -f in the push command)
-# Git passes the remote and URL as arguments
-# We can't easily detect --force here, but we block the dangerous branches above
+# Skip automated branches
+case "$branch" in
+  dependabot/*|renovate/*)
+    exit 0
+    ;;
+esac
+
+# Require a valid PR description before pushing
+echo "Validating PR description for branch '$branch'..."
+if ! pnpm validate:pr --branch "$branch"; then
+  echo ""
+  echo "BLOCKED: Fix the PR description above before pushing."
+  echo "  Create or update: prs/$(echo "$branch" | sed 's|/|-|g').json"
+  echo ""
+  exit 1
+fi

--- a/prs/fix-adversarial-review-retry.json
+++ b/prs/fix-adversarial-review-retry.json
@@ -1,0 +1,15 @@
+{
+  "branch": "fix/adversarial-review-retry",
+  "title": "fix(ci): retry on transient Letta errors, block on UNKNOWN verdict",
+  "summary": "Two fixes to the adversarial review workflow: (1) wrap the Letta CLI call in a retry loop (up to 3 attempts, 15s between) so transient 'Failed to send message' errors don't produce a false green; (2) treat UNKNOWN verdict as a hard block (exit 1) rather than a warning.",
+  "adrs": ["ADR-020"],
+  "claims": [
+    {
+      "id": "c1",
+      "adr_claim_id": "c2",
+      "statement": "The adversarial-review.yml workflow retries the Letta CLI up to 3 times on transient failure and blocks merge on both FAIL and UNKNOWN verdicts",
+      "evidence_type": "implementation",
+      "evidence_path": ".github/workflows/adversarial-review.yml"
+    }
+  ]
+}


### PR DESCRIPTION

---

### Updated 2026-04-02T21:07:48.010Z

## Summary

Two fixes to the adversarial review workflow: (1) wrap the Letta CLI call in a retry loop (up to 3 attempts, 15s between) so transient 'Failed to send message' errors don't produce a false green; (2) treat UNKNOWN verdict as a hard block (exit 1) rather than a warning.

## ADRs

- ADR-020

## Claims

| ID | Statement | Evidence |
|---|---|---|
| `c1` | The adversarial-review.yml workflow retries the Letta CLI up to 3 times on transient failure and blocks merge on both FAIL and UNKNOWN verdicts | implementation: `.github/workflows/adversarial-review.yml` |

---
_Generated from [`prs/fix-adversarial-review-retry.json`](../../blob/7bc48c8d07f29468821afaf8f4349d1a59897a54/prs/fix-adversarial-review-retry.json)_
---

### Updated 2026-04-02T21:09:09.500Z

## Summary

Two fixes to the adversarial review workflow: (1) wrap the Letta CLI call in a retry loop (up to 3 attempts, 15s between) so transient 'Failed to send message' errors don't produce a false green; (2) treat UNKNOWN verdict as a hard block (exit 1) rather than a warning.

## ADRs

- ADR-020

## Claims

| ID | Statement | Evidence |
|---|---|---|
| `c1` | The adversarial-review.yml workflow retries the Letta CLI up to 3 times on transient failure and blocks merge on both FAIL and UNKNOWN verdicts | implementation: `.github/workflows/adversarial-review.yml` |

---
_Generated from [`prs/fix-adversarial-review-retry.json`](../../blob/51afaae40937ed72f808d9f397ab9679b1d41367/prs/fix-adversarial-review-retry.json)_