### PR TITLE
feat: Supabase intelligence pipeline + parallel branch workers

### DIFF
--- a/.specs/SPEC-BRANCH-WORKERS.md
+++ b/.specs/SPEC-BRANCH-WORKERS.md
@@ -1,0 +1,201 @@
+# SPEC: Parallel Branch Workers via MCP Lite Edge Functions
+
+**Status**: Draft
+**Thoughtbox Session**: `9efd0294-ca85-46a9-b78f-b0fd17e3c2c5` (38 thoughts)
+**Date**: 2026-04-08
+
+## Problem
+
+The ThoughtHandler is a singleton with mutable in-memory state (`thoughtHistory`, `branches`, `currentSessionId`). Two concurrent agents writing to different branches race on this shared state. Parallel branch exploration — the most valuable use case for branching — is unsafe.
+
+## Solution
+
+Stateless MCP Lite edge function workers on Supabase, scoped to a single branch. Each worker writes directly to Postgres with branch-scoped numbering. No shared state, no concurrency hazard.
+
+## Architecture
+
+```
+┌─────────────────────────┐
+│  Parent Agent            │
+│  (orchestrator)          │
+├─────────────────────────┤
+│  Main Thoughtbox MCP     │  ← Cloud Run (unchanged)
+│  tb.branch.spawn()       │  ← Returns edge function URLs
+│  tb.branch.merge()       │  ← Records synthesis, updates statuses
+├─────────────────────────┤
+│        ┌──────────┐ ┌──────────┐ ┌──────────┐
+│        │ Subagent │ │ Subagent │ │ Subagent │
+│        │    A     │ │    B     │ │    C     │
+│        └────┬─────┘ └────┬─────┘ └────┬─────┘
+│             │            │            │
+│        ┌────▼─────┐ ┌────▼─────┐ ┌────▼─────┐
+│        │tb-branch │ │tb-branch │ │tb-branch │  ← Supabase Edge Functions
+│        │branch=a  │ │branch=b  │ │branch=c  │     (same function, different params)
+│        └────┬─────┘ └────┬─────┘ └────┬─────┘
+│             │            │            │
+│        ┌────▼────────────▼────────────▼─────┐
+│        │         Supabase Postgres           │  ← thoughts table, branches table
+│        │  triggers · pgmq · realtime         │  ← reactive intelligence
+│        └─────────────────────────────────────┘
+```
+
+## Components
+
+### 1. Supabase Edge Function: `tb-branch`
+
+Thin MCP Lite server. ~100 lines. Deployed once, parameterized per invocation.
+
+**Tools:**
+- `branch_thought` — write a thought to this branch (branch-scoped numbering)
+- `branch_status` — read this branch's metadata (thought count, status)
+- `branch_read` — read this branch's thoughts
+
+**Auth:** HMAC-signed URL token. Main MCP signs `{ session_id, branch_id, workspace_id, branch_from_thought, expires_at }` using `SUPABASE_SERVICE_ROLE_KEY`. Edge function verifies signature, extracts context.
+
+**DB access:** `supabase-js` with `SUPABASE_SERVICE_ROLE_KEY` (auto-available in edge functions).
+
+**Numbering:** Branch-local counter starting at 1. On cold start, queries `MAX(thought_number)` for the branch from Postgres.
+
+**Branch completion:** When `nextThoughtNeeded: false`, a Postgres trigger (`auto_complete_branch`) sets the branch status to `completed`.
+
+### 2. Main MCP Branch Module
+
+New `branch` module on Cloud Run. ~150 lines.
+
+**Operations:**
+
+| Operation | Input | Output | Effect |
+|-----------|-------|--------|--------|
+| `branch_spawn` | `sessionId, branchId, description, branchFromThought` | `{ branchId, workerUrl, status }` | Creates branch record, returns signed edge function URL |
+| `branch_merge` | `sessionId, synthesis, selectedBranchId?, resolution` | `{ mergeThoughtNumber, updatedBranches }` | Records main-track synthesis thought, updates branch statuses |
+| `branch_list` | `sessionId` | `{ branches: BranchMetadata[] }` | Lists all branches with status, thought count |
+| `branch_get` | `sessionId, branchId` | `{ branch, thoughts }` | Returns branch metadata + all thoughts |
+
+`resolution` values: `selected` (one branch wins), `synthesized` (combined insights), `abandoned` (none useful).
+
+### 3. Schema: `branches` Table
+
+```sql
+CREATE TABLE branches (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  session_id uuid NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+  workspace_id uuid NOT NULL REFERENCES workspaces(id),
+  branch_id text NOT NULL,
+  description text,
+  branch_from_thought integer NOT NULL,
+  status text NOT NULL DEFAULT 'active'
+    CHECK (status IN ('active','completed','merged','rejected','abandoned')),
+  spawned_at timestamptz NOT NULL DEFAULT now(),
+  completed_at timestamptz,
+  merge_thought_number integer,
+  created_by text,
+  UNIQUE(session_id, branch_id)
+);
+
+CREATE INDEX idx_branches_session ON branches(session_id);
+ALTER TABLE branches ENABLE ROW LEVEL SECURITY;
+ALTER PUBLICATION supabase_realtime ADD TABLE branches;
+```
+
+### 4. Schema: Thought Numbering Indexes
+
+Enforce branch-scoped uniqueness:
+
+```sql
+-- Main track: unique per session
+CREATE UNIQUE INDEX thoughts_main_track_unique
+  ON thoughts(session_id, thought_number)
+  WHERE branch_id IS NULL;
+
+-- Per branch: unique per session + branch
+CREATE UNIQUE INDEX thoughts_branch_unique
+  ON thoughts(session_id, branch_id, thought_number)
+  WHERE branch_id IS NOT NULL;
+```
+
+### 5. Postgres Trigger: Auto-Complete Branch
+
+```sql
+CREATE OR REPLACE FUNCTION auto_complete_branch()
+RETURNS trigger AS $$
+BEGIN
+  IF NEW.branch_id IS NOT NULL AND NEW.next_thought_needed = false THEN
+    UPDATE branches
+    SET status = 'completed', completed_at = now()
+    WHERE session_id = NEW.session_id
+      AND branch_id = NEW.branch_id
+      AND status = 'active';
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_auto_complete_branch
+  AFTER INSERT ON thoughts
+  FOR EACH ROW
+  EXECUTE FUNCTION auto_complete_branch();
+```
+
+## Agent Flow
+
+```
+1. Agent calls tb.branch.spawn({ sessionId, branchId: "approach-a", ... })
+   → Returns workerUrl: https://<ref>.supabase.co/functions/v1/tb-branch/mcp?token=<signed>
+
+2. Agent spawns subagent with:
+   - Branch worker MCP (workerUrl) for writing thoughts
+   - Main Thoughtbox MCP for reading knowledge graph, sessions, resources
+
+3. Subagent explores independently:
+   - Calls branch_thought() to record reasoning
+   - Reads knowledge graph via main MCP
+   - Finishes with nextThoughtNeeded: false
+
+4. Postgres trigger auto-completes branch status
+
+5. Parent agent collects all subagent results, calls:
+   tb.branch.merge({ sessionId, synthesis: "After exploring all three...",
+     selectedBranchId: "approach-a", resolution: "selected" })
+```
+
+## What We Don't Touch
+
+- `ThoughtHandler` — the singleton stays as-is for main-track thoughts
+- Existing session/knowledge/protocol/notebook operations
+- Cloud Run service configuration
+- Existing inline branching via `tb.thought({ branchFromThought, branchId })` — still works for sequential branching
+
+## Integration with Existing System
+
+- `session.get()` already calls `getAllThoughts()` and groups by branch — no change needed
+- `session.analyze()` — minor fix: query branches table for branch count instead of in-memory state
+- `session.export()` — branch sections render with scoped numbering
+- Knowledge graph — branch thoughts can create entities same as main thoughts
+- Observability — edge function writes land in same Supabase tables, visible to any Supabase-side intelligence
+
+## Future Extensions
+
+The edge function pattern extends beyond branching:
+- **tb-eval** — evaluation workers scoring thought chains
+- **tb-extract** — knowledge extraction from completed sessions
+- **tb-notebook** — data analysis notebooks with direct Postgres access
+
+Each is a thin, stateless, data-local MCP worker deployed as a Supabase Edge Function.
+
+## Implementation Units
+
+| Unit | Scope | ~Lines | Depends On |
+|------|-------|--------|------------|
+| 1. branches table migration | SQL | 40 | — |
+| 2. tb-branch edge function | Deno/TypeScript | 100 | Unit 1 |
+| 3. branch module (main MCP) | TypeScript | 150 | Unit 1 |
+| 4. SDK types update | TypeScript | 20 | Unit 3 |
+| 5. execute-tool wiring | TypeScript | 15 | Unit 3 |
+| 6. catalog registration | TypeScript | 30 | Unit 3 |
+| 7. session.analyze() fix | TypeScript | 5 | Unit 1 |
+
+## Open Questions
+
+1. **V1 auth**: HMAC-signed tokens or simpler API-key-in-URL for first iteration?
+2. **Thought budget**: Enforce max thoughts per branch in edge function, or leave to agent?
+3. **Merge thought type**: New `synthesis` thoughtType, or use existing `reasoning`?

--- a/src/__tests__/branch-workers.test.ts
+++ b/src/__tests__/branch-workers.test.ts
@@ -1,0 +1,301 @@
+import { createHmac, randomUUID } from 'node:crypto';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { BranchHandlers } from '../branch/handlers.js';
+import {
+  createServiceClient,
+  ensureTestWorkspace,
+  isSupabaseAvailable,
+  SUPABASE_TEST_SERVICE_ROLE_KEY,
+  SUPABASE_TEST_URL,
+  TEST_WORKSPACE_ID,
+} from './supabase-test-helpers.js';
+
+type BranchTokenPayload = {
+  session_id: string;
+  branch_id: string;
+  workspace_id: string;
+  branch_from_thought: number;
+  expires_at: string;
+};
+
+function signBranchToken(payload: BranchTokenPayload): string {
+  const encodedPayload = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  const signature = createHmac('sha256', SUPABASE_TEST_SERVICE_ROLE_KEY)
+    .update(encodedPayload)
+    .digest('base64url');
+  return `${encodedPayload}.${signature}`;
+}
+
+async function createSession(title: string): Promise<string> {
+  const client = createServiceClient();
+  const { data, error } = await client
+    .from('sessions')
+    .insert({
+      workspace_id: TEST_WORKSPACE_ID,
+      title,
+      status: 'active',
+      thought_count: 0,
+      branch_count: 0,
+    })
+    .select('id')
+    .single();
+
+  expect(error).toBeNull();
+  return data!.id;
+}
+
+async function insertMainThought(sessionId: string): Promise<void> {
+  const client = createServiceClient();
+  const { error } = await client.from('thoughts').insert({
+    session_id: sessionId,
+    workspace_id: TEST_WORKSPACE_ID,
+    thought_number: 1,
+    thought: 'Initial main-track thought',
+    total_thoughts: 1,
+    next_thought_needed: true,
+    thought_type: 'reasoning',
+  });
+
+  expect(error).toBeNull();
+}
+
+describe('Branch workers', () => {
+  let available = false;
+
+  beforeAll(async () => {
+    available = await isSupabaseAvailable();
+    if (available) {
+      await ensureTestWorkspace();
+    }
+  });
+
+  it('handleMerge records synthesis thoughts with the session workspace_id', async () => {
+    if (!available) return expect(true).toBe(true);
+
+    const client = createServiceClient();
+    const sessionId = await createSession(`merge-${randomUUID()}`);
+    await insertMainThought(sessionId);
+
+    const { error: branchInsertError } = await client.from('branches').insert([
+      {
+        session_id: sessionId,
+        workspace_id: TEST_WORKSPACE_ID,
+        branch_id: 'branch-a',
+        description: 'Explore option A',
+        branch_from_thought: 1,
+        status: 'completed',
+      },
+      {
+        session_id: sessionId,
+        workspace_id: TEST_WORKSPACE_ID,
+        branch_id: 'branch-b',
+        description: 'Explore option B',
+        branch_from_thought: 1,
+        status: 'completed',
+      },
+    ]);
+    expect(branchInsertError).toBeNull();
+
+    const handlers = new BranchHandlers({
+      supabaseUrl: SUPABASE_TEST_URL,
+      serviceRoleKey: SUPABASE_TEST_SERVICE_ROLE_KEY,
+      workspaceId: TEST_WORKSPACE_ID,
+    });
+
+    const result = await handlers.handleMerge({
+      sessionId,
+      synthesis: 'Branch A is the best resolution.',
+      selectedBranchId: 'branch-a',
+      resolution: 'selected',
+    });
+
+    expect(result.mergeThoughtNumber).toBe(2);
+    expect(result.updatedBranches).toEqual([
+      { branchId: 'branch-a', status: 'merged' },
+      { branchId: 'branch-b', status: 'rejected' },
+    ]);
+
+    const { data: mergeThought, error: mergeThoughtError } = await client
+      .from('thoughts')
+      .select('workspace_id, thought, branch_id')
+      .eq('session_id', sessionId)
+      .eq('thought_number', 2)
+      .is('branch_id', null)
+      .single();
+
+    expect(mergeThoughtError).toBeNull();
+    expect(mergeThought).toMatchObject({
+      workspace_id: TEST_WORKSPACE_ID,
+      thought: 'Branch A is the best resolution.',
+      branch_id: null,
+    });
+  });
+
+  it('handleList returns branch counts and spawnedAt metadata', async () => {
+    if (!available) return expect(true).toBe(true);
+
+    const client = createServiceClient();
+    const sessionId = await createSession(`list-${randomUUID()}`);
+    await insertMainThought(sessionId);
+
+    const { error: branchInsertError } = await client.from('branches').insert([
+      {
+        session_id: sessionId,
+        workspace_id: TEST_WORKSPACE_ID,
+        branch_id: 'branch-a',
+        description: 'Explore option A',
+        branch_from_thought: 1,
+        status: 'active',
+      },
+      {
+        session_id: sessionId,
+        workspace_id: TEST_WORKSPACE_ID,
+        branch_id: 'branch-b',
+        description: 'Explore option B',
+        branch_from_thought: 1,
+        status: 'completed',
+      },
+    ]);
+    expect(branchInsertError).toBeNull();
+
+    const { error: thoughtInsertError } = await client.from('thoughts').insert([
+      {
+        session_id: sessionId,
+        workspace_id: TEST_WORKSPACE_ID,
+        branch_id: 'branch-a',
+        branch_from_thought: 1,
+        thought_number: 1,
+        thought: 'Branch A thought 1',
+        total_thoughts: 2,
+        next_thought_needed: true,
+        thought_type: 'reasoning',
+      },
+      {
+        session_id: sessionId,
+        workspace_id: TEST_WORKSPACE_ID,
+        branch_id: 'branch-a',
+        branch_from_thought: 1,
+        thought_number: 2,
+        thought: 'Branch A thought 2',
+        total_thoughts: 2,
+        next_thought_needed: false,
+        thought_type: 'reasoning',
+      },
+      {
+        session_id: sessionId,
+        workspace_id: TEST_WORKSPACE_ID,
+        branch_id: 'branch-b',
+        branch_from_thought: 1,
+        thought_number: 1,
+        thought: 'Branch B thought 1',
+        total_thoughts: 1,
+        next_thought_needed: false,
+        thought_type: 'reasoning',
+      },
+    ]);
+    expect(thoughtInsertError).toBeNull();
+
+    const handlers = new BranchHandlers({
+      supabaseUrl: SUPABASE_TEST_URL,
+      serviceRoleKey: SUPABASE_TEST_SERVICE_ROLE_KEY,
+      workspaceId: TEST_WORKSPACE_ID,
+    });
+
+    const result = await handlers.handleList({ sessionId });
+    const counts = Object.fromEntries(
+      result.branches.map((branch) => [branch.branchId, branch.thoughtCount]),
+    );
+
+    expect(result.branches).toHaveLength(2);
+    expect(counts).toEqual({
+      'branch-a': 2,
+      'branch-b': 1,
+    });
+    expect(result.branches.every((branch) => typeof branch.spawnedAt === 'string')).toBe(true);
+  });
+
+  it('tb-branch rejects requests without a signed token', async () => {
+    if (!available) return expect(true).toBe(true);
+
+    const response = await fetch(`${SUPABASE_TEST_URL}/functions/v1/tb-branch/mcp`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 'missing-token',
+        method: 'tools/list',
+      }),
+    });
+
+    expect(response.status).toBe(401);
+  });
+
+  it('tb-branch accepts a valid signed token for concurrent branch thoughts', async () => {
+    if (!available) return expect(true).toBe(true);
+
+    const client = createServiceClient();
+    const sessionId = await createSession(`worker-${randomUUID()}`);
+    await insertMainThought(sessionId);
+
+    const { error: branchInsertError } = await client.from('branches').insert({
+      session_id: sessionId,
+      workspace_id: TEST_WORKSPACE_ID,
+      branch_id: 'parallel-worker',
+      description: 'Concurrent branch worker test',
+      branch_from_thought: 1,
+      status: 'active',
+    });
+    expect(branchInsertError).toBeNull();
+
+    const token = signBranchToken({
+      session_id: sessionId,
+      branch_id: 'parallel-worker',
+      workspace_id: TEST_WORKSPACE_ID,
+      branch_from_thought: 1,
+      expires_at: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    const endpoint =
+      `${SUPABASE_TEST_URL}/functions/v1/tb-branch/mcp` +
+      `?token=${encodeURIComponent(token)}`;
+
+    const responses = await Promise.all(
+      Array.from({ length: 5 }, (_, index) =>
+        fetch(endpoint, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            jsonrpc: '2.0',
+            id: `parallel-${index}`,
+            method: 'tools/call',
+            params: {
+              name: 'branch_thought',
+              arguments: {
+                thought: `Parallel branch thought ${index + 1}`,
+                thoughtType: 'reasoning',
+                nextThoughtNeeded: index < 4,
+              },
+            },
+          }),
+        }),
+      ),
+    );
+
+    const bodies = await Promise.all(responses.map((response) => response.json()));
+    const errors = bodies.filter((body) => body.error);
+
+    expect(responses.every((response) => response.ok)).toBe(true);
+    expect(errors).toEqual([]);
+
+    const { data: thoughts, error: thoughtQueryError } = await client
+      .from('thoughts')
+      .select('thought_number')
+      .eq('session_id', sessionId)
+      .eq('branch_id', 'parallel-worker')
+      .order('thought_number', { ascending: true });
+
+    expect(thoughtQueryError).toBeNull();
+    expect(thoughts?.map((thought) => thought.thought_number)).toEqual([1, 2, 3, 4, 5]);
+  });
+});

--- a/src/__tests__/intelligence-pipeline.test.ts
+++ b/src/__tests__/intelligence-pipeline.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Intelligence Pipeline Integration Tests
+ *
+ * Tests the v1 intelligence path: thought INSERT → pgmq trigger → queue worker → archive.
+ * Requires local Supabase running (`supabase start`).
+ */
+
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import {
+  createServiceClient,
+  ensureTestWorkspace,
+  isSupabaseAvailable,
+  TEST_WORKSPACE_ID,
+  SUPABASE_TEST_URL,
+  SUPABASE_TEST_SERVICE_ROLE_KEY,
+} from './supabase-test-helpers.js';
+
+const SKIP_REASON = 'Local Supabase not available';
+
+describe('Intelligence Pipeline', () => {
+  let available: boolean;
+
+  beforeAll(async () => {
+    available = await isSupabaseAvailable();
+    if (available) {
+      await ensureTestWorkspace();
+    }
+  });
+
+  describe('Migration validation', () => {
+    it('thoughts table has embedding column', async () => {
+      if (!available) return expect(true).toBe(true); // skip gracefully
+      const client = createServiceClient();
+      const { data, error } = await client
+        .from('thoughts')
+        .select('embedding')
+        .limit(0);
+      expect(error).toBeNull();
+    });
+
+    it('pgmq thought_processing queue exists', async () => {
+      if (!available) return expect(true).toBe(true);
+      const client = createServiceClient();
+      const { error } = await client.rpc('pgmq_read_queue', {
+        queue_name: 'thought_processing',
+        vt: 0,
+        qty: 0,
+      });
+      expect(error).toBeNull();
+    });
+
+    it('pgmq RPC wrappers are callable by service_role', async () => {
+      if (!available) return expect(true).toBe(true);
+      const client = createServiceClient();
+
+      const { error: readErr } = await client.rpc('pgmq_read_queue', {
+        queue_name: 'thought_processing',
+        vt: 0,
+        qty: 1,
+      });
+      expect(readErr).toBeNull();
+
+      // archive with a non-existent msg_id should return false, not error
+      const { data: archiveResult, error: archErr } = await client.rpc(
+        'pgmq_archive_queue_message',
+        { queue_name: 'thought_processing', msg_id: 999999999 },
+      );
+      expect(archErr).toBeNull();
+      expect(archiveResult).toBe(false);
+    });
+
+    it('enqueue trigger function exists on thoughts table', async () => {
+      if (!available) return expect(true).toBe(true);
+      const client = createServiceClient();
+      const { data, error } = await client.rpc('exec_sql' as never, {
+        sql: `SELECT tgname FROM pg_trigger WHERE tgname = 'trg_thought_insert_enqueue'`,
+      });
+      // If exec_sql doesn't exist, fall back to just verifying insert triggers enqueue
+      if (error) {
+        // The E2E test below will cover this
+        expect(true).toBe(true);
+        return;
+      }
+      expect(data).toHaveLength(1);
+    });
+  });
+
+  describe('Queue processing', () => {
+    let testSessionId: string;
+
+    beforeEach(async () => {
+      if (!available) return;
+      const client = createServiceClient();
+      // Create a fresh session for each test
+      const { data, error } = await client
+        .from('sessions')
+        .insert({
+          workspace_id: TEST_WORKSPACE_ID,
+          title: 'Intelligence Pipeline Test',
+          status: 'active',
+          thought_count: 0,
+          branch_count: 0,
+        })
+        .select('id')
+        .single();
+      expect(error).toBeNull();
+      testSessionId = data!.id;
+    });
+
+    it('thought insert enqueues to thought_processing', async () => {
+      if (!available) return expect(true).toBe(true);
+      const client = createServiceClient();
+
+      // Insert a thought — trigger should enqueue
+      const { data: thought, error: insertErr } = await client
+        .from('thoughts')
+        .insert({
+          session_id: testSessionId,
+          workspace_id: TEST_WORKSPACE_ID,
+          thought_number: 1,
+          thought: 'Test thought for queue enqueue verification',
+          total_thoughts: 1,
+          next_thought_needed: false,
+          thought_type: 'reasoning',
+        })
+        .select('id')
+        .single();
+      expect(insertErr).toBeNull();
+
+      // Read from queue — should find our message
+      const { data: messages, error: readErr } = await client.rpc(
+        'pgmq_read_queue',
+        { queue_name: 'thought_processing', vt: 0, qty: 10 },
+      );
+      expect(readErr).toBeNull();
+
+      const found = (messages as Array<{ message: { thought_id: string } }>).find(
+        (m) => m.message.thought_id === thought!.id,
+      );
+      expect(found).toBeDefined();
+
+      // Clean up: archive the message
+      if (found) {
+        await client.rpc('pgmq_archive_queue_message', {
+          queue_name: 'thought_processing',
+          msg_id: (found as { msg_id: number }).msg_id,
+        });
+      }
+    });
+
+    it('queue worker processes thought and archives message', async () => {
+      if (!available) return expect(true).toBe(true);
+      const client = createServiceClient();
+
+      // Insert thought
+      const { data: thought } = await client
+        .from('thoughts')
+        .insert({
+          session_id: testSessionId,
+          workspace_id: TEST_WORKSPACE_ID,
+          thought_number: 1,
+          thought: 'Test thought for worker processing',
+          total_thoughts: 1,
+          next_thought_needed: false,
+          thought_type: 'reasoning',
+        })
+        .select('id')
+        .single();
+
+      // Invoke the queue worker edge function
+      const workerUrl = `${SUPABASE_TEST_URL}/functions/v1/process-thought-queue`;
+      const response = await fetch(workerUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${SUPABASE_TEST_SERVICE_ROLE_KEY}`,
+        },
+        body: JSON.stringify({ source: 'test' }),
+      });
+
+      expect(response.ok).toBe(true);
+      const result = await response.json();
+      expect(result.read).toBeGreaterThanOrEqual(1);
+
+      // Find our message in the results
+      const processed = result.results.find(
+        (r: { ok: boolean }) => r.ok === true,
+      );
+      expect(processed).toBeDefined();
+
+      // Verify queue is drained for our message
+      const { data: remaining } = await client.rpc('pgmq_read_queue', {
+        queue_name: 'thought_processing',
+        vt: 0,
+        qty: 100,
+      });
+      const stillQueued = (
+        remaining as Array<{ message: { thought_id: string } }>
+      ).find((m) => m.message.thought_id === thought!.id);
+      expect(stillQueued).toBeUndefined();
+    });
+  });
+});

--- a/src/branch/__tests__/handlers.test.ts
+++ b/src/branch/__tests__/handlers.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+
+import { BranchHandlers } from '../handlers.js';
+
+function createHandlerWithFakeClient(fakeClient: unknown): BranchHandlers {
+  const handler = new BranchHandlers({
+    supabaseUrl: 'http://127.0.0.1:54321',
+    serviceRoleKey: 'service-role-key',
+    workspaceId: '11111111-1111-1111-1111-111111111111',
+  });
+
+  (handler as unknown as { client: unknown }).client = fakeClient;
+  return handler;
+}
+
+describe('BranchHandlers.handleMerge', () => {
+  it('throws when a branch status update fails', async () => {
+    const fakeClient = {
+      from(table: string) {
+        if (table === 'branches') {
+          return {
+            select() {
+              return {
+                eq: async () => ({
+                  data: [{ branch_id: 'branch-a', status: 'completed' }],
+                  error: null,
+                }),
+              };
+            },
+            update() {
+              let eqCalls = 0;
+              return {
+                eq() {
+                  eqCalls += 1;
+                  if (eqCalls < 2) return this;
+                  return Promise.resolve({
+                    error: { message: 'write failed' },
+                  });
+                },
+              };
+            },
+          };
+        }
+
+        if (table === 'thoughts') {
+          return {
+            select() {
+              return {
+                eq() {
+                  return this;
+                },
+                is() {
+                  return this;
+                },
+                order() {
+                  return this;
+                },
+                limit() {
+                  return this;
+                },
+                single: async () => ({
+                  data: { thought_number: 1 },
+                }),
+              };
+            },
+            insert: async () => ({ error: null }),
+          };
+        }
+
+        if (table === 'sessions') {
+          return {
+            select() {
+              return {
+                eq() {
+                  return this;
+                },
+                single: async () => ({
+                  data: { id: 'session-1', workspace_id: '11111111-1111-1111-1111-111111111111' },
+                  error: null,
+                }),
+              };
+            },
+          };
+        }
+
+        throw new Error(`Unexpected table: ${table}`);
+      },
+    };
+
+    const handler = createHandlerWithFakeClient(fakeClient);
+
+    await expect(
+      handler.handleMerge({
+        sessionId: 'session-1',
+        synthesis: 'Synthesis thought',
+        selectedBranchId: 'branch-a',
+        resolution: 'selected',
+      }),
+    ).rejects.toThrow('Failed to update branch branch-a: write failed');
+  });
+});

--- a/src/branch/handlers.ts
+++ b/src/branch/handlers.ts
@@ -134,10 +134,11 @@ export class BranchHandlers {
     const { data: branches, error: brErr } = await this.client
       .from("branches")
       .select("branch_id, status")
-      .eq("session_id", sessionId);
+      .eq("session_id", sessionId)
+      .in("status", ["active", "completed"]);
 
     if (brErr || !branches?.length) {
-      throw new Error(`No branches found for session ${sessionId}`);
+      throw new Error(`No resolvable branches for session ${sessionId}`);
     }
 
     const mergeThoughtNumber = await this.insertMainTrackThought(
@@ -250,33 +251,39 @@ export class BranchHandlers {
     workspaceId: string,
     synthesis: string
   ): Promise<number> {
-    const { data: maxRow } = await this.client
-      .from("thoughts")
-      .select("thought_number")
-      .eq("session_id", sessionId)
-      .is("branch_id", null)
-      .order("thought_number", { ascending: false })
-      .limit(1)
-      .single();
+    const maxAttempts = 5;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      const { data: maxRow } = await this.client
+        .from("thoughts")
+        .select("thought_number")
+        .eq("session_id", sessionId)
+        .is("branch_id", null)
+        .order("thought_number", { ascending: false })
+        .limit(1)
+        .single();
 
-    const nextNumber = ((maxRow?.thought_number as number) ?? 0) + 1;
+      const nextNumber = ((maxRow?.thought_number as number) ?? 0) + 1;
 
-    const { error } = await this.client.from("thoughts").insert({
-      session_id: sessionId,
-      workspace_id: workspaceId,
-      thought_number: nextNumber,
-      thought: synthesis,
-      thought_type: "reasoning",
-      branch_id: null,
-      next_thought_needed: false,
-      total_thoughts: nextNumber,
-    });
+      const { error } = await this.client.from("thoughts").insert({
+        session_id: sessionId,
+        workspace_id: workspaceId,
+        thought_number: nextNumber,
+        thought: synthesis,
+        thought_type: "reasoning",
+        branch_id: null,
+        next_thought_needed: false,
+        total_thoughts: nextNumber,
+      });
 
-    if (error) {
-      throw new Error(`Failed to insert merge thought: ${error.message}`);
+      if (!error) return nextNumber;
+      if (!error.message.includes("thoughts_main_track_unique")) {
+        throw new Error(`Failed to insert merge thought: ${error.message}`);
+      }
+      // Unique constraint conflict — retry with fresh MAX
     }
-
-    return nextNumber;
+    throw new Error(
+      `Failed to insert merge thought after ${maxAttempts} attempts`
+    );
   }
 
   /**

--- a/src/branch/handlers.ts
+++ b/src/branch/handlers.ts
@@ -5,7 +5,30 @@
  * Uses Supabase client directly (service_role, no session persistence).
  */
 
+import { createHmac } from "node:crypto";
+
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+const BRANCH_WORKER_TOKEN_TTL_MS = 60 * 60 * 1000;
+
+type BranchWorkerTokenPayload = {
+  session_id: string;
+  branch_id: string;
+  workspace_id: string;
+  branch_from_thought: number;
+  expires_at: string;
+};
+
+function encodeBranchWorkerToken(
+  payload: BranchWorkerTokenPayload,
+  secret: string
+): string {
+  const encodedPayload = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  const signature = createHmac("sha256", secret)
+    .update(encodedPayload)
+    .digest("base64url");
+  return `${encodedPayload}.${signature}`;
+}
 
 export interface BranchHandlerDeps {
   supabaseUrl: string;
@@ -16,9 +39,11 @@ export interface BranchHandlerDeps {
 export class BranchHandlers {
   private client: SupabaseClient;
   private workspaceId: string;
+  private serviceRoleKey: string;
 
   constructor(deps: BranchHandlerDeps) {
     this.workspaceId = deps.workspaceId;
+    this.serviceRoleKey = deps.serviceRoleKey;
     this.client = createClient(deps.supabaseUrl, deps.serviceRoleKey, {
       auth: { persistSession: false, autoRefreshToken: false },
     });
@@ -77,12 +102,19 @@ export class BranchHandlers {
     }
 
     const supabaseUrl = process.env.SUPABASE_URL ?? "";
+    const token = encodeBranchWorkerToken(
+      {
+        session_id: sessionId,
+        branch_id: branchId,
+        workspace_id: workspaceId,
+        branch_from_thought: branchFromThought,
+        expires_at: new Date(Date.now() + BRANCH_WORKER_TOKEN_TTL_MS).toISOString(),
+      },
+      this.serviceRoleKey
+    );
     const workerUrl =
       `${supabaseUrl}/functions/v1/tb-branch/mcp` +
-      `?session_id=${sessionId}` +
-      `&branch_id=${branchId}` +
-      `&workspace_id=${workspaceId}` +
-      `&branch_from=${branchFromThought}`;
+      `?token=${encodeURIComponent(token)}`;
 
     return { branchId, workerUrl, status: "active", sessionId };
   }
@@ -97,6 +129,7 @@ export class BranchHandlers {
     updatedBranches: Array<{ branchId: string; status: string }>;
   }> {
     const { sessionId, synthesis, selectedBranchId, resolution } = args;
+    const workspaceId = await this.getSessionWorkspaceId(sessionId);
 
     const { data: branches, error: brErr } = await this.client
       .from("branches")
@@ -108,7 +141,7 @@ export class BranchHandlers {
     }
 
     const mergeThoughtNumber = await this.insertMainTrackThought(
-      sessionId, synthesis
+      sessionId, workspaceId, synthesis
     );
 
     const updatedBranches = await this.resolveBranches(
@@ -131,33 +164,46 @@ export class BranchHandlers {
   }> {
     const { data: branches, error } = await this.client
       .from("branches")
-      .select("branch_id, description, status, branch_from_thought, created_at, completed_at")
+      .select("branch_id, description, status, branch_from_thought, spawned_at, completed_at")
       .eq("session_id", args.sessionId)
-      .order("created_at", { ascending: true });
+      .order("spawned_at", { ascending: true });
 
     if (error) {
       throw new Error(`Failed to list branches: ${error.message}`);
     }
 
-    const result = await Promise.all(
-      (branches ?? []).map(async (b) => {
-        const { count } = await this.client
-          .from("thoughts")
-          .select("id", { count: "exact", head: true })
-          .eq("session_id", args.sessionId)
-          .eq("branch_id", b.branch_id);
+    const branchIds = (branches ?? [])
+      .map((branch) => branch.branch_id as string | null)
+      .filter((branchId): branchId is string => branchId !== null);
+    const thoughtCounts = new Map<string, number>();
 
-        return {
-          branchId: b.branch_id as string,
-          description: b.description as string | null,
-          status: b.status as string,
-          thoughtCount: count ?? 0,
-          branchFromThought: b.branch_from_thought as number,
-          spawnedAt: b.created_at as string,
-          completedAt: b.completed_at as string | null,
-        };
-      })
-    );
+    if (branchIds.length > 0) {
+      const { data: branchThoughts, error: thoughtError } = await this.client
+        .from("thoughts")
+        .select("branch_id")
+        .eq("session_id", args.sessionId)
+        .in("branch_id", branchIds);
+
+      if (thoughtError) {
+        throw new Error(`Failed to list branch thoughts: ${thoughtError.message}`);
+      }
+
+      for (const thought of branchThoughts ?? []) {
+        const branchId = thought.branch_id as string | null;
+        if (!branchId) continue;
+        thoughtCounts.set(branchId, (thoughtCounts.get(branchId) ?? 0) + 1);
+      }
+    }
+
+    const result = (branches ?? []).map((b) => ({
+      branchId: b.branch_id as string,
+      description: b.description as string | null,
+      status: b.status as string,
+      thoughtCount: thoughtCounts.get(b.branch_id as string) ?? 0,
+      branchFromThought: b.branch_from_thought as number,
+      spawnedAt: b.spawned_at as string,
+      completedAt: b.completed_at as string | null,
+    }));
 
     return { branches: result };
   }
@@ -201,6 +247,7 @@ export class BranchHandlers {
    */
   private async insertMainTrackThought(
     sessionId: string,
+    workspaceId: string,
     synthesis: string
   ): Promise<number> {
     const { data: maxRow } = await this.client
@@ -216,6 +263,7 @@ export class BranchHandlers {
 
     const { error } = await this.client.from("thoughts").insert({
       session_id: sessionId,
+      workspace_id: workspaceId,
       thought_number: nextNumber,
       thought: synthesis,
       thought_type: "reasoning",
@@ -263,15 +311,33 @@ export class BranchHandlers {
         updatePayload.merge_thought_number = mergeThoughtNumber;
       }
 
-      await this.client
+      const { error: updateError } = await this.client
         .from("branches")
         .update(updatePayload)
         .eq("session_id", sessionId)
         .eq("branch_id", bid);
 
+      if (updateError) {
+        throw new Error(`Failed to update branch ${bid}: ${updateError.message}`);
+      }
+
       updated.push({ branchId: bid, status: newStatus });
     }
 
     return updated;
+  }
+
+  private async getSessionWorkspaceId(sessionId: string): Promise<string> {
+    const { data: session, error } = await this.client
+      .from("sessions")
+      .select("id, workspace_id")
+      .eq("id", sessionId)
+      .single();
+
+    if (error || !session?.workspace_id) {
+      throw new Error(`Session ${sessionId} not found`);
+    }
+
+    return session.workspace_id as string;
   }
 }

--- a/src/branch/handlers.ts
+++ b/src/branch/handlers.ts
@@ -1,0 +1,277 @@
+/**
+ * Branch Handlers
+ *
+ * Business logic for branch spawn, merge, list, and get operations.
+ * Uses Supabase client directly (service_role, no session persistence).
+ */
+
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+export interface BranchHandlerDeps {
+  supabaseUrl: string;
+  serviceRoleKey: string;
+  workspaceId: string;
+}
+
+export class BranchHandlers {
+  private client: SupabaseClient;
+  private workspaceId: string;
+
+  constructor(deps: BranchHandlerDeps) {
+    this.workspaceId = deps.workspaceId;
+    this.client = createClient(deps.supabaseUrl, deps.serviceRoleKey, {
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
+  }
+
+  async handleSpawn(args: {
+    sessionId: string;
+    branchId: string;
+    description?: string;
+    branchFromThought: number;
+  }): Promise<{
+    branchId: string;
+    workerUrl: string;
+    status: string;
+    sessionId: string;
+  }> {
+    const { sessionId, branchId, description, branchFromThought } = args;
+
+    const { data: session, error: sessErr } = await this.client
+      .from("sessions")
+      .select("id, workspace_id")
+      .eq("id", sessionId)
+      .single();
+
+    if (sessErr || !session) {
+      throw new Error(`Session ${sessionId} not found`);
+    }
+
+    const { data: thought, error: thErr } = await this.client
+      .from("thoughts")
+      .select("id")
+      .eq("session_id", sessionId)
+      .eq("thought_number", branchFromThought)
+      .is("branch_id", null)
+      .single();
+
+    if (thErr || !thought) {
+      throw new Error(
+        `Main-track thought ${branchFromThought} not found in session ${sessionId}`
+      );
+    }
+
+    const workspaceId = session.workspace_id ?? this.workspaceId;
+
+    const { error: insErr } = await this.client.from("branches").insert({
+      session_id: sessionId,
+      workspace_id: workspaceId,
+      branch_id: branchId,
+      description: description ?? null,
+      branch_from_thought: branchFromThought,
+      status: "active",
+    });
+
+    if (insErr) {
+      throw new Error(`Failed to create branch: ${insErr.message}`);
+    }
+
+    const supabaseUrl = process.env.SUPABASE_URL ?? "";
+    const workerUrl =
+      `${supabaseUrl}/functions/v1/tb-branch/mcp` +
+      `?session_id=${sessionId}` +
+      `&branch_id=${branchId}` +
+      `&workspace_id=${workspaceId}` +
+      `&branch_from=${branchFromThought}`;
+
+    return { branchId, workerUrl, status: "active", sessionId };
+  }
+
+  async handleMerge(args: {
+    sessionId: string;
+    synthesis: string;
+    selectedBranchId?: string;
+    resolution: "selected" | "synthesized" | "abandoned";
+  }): Promise<{
+    mergeThoughtNumber: number;
+    updatedBranches: Array<{ branchId: string; status: string }>;
+  }> {
+    const { sessionId, synthesis, selectedBranchId, resolution } = args;
+
+    const { data: branches, error: brErr } = await this.client
+      .from("branches")
+      .select("branch_id, status")
+      .eq("session_id", sessionId);
+
+    if (brErr || !branches?.length) {
+      throw new Error(`No branches found for session ${sessionId}`);
+    }
+
+    const mergeThoughtNumber = await this.insertMainTrackThought(
+      sessionId, synthesis
+    );
+
+    const updatedBranches = await this.resolveBranches(
+      sessionId, branches, resolution, selectedBranchId, mergeThoughtNumber
+    );
+
+    return { mergeThoughtNumber, updatedBranches };
+  }
+
+  async handleList(args: { sessionId: string }): Promise<{
+    branches: Array<{
+      branchId: string;
+      description: string | null;
+      status: string;
+      thoughtCount: number;
+      branchFromThought: number;
+      spawnedAt: string;
+      completedAt: string | null;
+    }>;
+  }> {
+    const { data: branches, error } = await this.client
+      .from("branches")
+      .select("branch_id, description, status, branch_from_thought, created_at, completed_at")
+      .eq("session_id", args.sessionId)
+      .order("created_at", { ascending: true });
+
+    if (error) {
+      throw new Error(`Failed to list branches: ${error.message}`);
+    }
+
+    const result = await Promise.all(
+      (branches ?? []).map(async (b) => {
+        const { count } = await this.client
+          .from("thoughts")
+          .select("id", { count: "exact", head: true })
+          .eq("session_id", args.sessionId)
+          .eq("branch_id", b.branch_id);
+
+        return {
+          branchId: b.branch_id as string,
+          description: b.description as string | null,
+          status: b.status as string,
+          thoughtCount: count ?? 0,
+          branchFromThought: b.branch_from_thought as number,
+          spawnedAt: b.created_at as string,
+          completedAt: b.completed_at as string | null,
+        };
+      })
+    );
+
+    return { branches: result };
+  }
+
+  async handleGet(args: {
+    sessionId: string;
+    branchId: string;
+  }): Promise<{
+    branch: Record<string, unknown>;
+    thoughts: Array<Record<string, unknown>>;
+  }> {
+    const { data: branch, error: brErr } = await this.client
+      .from("branches")
+      .select("*")
+      .eq("session_id", args.sessionId)
+      .eq("branch_id", args.branchId)
+      .single();
+
+    if (brErr || !branch) {
+      throw new Error(
+        `Branch ${args.branchId} not found in session ${args.sessionId}`
+      );
+    }
+
+    const { data: thoughts, error: thErr } = await this.client
+      .from("thoughts")
+      .select("*")
+      .eq("session_id", args.sessionId)
+      .eq("branch_id", args.branchId)
+      .order("thought_number", { ascending: true });
+
+    if (thErr) {
+      throw new Error(`Failed to fetch branch thoughts: ${thErr.message}`);
+    }
+
+    return { branch, thoughts: thoughts ?? [] };
+  }
+
+  /**
+   * Insert a main-track synthesis thought and return its thought_number.
+   */
+  private async insertMainTrackThought(
+    sessionId: string,
+    synthesis: string
+  ): Promise<number> {
+    const { data: maxRow } = await this.client
+      .from("thoughts")
+      .select("thought_number")
+      .eq("session_id", sessionId)
+      .is("branch_id", null)
+      .order("thought_number", { ascending: false })
+      .limit(1)
+      .single();
+
+    const nextNumber = ((maxRow?.thought_number as number) ?? 0) + 1;
+
+    const { error } = await this.client.from("thoughts").insert({
+      session_id: sessionId,
+      thought_number: nextNumber,
+      thought: synthesis,
+      thought_type: "reasoning",
+      branch_id: null,
+      next_thought_needed: false,
+      total_thoughts: nextNumber,
+    });
+
+    if (error) {
+      throw new Error(`Failed to insert merge thought: ${error.message}`);
+    }
+
+    return nextNumber;
+  }
+
+  /**
+   * Update branch statuses based on the chosen resolution strategy.
+   */
+  private async resolveBranches(
+    sessionId: string,
+    branches: Array<{ branch_id: string | null; status: string | null }>,
+    resolution: "selected" | "synthesized" | "abandoned",
+    selectedBranchId: string | undefined,
+    mergeThoughtNumber: number
+  ): Promise<Array<{ branchId: string; status: string }>> {
+    const updated: Array<{ branchId: string; status: string }> = [];
+
+    for (const b of branches) {
+      const bid = b.branch_id as string;
+      let newStatus: string;
+
+      if (resolution === "abandoned") {
+        newStatus = "abandoned";
+      } else if (resolution === "selected") {
+        newStatus = bid === selectedBranchId ? "merged" : "rejected";
+      } else {
+        newStatus = "merged";
+      }
+
+      const updatePayload: Record<string, unknown> = {
+        status: newStatus,
+        completed_at: new Date().toISOString(),
+      };
+      if (newStatus === "merged") {
+        updatePayload.merge_thought_number = mergeThoughtNumber;
+      }
+
+      await this.client
+        .from("branches")
+        .update(updatePayload)
+        .eq("session_id", sessionId)
+        .eq("branch_id", bid);
+
+      updated.push({ branchId: bid, status: newStatus });
+    }
+
+    return updated;
+  }
+}

--- a/src/branch/handlers.ts
+++ b/src/branch/handlers.ts
@@ -9,7 +9,7 @@ import { createHmac } from "node:crypto";
 
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 
-const BRANCH_WORKER_TOKEN_TTL_MS = 60 * 60 * 1000;
+const BRANCH_WORKER_TOKEN_TTL_MS = 4 * 60 * 60 * 1000; // 4 hours
 
 type BranchWorkerTokenPayload = {
   session_id: string;
@@ -38,10 +38,12 @@ export interface BranchHandlerDeps {
 
 export class BranchHandlers {
   private client: SupabaseClient;
+  private supabaseUrl: string;
   private workspaceId: string;
   private serviceRoleKey: string;
 
   constructor(deps: BranchHandlerDeps) {
+    this.supabaseUrl = deps.supabaseUrl;
     this.workspaceId = deps.workspaceId;
     this.serviceRoleKey = deps.serviceRoleKey;
     this.client = createClient(deps.supabaseUrl, deps.serviceRoleKey, {
@@ -101,7 +103,7 @@ export class BranchHandlers {
       throw new Error(`Failed to create branch: ${insErr.message}`);
     }
 
-    const supabaseUrl = process.env.SUPABASE_URL ?? "";
+    const supabaseUrl = this.supabaseUrl;
     const token = encodeBranchWorkerToken(
       {
         session_id: sessionId,

--- a/src/branch/index.ts
+++ b/src/branch/index.ts
@@ -1,0 +1,124 @@
+/**
+ * Branch Toolhost
+ *
+ * MCP toolhost for managing reasoning branches within sessions.
+ * Follows the same pattern as the sessions toolhost.
+ */
+
+import { BranchHandlers, type BranchHandlerDeps } from "./handlers.js";
+import { getOperation } from "./operations.js";
+
+export { BRANCH_TOOL } from "./operations.js";
+export { getOperationNames, getOperationsCatalog } from "./operations.js";
+export type { BranchHandlerDeps } from "./handlers.js";
+
+export class BranchHandler {
+  private handlers: BranchHandlers;
+  private initialized = false;
+
+  constructor(deps: BranchHandlerDeps) {
+    this.handlers = new BranchHandlers(deps);
+  }
+
+  async init(): Promise<void> {
+    if (this.initialized) return;
+    this.initialized = true;
+  }
+
+  async processTool(
+    operation: string,
+    args: Record<string, unknown>
+  ): Promise<{
+    content: Array<
+      | { type: "text"; text: string }
+      | {
+          type: "resource";
+          resource: {
+            uri: string;
+            text: string;
+            mimeType: string;
+            title?: string;
+            annotations?: Record<string, unknown>;
+          };
+        }
+    >;
+    isError: boolean;
+  }> {
+    try {
+      let result: unknown;
+      const opDef = getOperation(`branch_${operation}`);
+
+      switch (operation) {
+        case "spawn":
+          result = await this.handlers.handleSpawn(
+            args as Parameters<BranchHandlers["handleSpawn"]>[0]
+          );
+          break;
+        case "merge":
+          result = await this.handlers.handleMerge(
+            args as Parameters<BranchHandlers["handleMerge"]>[0]
+          );
+          break;
+        case "list":
+          result = await this.handlers.handleList(
+            args as Parameters<BranchHandlers["handleList"]>[0]
+          );
+          break;
+        case "get":
+          result = await this.handlers.handleGet(
+            args as Parameters<BranchHandlers["handleGet"]>[0]
+          );
+          break;
+        default:
+          throw new Error(`Unknown branch operation: ${operation}`);
+      }
+
+      const content: Array<
+        | { type: "text"; text: string }
+        | {
+            type: "resource";
+            resource: {
+              uri: string;
+              text: string;
+              mimeType: string;
+              title?: string;
+              annotations?: Record<string, unknown>;
+            };
+          }
+      > = [{ type: "text", text: JSON.stringify(result, null, 2) }];
+
+      if (opDef) {
+        content.push({
+          type: "resource",
+          resource: {
+            uri: `thoughtbox://branch/operations/${operation}`,
+            title: opDef.title,
+            mimeType: "application/json",
+            text: JSON.stringify(opDef, null, 2),
+            annotations: { audience: ["assistant"], priority: 0.5 },
+          },
+        });
+      }
+
+      return { content, isError: false };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(
+              {
+                success: false,
+                error:
+                  error instanceof Error ? error.message : String(error),
+              },
+              null,
+              2
+            ),
+          },
+        ],
+        isError: true,
+      };
+    }
+  }
+}

--- a/src/branch/operations.ts
+++ b/src/branch/operations.ts
@@ -1,0 +1,202 @@
+/**
+ * Operations Catalog for Branch Toolhost
+ *
+ * Defines all available branch operations with their schemas,
+ * descriptions, categories, and examples.
+ */
+
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+
+export interface OperationDefinition {
+  name: string;
+  title: string;
+  description: string;
+  category: string;
+  inputSchema: Record<string, unknown>;
+  example?: Record<string, unknown>;
+}
+
+export const BRANCH_TOOL: Tool = {
+  name: "branch",
+  description:
+    "Toolhost for managing reasoning branches. " +
+    "Spawn parallel explorations, merge results, list and inspect branches.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      operation: {
+        type: "string",
+        enum: ["branch_spawn", "branch_merge", "branch_list", "branch_get"],
+        description: "The branch operation to execute",
+      },
+      args: {
+        type: "object",
+        description: "Arguments for the operation",
+      },
+    },
+    required: ["operation"],
+  },
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+  },
+};
+
+export const BRANCH_OPERATIONS: OperationDefinition[] = [
+  {
+    name: "branch_spawn",
+    title: "Spawn Branch",
+    description:
+      "Create a new reasoning branch from a main-track thought. " +
+      "Returns a worker URL for the branch MCP endpoint.",
+    category: "branch-management",
+    inputSchema: {
+      type: "object",
+      properties: {
+        sessionId: {
+          type: "string",
+          description: "The session to branch within",
+        },
+        branchId: {
+          type: "string",
+          description: "Unique identifier for the new branch",
+        },
+        description: {
+          type: "string",
+          description: "Human-readable description of the branch purpose",
+        },
+        branchFromThought: {
+          type: "number",
+          description: "Main-track thought number to branch from",
+        },
+      },
+      required: ["sessionId", "branchId", "branchFromThought"],
+    },
+    example: {
+      sessionId: "abc-123",
+      branchId: "explore-caching",
+      description: "Explore Redis caching strategy",
+      branchFromThought: 5,
+    },
+  },
+  {
+    name: "branch_merge",
+    title: "Merge Branches",
+    description:
+      "Merge branch results back into the main track. " +
+      "Records a synthesis thought and updates branch statuses.",
+    category: "branch-management",
+    inputSchema: {
+      type: "object",
+      properties: {
+        sessionId: {
+          type: "string",
+          description: "The session containing branches to merge",
+        },
+        synthesis: {
+          type: "string",
+          description: "Synthesis text summarizing branch outcomes",
+        },
+        selectedBranchId: {
+          type: "string",
+          description:
+            "Branch to select (required when resolution is 'selected')",
+        },
+        resolution: {
+          type: "string",
+          enum: ["selected", "synthesized", "abandoned"],
+          description:
+            "How to resolve: select one branch, synthesize all, or abandon",
+        },
+      },
+      required: ["sessionId", "synthesis", "resolution"],
+    },
+    example: {
+      sessionId: "abc-123",
+      synthesis: "Redis caching is the better approach based on latency data.",
+      selectedBranchId: "explore-caching",
+      resolution: "selected",
+    },
+  },
+  {
+    name: "branch_list",
+    title: "List Branches",
+    description:
+      "List all branches for a session with thought counts and status.",
+    category: "branch-retrieval",
+    inputSchema: {
+      type: "object",
+      properties: {
+        sessionId: {
+          type: "string",
+          description: "The session to list branches for",
+        },
+      },
+      required: ["sessionId"],
+    },
+    example: {
+      sessionId: "abc-123",
+    },
+  },
+  {
+    name: "branch_get",
+    title: "Get Branch",
+    description:
+      "Retrieve a specific branch with its metadata and all thoughts.",
+    category: "branch-retrieval",
+    inputSchema: {
+      type: "object",
+      properties: {
+        sessionId: {
+          type: "string",
+          description: "The session containing the branch",
+        },
+        branchId: {
+          type: "string",
+          description: "The branch to retrieve",
+        },
+      },
+      required: ["sessionId", "branchId"],
+    },
+    example: {
+      sessionId: "abc-123",
+      branchId: "explore-caching",
+    },
+  },
+];
+
+export function getOperation(name: string): OperationDefinition | undefined {
+  return BRANCH_OPERATIONS.find((op) => op.name === name);
+}
+
+export function getOperationNames(): string[] {
+  return BRANCH_OPERATIONS.map((op) => op.name);
+}
+
+export function getOperationsCatalog(): string {
+  return JSON.stringify(
+    {
+      version: "1.0.0",
+      operations: BRANCH_OPERATIONS.map((op) => ({
+        name: op.name,
+        title: op.title,
+        description: op.description,
+        category: op.category,
+        inputs: op.inputSchema,
+        example: op.example,
+      })),
+      categories: [
+        {
+          name: "branch-management",
+          description: "Spawn and merge reasoning branches",
+        },
+        {
+          name: "branch-retrieval",
+          description: "List and inspect branches",
+        },
+      ],
+    },
+    null,
+    2
+  );
+}

--- a/src/branch/tool.ts
+++ b/src/branch/tool.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+import type { BranchHandler } from "./index.js";
+
+export const branchToolInputSchema = z.object({
+  operation: z.enum([
+    "branch_spawn", "branch_merge", "branch_list", "branch_get",
+  ]),
+  sessionId: z.string().describe("Session ID"),
+  branchId: z.string().optional().describe("Branch identifier"),
+  description: z.string().optional().describe("Branch description"),
+  branchFromThought: z.number().optional().describe(
+    "Main-track thought number to branch from"
+  ),
+  synthesis: z.string().optional().describe("Merge synthesis text"),
+  selectedBranchId: z.string().optional().describe(
+    "Branch to select for 'selected' resolution"
+  ),
+  resolution: z.enum(["selected", "synthesized", "abandoned"]).optional()
+    .describe("How to resolve branches on merge"),
+});
+
+export type BranchToolInput = z.infer<typeof branchToolInputSchema>;
+
+export const BRANCH_TOOL = {
+  name: "thoughtbox_branch",
+  description:
+    "Toolhost for managing reasoning branches. " +
+    "Spawn parallel explorations, merge results, list and inspect branches.",
+  inputSchema: branchToolInputSchema,
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+  },
+};
+
+export class BranchTool {
+  constructor(private handler: BranchHandler) {}
+
+  async handle(input: BranchToolInput) {
+    const { operation, ...args } = input;
+    const strippedOp = operation.replace("branch_", "");
+    return this.handler.processTool(strippedOp, args);
+  }
+}

--- a/src/code-mode/execute-tool.ts
+++ b/src/code-mode/execute-tool.ts
@@ -19,6 +19,7 @@ import type { NotebookTool, NotebookToolInput } from "../notebook/tool.js";
 import type { TheseusTool, TheseusToolInput } from "../protocol/theseus-tool.js";
 import type { UlyssesTool, UlyssesToolInput } from "../protocol/ulysses-tool.js";
 import type { ObservabilityGatewayHandler, ObservabilityInput } from "../observability/gateway-handler.js";
+import type { BranchHandler } from "../branch/index.js";
 
 const MAX_LOGS = 100;
 const TIMEOUT_MS = 30_000;
@@ -41,6 +42,7 @@ export interface ExecuteToolDeps {
   theseusTool: TheseusTool;
   ulyssesTool: UlyssesTool;
   observabilityHandler: ObservabilityGatewayHandler;
+  branchHandler: BranchHandler;
 }
 
 export const EXECUTE_TOOL = {
@@ -99,7 +101,7 @@ interface TbContext {
 
 function buildTbObject(deps: ExecuteToolDeps, ctx: TbContext): Record<string, unknown> {
   const { thoughtTool, sessionTool, knowledgeTool, notebookTool,
-          theseusTool, ulyssesTool, observabilityHandler } = deps;
+          theseusTool, ulyssesTool, observabilityHandler, branchHandler } = deps;
 
   return {
     thought: async (input: ThoughtToolInput) => {
@@ -215,6 +217,17 @@ function buildTbObject(deps: ExecuteToolDeps, ctx: TbContext): Record<string, un
 
     observability: async (input: ObservabilityInput) =>
       unwrapToolResult(await observabilityHandler.handle(input)),
+
+    branch: {
+      spawn: async (args: Record<string, unknown>) =>
+        unwrapToolResult(await branchHandler.processTool("spawn", args)),
+      merge: async (args: Record<string, unknown>) =>
+        unwrapToolResult(await branchHandler.processTool("merge", args)),
+      list: async (args: Record<string, unknown>) =>
+        unwrapToolResult(await branchHandler.processTool("list", args)),
+      get: async (args: Record<string, unknown>) =>
+        unwrapToolResult(await branchHandler.processTool("get", args)),
+    },
   };
 }
 

--- a/src/code-mode/sdk-types.ts
+++ b/src/code-mode/sdk-types.ts
@@ -125,5 +125,13 @@ interface TB {
       model?: string;
     };
   }): Promise<unknown>;
+
+  /** Branch management. Source: src/branch/index.ts */
+  branch: {
+    spawn(args: { sessionId: string; branchId: string; description?: string; branchFromThought: number }): Promise<unknown>;
+    merge(args: { sessionId: string; synthesis: string; selectedBranchId?: string; resolution: "selected" | "synthesized" | "abandoned" }): Promise<unknown>;
+    list(args: { sessionId: string }): Promise<unknown>;
+    get(args: { sessionId: string; branchId: string }): Promise<unknown>;
+  };
 }
 \`\`\``;

--- a/src/knowledge/types.ts
+++ b/src/knowledge/types.ts
@@ -1,8 +1,9 @@
 /**
  * Knowledge Graph Memory System - Type Definitions
  *
- * Phase 1 MVP: Basic entity/relation/observation storage
- * No embeddings, no semantic search, no auto-extraction
+ * Structural graph: entities, relations, observations.
+ * Embedding column exists on entities/observations (migration 20260408) but is not populated yet.
+ * Semantic search deferred until a real embedding provider is wired.
  *
  * @see dgm-specs/SPEC-KNOWLEDGE-MEMORY.md
  */

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -65,6 +65,7 @@ import { createClient as createSupabaseClient } from "@supabase/supabase-js";
 import {
   ObservabilityGatewayHandler,
 } from "./observability/index.js";
+import { BranchHandler } from "./branch/index.js";
 import { SUBAGENT_SUMMARIZE_CONTENT } from "./resources/subagent-summarize-content.js";
 import { EVOLUTION_CHECK_CONTENT } from "./resources/evolution-check-content.js";
 import { BEHAVIORAL_TESTS } from "./resources/behavioral-tests-content.js";
@@ -401,6 +402,15 @@ Use \`console.log()\` for debugging — output captured in response logs.`;
     serviceRoleKey: process.env.SUPABASE_SERVICE_ROLE_KEY,
   });
 
+  // Branch handler — requires Supabase credentials
+  const branchSupabaseUrl = process.env.SUPABASE_URL ?? "";
+  const branchServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY ?? "";
+  const branchHandler = new BranchHandler({
+    supabaseUrl: branchSupabaseUrl,
+    serviceRoleKey: branchServiceKey,
+    workspaceId: args.workspaceId ?? "default",
+  });
+
   // =============================================================================
   // Code Mode Tools (replaces individual tool registrations)
   // =============================================================================
@@ -415,6 +425,7 @@ Use \`console.log()\` for debugging — output captured in response logs.`;
     theseusTool,
     ulyssesTool,
     observabilityHandler,
+    branchHandler,
   });
 
   registerTool(SEARCH_TOOL, searchTool);

--- a/supabase/.gitignore
+++ b/supabase/.gitignore
@@ -1,6 +1,8 @@
 # Supabase
 .branches
 .temp
+# Deno v2 lockfiles break local `supabase functions serve` (edge runtime expects older format)
+functions/**/deno.lock
 
 # dotenvx
 .env.keys

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -270,6 +270,13 @@ inspector_port = 8083
 # For example, if you want to serve static HTML pages in your function:
 # static_files = [ "./functions/MY_FUNCTION_NAME/*.html" ]
 
+# Prototype: background queue worker (cron / pg_net); not a user-facing MCP surface.
+[functions.process-thought-queue]
+enabled = true
+verify_jwt = false
+import_map = "./functions/process-thought-queue/deno.json"
+entrypoint = "./functions/process-thought-queue/index.ts"
+
 [analytics]
 enabled = true
 port = 54327

--- a/supabase/functions/process-thought-queue/deno.json
+++ b/supabase/functions/process-thought-queue/deno.json
@@ -1,0 +1,8 @@
+{
+  "imports": {
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2"
+  },
+  "compilerOptions": {
+    "lib": ["deno.window", "deno.unstable"]
+  }
+}

--- a/supabase/functions/process-thought-queue/index.ts
+++ b/supabase/functions/process-thought-queue/index.ts
@@ -1,0 +1,229 @@
+/**
+ * Background queue worker: thought_processing (pgmq) → archive + Realtime signal.
+ *
+ * NOT an MCP surface — invoke only from cron, pg_net, or internal automation (see SUPABASE-INTELLIGENCE.md).
+ *
+ * Prerequisites:
+ * - Migration 20260408033928_add_hub_tables_vectors_pgmq_realtime.sql applied (queue + thoughts.embedding).
+ * - RPC wrappers in same migration: pgmq_read_queue, pgmq_archive_queue_message.
+ *
+ * Embeddings: NOT generated here. The embedding column exists on thoughts but is populated
+ * only when a real embedding provider is wired (external API or Cloud Run worker).
+ * This worker processes the queue, broadcasts a Realtime event, and archives the message.
+ * Embedding generation can be added as a step in processOneMessage when ready.
+ *
+ * Env:
+ * - SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY (auto in hosted Edge)
+ * - CRON_SECRET (optional): require Authorization: Bearer <CRON_SECRET>
+ */
+
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+
+import { createClient, type SupabaseClient } from "jsr:@supabase/supabase-js@2";
+
+const QUEUE = "thought_processing";
+
+type QueueRow = {
+  msg_id: number;
+  read_ct: number;
+  enqueued_at: string;
+  vt: string;
+  message: { thought_id?: string; action?: string; [key: string]: unknown };
+};
+
+type ThoughtRow = {
+  id: string;
+  workspace_id: string;
+  session_id: string;
+  thought: string;
+  embedding: string | null;
+};
+
+function assertAuthorized(req: Request): void {
+  const secret = Deno.env.get("CRON_SECRET");
+  if (!secret) return;
+  const auth = req.headers.get("Authorization");
+  if (auth !== `Bearer ${secret}`) {
+    throw new HttpError(401, "Unauthorized");
+  }
+}
+
+class HttpError extends Error {
+  constructor(
+    public status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "HttpError";
+  }
+}
+
+async function broadcastProcessingEvent(
+  supabase: SupabaseClient,
+  workspaceId: string,
+  payload: Record<string, unknown>,
+): Promise<void> {
+  try {
+    const channelName = `intelligence:${workspaceId}`;
+    const channel = supabase.channel(channelName, {
+      config: { broadcast: { ack: false } },
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      const t = setTimeout(() => reject(new Error("Realtime subscribe timeout")), 8000);
+      channel.subscribe((status, err) => {
+        if (status === "SUBSCRIBED") {
+          clearTimeout(t);
+          resolve();
+        } else if (status === "CHANNEL_ERROR" || status === "TIMED_OUT") {
+          clearTimeout(t);
+          reject(err ?? new Error(status));
+        }
+      });
+    });
+
+    try {
+      const sendRes = await channel.send({
+        type: "broadcast",
+        event: "thought_processed",
+        payload,
+      });
+      if (sendRes !== "ok" && (sendRes as { error?: unknown }).error) {
+        console.warn("Realtime broadcast:", sendRes);
+      }
+    } finally {
+      await supabase.removeChannel(channel);
+    }
+  } catch (e) {
+    console.warn("broadcastProcessingEvent skipped:", e);
+  }
+}
+
+function coerceMsgId(row: QueueRow): number {
+  const id = row.msg_id as unknown;
+  if (typeof id === "number") return id;
+  if (typeof id === "string") return Number(id);
+  return Number(id);
+}
+
+async function processOneMessage(
+  supabase: SupabaseClient,
+  row: QueueRow,
+): Promise<{ ok: boolean; detail: string }> {
+  const msgId = coerceMsgId(row);
+  const thoughtId = row.message?.thought_id;
+  if (!thoughtId || typeof thoughtId !== "string") {
+    await supabase.rpc("pgmq_archive_queue_message", {
+      queue_name: QUEUE,
+      msg_id: msgId,
+    });
+    return { ok: false, detail: "invalid payload; archived poison message" };
+  }
+
+  const { data: thought, error: fetchErr } = await supabase
+    .from("thoughts")
+    .select("id, workspace_id, session_id, thought, embedding")
+    .eq("id", thoughtId)
+    .maybeSingle();
+
+  if (fetchErr) {
+    console.error("fetch thought", fetchErr);
+    return { ok: false, detail: fetchErr.message };
+  }
+  if (!thought) {
+    await supabase.rpc("pgmq_archive_queue_message", {
+      queue_name: QUEUE,
+      msg_id: msgId,
+    });
+    return { ok: false, detail: "thought not found; archived" };
+  }
+
+  const t = thought as ThoughtRow;
+
+  try {
+    // TODO: Wire real embedding provider here.
+    // When ready, generate embedding and write to thoughts.embedding:
+    //   const vec = await generateEmbedding(t.thought);
+    //   await supabase.from("thoughts").update({ embedding: vec }).eq("id", t.id);
+
+    await broadcastProcessingEvent(supabase, t.workspace_id, {
+      thought_id: t.id,
+      session_id: t.session_id,
+      has_embedding: t.embedding != null,
+      msg_id: msgId,
+    });
+
+    const { data: archived, error: archErr } = await supabase.rpc(
+      "pgmq_archive_queue_message",
+      { queue_name: QUEUE, msg_id: msgId },
+    );
+
+    if (archErr) {
+      console.error("archive", archErr);
+      return { ok: false, detail: archErr.message };
+    }
+    if (archived === false) {
+      return { ok: false, detail: "archive returned false" };
+    }
+
+    return { ok: true, detail: "processed" };
+  } catch (e) {
+    console.error("processOneMessage", e);
+    return { ok: false, detail: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+Deno.serve(async (req: Request) => {
+  if (req.method !== "POST" && req.method !== "GET") {
+    return new Response("Method not allowed", { status: 405 });
+  }
+
+  try {
+    assertAuthorized(req);
+  } catch (e) {
+    if (e instanceof HttpError) {
+      return new Response(e.message, { status: e.status });
+    }
+    throw e;
+  }
+
+  const url = Deno.env.get("SUPABASE_URL");
+  const key = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  if (!url || !key) {
+    return new Response("Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY", { status: 500 });
+  }
+
+  const supabase = createClient(url, key, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+  const vt = 30;
+  const qty = 5;
+
+  const { data: messages, error: readErr } = await supabase.rpc("pgmq_read_queue", {
+    queue_name: QUEUE,
+    vt,
+    qty,
+  });
+
+  if (readErr) {
+    console.error("pgmq_read_queue", readErr);
+    return new Response(JSON.stringify({ error: readErr.message }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const batch = (messages ?? []) as QueueRow[];
+  const results: { msg_id: number; ok: boolean; detail: string }[] = [];
+
+  for (const m of batch) {
+    const r = await processOneMessage(supabase, m);
+    results.push({ msg_id: coerceMsgId(m), ok: r.ok, detail: r.detail });
+  }
+
+  return new Response(
+    JSON.stringify({ queue: QUEUE, read: batch.length, results }),
+    { headers: { "Content-Type": "application/json" } },
+  );
+});

--- a/supabase/functions/tb-branch/deno.json
+++ b/supabase/functions/tb-branch/deno.json
@@ -1,0 +1,10 @@
+{
+  "imports": {
+    "hono": "npm:hono@4.6.14",
+    "zod": "npm:zod@3.24.4",
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2"
+  },
+  "compilerOptions": {
+    "lib": ["deno.window", "deno.unstable"]
+  }
+}

--- a/supabase/functions/tb-branch/index.ts
+++ b/supabase/functions/tb-branch/index.ts
@@ -41,6 +41,18 @@ const BranchReadInput = z.object({
   offset: z.number().default(0),
 });
 
+const BranchTokenPayload = z.object({
+  session_id: z.string().uuid(),
+  branch_id: z.string().min(1),
+  workspace_id: z.string().uuid(),
+  branch_from_thought: z.number().int().positive(),
+  expires_at: z.string().datetime(),
+});
+
+const THOUGHT_INSERT_MAX_ATTEMPTS = 5;
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
 // --- Branch context from URL params ---
 
 type BranchContext = {
@@ -50,48 +62,102 @@ type BranchContext = {
   branchFrom: number | null;
 };
 
-function parseBranchContext(url: URL): BranchContext {
-  const sessionId = url.searchParams.get("session_id");
-  const branchId = url.searchParams.get("branch_id");
-  const workspaceId = url.searchParams.get("workspace_id");
-  const branchFromRaw = url.searchParams.get("branch_from");
+class HttpError extends Error {
+  constructor(
+    public status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "HttpError";
+  }
+}
 
-  if (!sessionId || !branchId || !workspaceId) {
-    throw new McpError(
-      -32602,
-      "Missing required query params: session_id, branch_id, workspace_id",
-    );
+function encodeBase64Url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+function decodeBase64Url(value: string): Uint8Array {
+  const base64 = value.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, "=");
+  const binary = atob(padded);
+  return Uint8Array.from(binary, (char) => char.charCodeAt(0));
+}
+
+function timingSafeEqual(left: string, right: string): boolean {
+  if (left.length !== right.length) return false;
+
+  let diff = 0;
+  for (let index = 0; index < left.length; index += 1) {
+    diff |= left.charCodeAt(index) ^ right.charCodeAt(index);
+  }
+
+  return diff === 0;
+}
+
+async function signTokenSegment(segment: string, secret: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    textEncoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign("HMAC", key, textEncoder.encode(segment));
+  return encodeBase64Url(new Uint8Array(signature));
+}
+
+async function parseBranchContext(url: URL): Promise<BranchContext> {
+  const token = url.searchParams.get("token");
+  if (!token) {
+    throw new HttpError(401, "Missing token");
+  }
+
+  const [payloadSegment, signatureSegment, ...rest] = token.split(".");
+  if (!payloadSegment || !signatureSegment || rest.length > 0) {
+    throw new HttpError(401, "Invalid token");
+  }
+
+  const secret = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  if (!secret) {
+    throw new HttpError(500, "Missing SUPABASE_SERVICE_ROLE_KEY");
+  }
+
+  const expectedSignature = await signTokenSegment(payloadSegment, secret);
+  if (!timingSafeEqual(signatureSegment, expectedSignature)) {
+    throw new HttpError(401, "Invalid token signature");
+  }
+
+  let payload: z.infer<typeof BranchTokenPayload>;
+  try {
+    const decodedPayload = textDecoder.decode(decodeBase64Url(payloadSegment));
+    payload = BranchTokenPayload.parse(JSON.parse(decodedPayload));
+  } catch {
+    throw new HttpError(401, "Invalid token payload");
+  }
+
+  if (Date.parse(payload.expires_at) <= Date.now()) {
+    throw new HttpError(401, "Token expired");
   }
 
   return {
-    sessionId,
-    branchId,
-    workspaceId,
-    branchFrom: branchFromRaw ? Number(branchFromRaw) : null,
+    sessionId: payload.session_id,
+    branchId: payload.branch_id,
+    workspaceId: payload.workspace_id,
+    branchFrom: payload.branch_from_thought,
   };
 }
 
 // --- Thought numbering (branch-scoped) ---
-
-let cachedNextNumber: Map<string, number> = new Map();
-
-function cacheKey(sessionId: string, branchId: string): string {
-  return `${sessionId}::${branchId}`;
-}
 
 async function getNextThoughtNumber(
   supabase: SupabaseClient,
   sessionId: string,
   branchId: string,
 ): Promise<number> {
-  const key = cacheKey(sessionId, branchId);
-  const cached = cachedNextNumber.get(key);
-  if (cached !== undefined) {
-    const next = cached + 1;
-    cachedNextNumber.set(key, next);
-    return next;
-  }
-
   const { data, error } = await supabase
     .from("thoughts")
     .select("thought_number")
@@ -106,9 +172,15 @@ async function getNextThoughtNumber(
   }
 
   const maxNum = data?.thought_number ?? 0;
-  const next = maxNum + 1;
-  cachedNextNumber.set(key, next);
-  return next;
+  return maxNum + 1;
+}
+
+function isThoughtNumberConflict(error: { code?: string; message?: string } | null): boolean {
+  if (!error) return false;
+  return (
+    error.code === "23505" ||
+    error.message?.includes("thoughts_branch_unique") === true
+  );
 }
 
 // --- Content hashing ---
@@ -215,51 +287,60 @@ async function handleBranchThought(
   args: Record<string, unknown>,
 ): Promise<unknown> {
   const input = BranchThoughtInput.parse(args);
-  const thoughtNumber = await getNextThoughtNumber(
-    supabase,
-    ctx.sessionId,
-    ctx.branchId,
-  );
   const contentHash = await hashContent(input.thought);
 
-  const row = {
-    session_id: ctx.sessionId,
-    workspace_id: ctx.workspaceId,
-    thought_number: thoughtNumber,
-    thought: input.thought,
-    total_thoughts: input.totalThoughts ?? thoughtNumber,
-    next_thought_needed: input.nextThoughtNeeded,
-    thought_type: input.thoughtType,
-    is_revision: input.isRevision,
-    revises_thought: input.revisesThought ?? null,
-    branch_from_thought: ctx.branchFrom,
-    branch_id: ctx.branchId,
-    needs_more_thoughts: input.needsMoreThoughts ?? null,
-    confidence: input.confidence ?? null,
-    options: input.options ?? null,
-    action_result: input.actionResult ?? null,
-    beliefs: input.beliefs ?? null,
-    assumption_change: input.assumptionChange ?? null,
-    context_data: input.contextData ?? null,
-    progress_data: input.progressData ?? null,
-    agent_id: input.agentId ?? null,
-    agent_name: input.agentName ?? null,
-    content_hash: contentHash,
-    parent_hash: null,
-    critique: input.critique ?? null,
-  };
+  for (let attempt = 1; attempt <= THOUGHT_INSERT_MAX_ATTEMPTS; attempt += 1) {
+    const thoughtNumber = await getNextThoughtNumber(
+      supabase,
+      ctx.sessionId,
+      ctx.branchId,
+    );
 
-  const { error } = await supabase.from("thoughts").insert(row);
-  if (error) {
+    const row = {
+      session_id: ctx.sessionId,
+      workspace_id: ctx.workspaceId,
+      thought_number: thoughtNumber,
+      thought: input.thought,
+      total_thoughts: input.totalThoughts ?? thoughtNumber,
+      next_thought_needed: input.nextThoughtNeeded,
+      thought_type: input.thoughtType,
+      is_revision: input.isRevision,
+      revises_thought: input.revisesThought ?? null,
+      branch_from_thought: ctx.branchFrom,
+      branch_id: ctx.branchId,
+      needs_more_thoughts: input.needsMoreThoughts ?? null,
+      confidence: input.confidence ?? null,
+      options: input.options ?? null,
+      action_result: input.actionResult ?? null,
+      beliefs: input.beliefs ?? null,
+      assumption_change: input.assumptionChange ?? null,
+      context_data: input.contextData ?? null,
+      progress_data: input.progressData ?? null,
+      agent_id: input.agentId ?? null,
+      agent_name: input.agentName ?? null,
+      content_hash: contentHash,
+      parent_hash: null,
+      critique: input.critique ?? null,
+    };
+
+    const { error } = await supabase.from("thoughts").insert(row);
+    if (!error) {
+      return {
+        thoughtNumber,
+        branchId: ctx.branchId,
+        sessionId: ctx.sessionId,
+        contentHash,
+      };
+    }
+
+    if (isThoughtNumberConflict(error) && attempt < THOUGHT_INSERT_MAX_ATTEMPTS) {
+      continue;
+    }
+
     throw new McpError(-32603, `Insert failed: ${error.message}`);
   }
 
-  return {
-    thoughtNumber,
-    branchId: ctx.branchId,
-    sessionId: ctx.sessionId,
-    contentHash,
-  };
+  throw new McpError(-32603, "Insert failed after retrying thought number allocation");
 }
 
 async function handleBranchStatus(
@@ -431,16 +512,16 @@ mcpApp.post("/mcp", async (c) => {
 
   let ctx: BranchContext;
   try {
-    ctx = parseBranchContext(url);
+    ctx = await parseBranchContext(url);
   } catch (e) {
-    if (e instanceof McpError) {
+    if (e instanceof HttpError) {
       return c.json(
         {
           jsonrpc: "2.0",
           id: null,
-          error: { code: e.code, message: e.message },
+          error: { code: -32001, message: e.message },
         },
-        400,
+        { status: e.status as 400 | 401 | 500 },
       );
     }
     throw e;
@@ -452,7 +533,16 @@ mcpApp.post("/mcp", async (c) => {
   return c.json(response);
 });
 
-mcpApp.get("/mcp", (c) => {
+mcpApp.get("/mcp", async (c) => {
+  try {
+    await parseBranchContext(new URL(c.req.url));
+  } catch (e) {
+    if (e instanceof HttpError) {
+      return c.json({ error: e.message }, { status: e.status as 400 | 401 | 500 });
+    }
+    throw e;
+  }
+
   return c.json({
     name: "tb-branch",
     version: "0.1.0",

--- a/supabase/functions/tb-branch/index.ts
+++ b/supabase/functions/tb-branch/index.ts
@@ -1,0 +1,467 @@
+/**
+ * tb-branch: MCP Lite edge function for branch-scoped thought writes.
+ *
+ * Implements a minimal MCP JSON-RPC server over Streamable HTTP transport.
+ * Reads session_id, branch_id, workspace_id, branch_from from URL query params.
+ * Writes directly to the existing `thoughts` table using service_role.
+ *
+ * Tools: branch_thought, branch_status, branch_read
+ */
+
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+
+import { Hono } from "hono";
+import { z } from "zod";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+// --- Schemas ---
+
+const BranchThoughtInput = z.object({
+  thought: z.string(),
+  thoughtType: z.string().default("reasoning"),
+  nextThoughtNeeded: z.boolean(),
+  confidence: z.string().nullable().optional(),
+  totalThoughts: z.number().nullable().optional(),
+  isRevision: z.boolean().default(false),
+  revisesThought: z.number().nullable().optional(),
+  needsMoreThoughts: z.boolean().nullable().optional(),
+  options: z.record(z.unknown()).nullable().optional(),
+  actionResult: z.record(z.unknown()).nullable().optional(),
+  beliefs: z.record(z.unknown()).nullable().optional(),
+  assumptionChange: z.record(z.unknown()).nullable().optional(),
+  contextData: z.record(z.unknown()).nullable().optional(),
+  progressData: z.record(z.unknown()).nullable().optional(),
+  agentId: z.string().nullable().optional(),
+  agentName: z.string().nullable().optional(),
+  critique: z.string().nullable().optional(),
+});
+
+const BranchReadInput = z.object({
+  limit: z.number().default(50),
+  offset: z.number().default(0),
+});
+
+// --- Branch context from URL params ---
+
+type BranchContext = {
+  sessionId: string;
+  branchId: string;
+  workspaceId: string;
+  branchFrom: number | null;
+};
+
+function parseBranchContext(url: URL): BranchContext {
+  const sessionId = url.searchParams.get("session_id");
+  const branchId = url.searchParams.get("branch_id");
+  const workspaceId = url.searchParams.get("workspace_id");
+  const branchFromRaw = url.searchParams.get("branch_from");
+
+  if (!sessionId || !branchId || !workspaceId) {
+    throw new McpError(
+      -32602,
+      "Missing required query params: session_id, branch_id, workspace_id",
+    );
+  }
+
+  return {
+    sessionId,
+    branchId,
+    workspaceId,
+    branchFrom: branchFromRaw ? Number(branchFromRaw) : null,
+  };
+}
+
+// --- Thought numbering (branch-scoped) ---
+
+let cachedNextNumber: Map<string, number> = new Map();
+
+function cacheKey(sessionId: string, branchId: string): string {
+  return `${sessionId}::${branchId}`;
+}
+
+async function getNextThoughtNumber(
+  supabase: SupabaseClient,
+  sessionId: string,
+  branchId: string,
+): Promise<number> {
+  const key = cacheKey(sessionId, branchId);
+  const cached = cachedNextNumber.get(key);
+  if (cached !== undefined) {
+    const next = cached + 1;
+    cachedNextNumber.set(key, next);
+    return next;
+  }
+
+  const { data, error } = await supabase
+    .from("thoughts")
+    .select("thought_number")
+    .eq("session_id", sessionId)
+    .eq("branch_id", branchId)
+    .order("thought_number", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    throw new McpError(-32603, `Failed to query max thought_number: ${error.message}`);
+  }
+
+  const maxNum = data?.thought_number ?? 0;
+  const next = maxNum + 1;
+  cachedNextNumber.set(key, next);
+  return next;
+}
+
+// --- Content hashing ---
+
+async function hashContent(content: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(content);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+// --- MCP JSON-RPC types ---
+
+class McpError extends Error {
+  constructor(
+    public code: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "McpError";
+  }
+}
+
+type JsonRpcRequest = {
+  jsonrpc: "2.0";
+  id?: string | number;
+  method: string;
+  params?: Record<string, unknown>;
+};
+
+type JsonRpcResponse = {
+  jsonrpc: "2.0";
+  id: string | number | null;
+  result?: unknown;
+  error?: { code: number; message: string; data?: unknown };
+};
+
+// --- Tool definitions ---
+
+const TOOLS = [
+  {
+    name: "branch_thought",
+    description:
+      "Record a thought on this branch. Thoughts are numbered sequentially within the branch.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        thought: { type: "string", description: "The thought content" },
+        thoughtType: {
+          type: "string",
+          description: "Type of thought (reasoning, hypothesis, etc.)",
+          default: "reasoning",
+        },
+        nextThoughtNeeded: {
+          type: "boolean",
+          description: "Whether another thought is expected after this one",
+        },
+        confidence: { type: "string", description: "Confidence level" },
+        totalThoughts: { type: "number", description: "Expected total thoughts" },
+        isRevision: { type: "boolean", default: false },
+        revisesThought: { type: "number" },
+        needsMoreThoughts: { type: "boolean" },
+        options: { type: "object" },
+        actionResult: { type: "object" },
+        beliefs: { type: "object" },
+        assumptionChange: { type: "object" },
+        contextData: { type: "object" },
+        progressData: { type: "object" },
+        agentId: { type: "string" },
+        agentName: { type: "string" },
+        critique: { type: "string" },
+      },
+      required: ["thought", "nextThoughtNeeded"],
+    },
+  },
+  {
+    name: "branch_status",
+    description:
+      "Get the status of the current branch (thought count, context).",
+    inputSchema: {
+      type: "object" as const,
+      properties: {},
+    },
+  },
+  {
+    name: "branch_read",
+    description: "Read thoughts from this branch, ordered by thought number.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        limit: { type: "number", default: 50 },
+        offset: { type: "number", default: 0 },
+      },
+    },
+  },
+];
+
+// --- Tool handlers ---
+
+async function handleBranchThought(
+  supabase: SupabaseClient,
+  ctx: BranchContext,
+  args: Record<string, unknown>,
+): Promise<unknown> {
+  const input = BranchThoughtInput.parse(args);
+  const thoughtNumber = await getNextThoughtNumber(
+    supabase,
+    ctx.sessionId,
+    ctx.branchId,
+  );
+  const contentHash = await hashContent(input.thought);
+
+  const row = {
+    session_id: ctx.sessionId,
+    workspace_id: ctx.workspaceId,
+    thought_number: thoughtNumber,
+    thought: input.thought,
+    total_thoughts: input.totalThoughts ?? thoughtNumber,
+    next_thought_needed: input.nextThoughtNeeded,
+    thought_type: input.thoughtType,
+    is_revision: input.isRevision,
+    revises_thought: input.revisesThought ?? null,
+    branch_from_thought: ctx.branchFrom,
+    branch_id: ctx.branchId,
+    needs_more_thoughts: input.needsMoreThoughts ?? null,
+    confidence: input.confidence ?? null,
+    options: input.options ?? null,
+    action_result: input.actionResult ?? null,
+    beliefs: input.beliefs ?? null,
+    assumption_change: input.assumptionChange ?? null,
+    context_data: input.contextData ?? null,
+    progress_data: input.progressData ?? null,
+    agent_id: input.agentId ?? null,
+    agent_name: input.agentName ?? null,
+    content_hash: contentHash,
+    parent_hash: null,
+    critique: input.critique ?? null,
+  };
+
+  const { error } = await supabase.from("thoughts").insert(row);
+  if (error) {
+    throw new McpError(-32603, `Insert failed: ${error.message}`);
+  }
+
+  return {
+    thoughtNumber,
+    branchId: ctx.branchId,
+    sessionId: ctx.sessionId,
+    contentHash,
+  };
+}
+
+async function handleBranchStatus(
+  supabase: SupabaseClient,
+  ctx: BranchContext,
+): Promise<unknown> {
+  const { count, error } = await supabase
+    .from("thoughts")
+    .select("*", { count: "exact", head: true })
+    .eq("session_id", ctx.sessionId)
+    .eq("branch_id", ctx.branchId);
+
+  if (error) {
+    throw new McpError(-32603, `Count query failed: ${error.message}`);
+  }
+
+  return {
+    branchId: ctx.branchId,
+    sessionId: ctx.sessionId,
+    workspaceId: ctx.workspaceId,
+    thoughtCount: count ?? 0,
+    branchFromThought: ctx.branchFrom,
+  };
+}
+
+async function handleBranchRead(
+  supabase: SupabaseClient,
+  ctx: BranchContext,
+  args: Record<string, unknown>,
+): Promise<unknown> {
+  const input = BranchReadInput.parse(args);
+
+  const { data, error } = await supabase
+    .from("thoughts")
+    .select("*")
+    .eq("session_id", ctx.sessionId)
+    .eq("branch_id", ctx.branchId)
+    .order("thought_number", { ascending: true })
+    .range(input.offset, input.offset + input.limit - 1);
+
+  if (error) {
+    throw new McpError(-32603, `Read query failed: ${error.message}`);
+  }
+
+  return { thoughts: data ?? [] };
+}
+
+// --- MCP JSON-RPC dispatcher ---
+
+async function handleRpc(
+  req: JsonRpcRequest,
+  supabase: SupabaseClient,
+  ctx: BranchContext,
+): Promise<JsonRpcResponse> {
+  const id = req.id ?? null;
+
+  try {
+    switch (req.method) {
+      case "initialize": {
+        return {
+          jsonrpc: "2.0",
+          id,
+          result: {
+            protocolVersion: "2024-11-05",
+            capabilities: { tools: {} },
+            serverInfo: {
+              name: "tb-branch",
+              version: "0.1.0",
+            },
+          },
+        };
+      }
+
+      case "notifications/initialized": {
+        return { jsonrpc: "2.0", id, result: {} };
+      }
+
+      case "tools/list": {
+        return { jsonrpc: "2.0", id, result: { tools: TOOLS } };
+      }
+
+      case "tools/call": {
+        const params = req.params ?? {};
+        const toolName = params.name as string;
+        const toolArgs = (params.arguments ?? {}) as Record<string, unknown>;
+
+        let content: unknown;
+        switch (toolName) {
+          case "branch_thought":
+            content = await handleBranchThought(supabase, ctx, toolArgs);
+            break;
+          case "branch_status":
+            content = await handleBranchStatus(supabase, ctx);
+            break;
+          case "branch_read":
+            content = await handleBranchRead(supabase, ctx, toolArgs);
+            break;
+          default:
+            throw new McpError(-32601, `Unknown tool: ${toolName}`);
+        }
+
+        return {
+          jsonrpc: "2.0",
+          id,
+          result: {
+            content: [
+              { type: "text", text: JSON.stringify(content, null, 2) },
+            ],
+          },
+        };
+      }
+
+      default: {
+        return {
+          jsonrpc: "2.0",
+          id,
+          error: { code: -32601, message: `Unknown method: ${req.method}` },
+        };
+      }
+    }
+  } catch (e) {
+    if (e instanceof McpError) {
+      return {
+        jsonrpc: "2.0",
+        id,
+        error: { code: e.code, message: e.message },
+      };
+    }
+    if (e instanceof z.ZodError) {
+      return {
+        jsonrpc: "2.0",
+        id,
+        error: {
+          code: -32602,
+          message: "Invalid params",
+          data: e.errors,
+        },
+      };
+    }
+    const msg = e instanceof Error ? e.message : String(e);
+    return {
+      jsonrpc: "2.0",
+      id,
+      error: { code: -32603, message: msg },
+    };
+  }
+}
+
+// --- Supabase client factory ---
+
+function getSupabaseClient(): SupabaseClient {
+  const url = Deno.env.get("SUPABASE_URL");
+  const key = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  if (!url || !key) {
+    throw new McpError(-32603, "Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY");
+  }
+  return createClient(url, key, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+// --- Hono app ---
+
+const app = new Hono();
+const mcpApp = new Hono();
+
+mcpApp.post("/mcp", async (c) => {
+  const url = new URL(c.req.url);
+
+  let ctx: BranchContext;
+  try {
+    ctx = parseBranchContext(url);
+  } catch (e) {
+    if (e instanceof McpError) {
+      return c.json(
+        {
+          jsonrpc: "2.0",
+          id: null,
+          error: { code: e.code, message: e.message },
+        },
+        400,
+      );
+    }
+    throw e;
+  }
+
+  const supabase = getSupabaseClient();
+  const body = await c.req.json<JsonRpcRequest>();
+  const response = await handleRpc(body, supabase, ctx);
+  return c.json(response);
+});
+
+mcpApp.get("/mcp", (c) => {
+  return c.json({
+    name: "tb-branch",
+    version: "0.1.0",
+    description: "Branch-scoped thought writer for Thoughtbox",
+    transport: "streamable-http",
+    tools: TOOLS.map((t) => t.name),
+  });
+});
+
+app.route("/tb-branch", mcpApp);
+
+export default app;

--- a/supabase/migrations/20260408033928_add_hub_tables_vectors_pgmq_realtime.sql
+++ b/supabase/migrations/20260408033928_add_hub_tables_vectors_pgmq_realtime.sql
@@ -1,0 +1,354 @@
+-- Migration: Add hub tables, vector foundations, pgmq queues, and Realtime for Supabase Intelligence Plane
+-- Layer 2 + initial intelligence (follows .specs/hub-deployed/SCOPE-LAYER-2-SUPABASE-HUB-STORAGE.md exactly)
+-- Follows supabase-postgres-best-practices: indexes on FKs/join columns, RLS in same migration, HNSW for vectors, service_role bypass
+
+-- 1. Enable extensions (if not already)
+CREATE EXTENSION IF NOT EXISTS vector;
+CREATE EXTENSION IF NOT EXISTS pgmq;
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+CREATE EXTENSION IF NOT EXISTS pg_net;
+
+-- 2. Hub tables (exact match to Layer 2 spec)
+CREATE TABLE IF NOT EXISTS public.hub_agents (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id text UNIQUE NOT NULL,
+  name text NOT NULL,
+  role text NOT NULL DEFAULT 'contributor' CHECK (role IN ('coordinator', 'contributor')),
+  profile text,
+  client_info text,
+  registered_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.hub_workspaces (
+  id text PRIMARY KEY,
+  tenant_workspace_id uuid NOT NULL REFERENCES public.workspaces(id),
+  name text NOT NULL,
+  description text NOT NULL DEFAULT '',
+  created_by text NOT NULL REFERENCES public.hub_agents(agent_id),
+  main_session_id text,
+  agents jsonb NOT NULL DEFAULT '[]',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.hub_problems (
+  id text PRIMARY KEY,
+  workspace_id text NOT NULL REFERENCES public.hub_workspaces(id),
+  tenant_workspace_id uuid NOT NULL REFERENCES public.workspaces(id),
+  title text NOT NULL,
+  description text NOT NULL DEFAULT '',
+  created_by text NOT NULL,
+  assigned_to text REFERENCES public.hub_agents(agent_id),
+  status text NOT NULL DEFAULT 'open',
+  branch_id text,
+  branch_from_thought integer,
+  resolution text,
+  depends_on jsonb NOT NULL DEFAULT '[]',
+  parent_id text REFERENCES public.hub_problems(id),
+  comments jsonb NOT NULL DEFAULT '[]',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.hub_proposals (
+  id text PRIMARY KEY,
+  workspace_id text NOT NULL REFERENCES public.hub_workspaces(id),
+  tenant_workspace_id uuid NOT NULL REFERENCES public.workspaces(id),
+  title text NOT NULL,
+  description text NOT NULL DEFAULT '',
+  created_by text NOT NULL,
+  source_branch text NOT NULL DEFAULT '',
+  problem_id text REFERENCES public.hub_problems(id),
+  status text NOT NULL DEFAULT 'open',
+  reviews jsonb NOT NULL DEFAULT '[]',
+  merge_thought_number integer,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.hub_consensus_markers (
+  id text PRIMARY KEY,
+  workspace_id text NOT NULL REFERENCES public.hub_workspaces(id),
+  tenant_workspace_id uuid NOT NULL REFERENCES public.workspaces(id),
+  name text NOT NULL,
+  description text NOT NULL DEFAULT '',
+  thought_ref integer NOT NULL,
+  branch_id text,
+  agreed_by jsonb NOT NULL DEFAULT '[]',
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.hub_channels (
+  id text PRIMARY KEY,
+  workspace_id text NOT NULL REFERENCES public.hub_workspaces(id),
+  tenant_workspace_id uuid NOT NULL REFERENCES public.workspaces(id),
+  problem_id text NOT NULL REFERENCES public.hub_problems(id)
+);
+
+CREATE TABLE IF NOT EXISTS public.hub_channel_messages (
+  id text NOT NULL,
+  channel_id text NOT NULL REFERENCES public.hub_channels(id),
+  tenant_workspace_id uuid NOT NULL REFERENCES public.workspaces(id),
+  agent_id text NOT NULL REFERENCES public.hub_agents(agent_id),
+  content text NOT NULL,
+  ref jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (channel_id, id)
+);
+
+-- 3. Vector columns + indexes (gte-small dimension = 384, cosine similarity)
+ALTER TABLE public.thoughts 
+  ADD COLUMN IF NOT EXISTS embedding vector(384);
+
+ALTER TABLE public.entities 
+  ADD COLUMN IF NOT EXISTS embedding vector(384);
+
+ALTER TABLE public.observations 
+  ADD COLUMN IF NOT EXISTS embedding vector(384);
+
+-- HNSW indexes for fast ANN (best practices: create after data or use with care on large tables)
+CREATE INDEX IF NOT EXISTS thoughts_embedding_hnsw ON public.thoughts 
+  USING hnsw (embedding vector_cosine_ops);
+
+CREATE INDEX IF NOT EXISTS entities_embedding_hnsw ON public.entities 
+  USING hnsw (embedding vector_cosine_ops);
+
+CREATE INDEX IF NOT EXISTS observations_embedding_hnsw ON public.observations 
+  USING hnsw (embedding vector_cosine_ops);
+
+-- Existing tsvector for hybrid search (already present on observations)
+-- Add similar for thoughts/entities if not present (best practice for hybrid)
+ALTER TABLE public.thoughts 
+  ADD COLUMN IF NOT EXISTS content_tsv tsvector 
+  GENERATED ALWAYS AS (to_tsvector('english', coalesce(thought, ''))) STORED;
+
+CREATE INDEX IF NOT EXISTS thoughts_content_tsv ON public.thoughts USING gin (content_tsv);
+
+-- 4. pgmq queues for intelligence pipeline
+SELECT FROM pgmq.create('thought_processing');
+SELECT FROM pgmq.create('entity_processing');
+SELECT FROM pgmq.create('session_closing');
+
+-- 4a. RPC wrappers: expose pgmq.read / pgmq.archive to PostgREST for Edge Function queue workers.
+-- service_role only — Edge Functions use service role key.
+CREATE OR REPLACE FUNCTION public.pgmq_read_queue(
+  queue_name text,
+  vt integer DEFAULT 30,
+  qty integer DEFAULT 5
+)
+RETURNS SETOF pgmq.message_record
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pgmq
+AS $$
+  SELECT * FROM pgmq.read(queue_name, vt, qty);
+$$;
+
+REVOKE ALL ON FUNCTION public.pgmq_read_queue(text, integer, integer) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.pgmq_read_queue(text, integer, integer) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.pgmq_archive_queue_message(
+  queue_name text,
+  msg_id bigint
+)
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pgmq
+AS $$
+  SELECT pgmq.archive(queue_name, msg_id);
+$$;
+
+REVOKE ALL ON FUNCTION public.pgmq_archive_queue_message(text, bigint) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.pgmq_archive_queue_message(text, bigint) TO service_role;
+
+-- 5. Triggers to enqueue on INSERT (intelligence plane: "agent writes thoughts, everything else automatic")
+CREATE OR REPLACE FUNCTION public.enqueue_thought_processing()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pgmq
+AS $$
+BEGIN
+  PERFORM pgmq.send('thought_processing', jsonb_build_object('thought_id', NEW.id, 'action', 'process'));
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_thought_insert_enqueue
+  AFTER INSERT ON public.thoughts
+  FOR EACH ROW EXECUTE FUNCTION public.enqueue_thought_processing();
+
+-- Similar for entities (add as needed)
+CREATE OR REPLACE FUNCTION public.enqueue_entity_processing()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pgmq
+AS $$
+BEGIN
+  PERFORM pgmq.send('entity_processing', jsonb_build_object('entity_id', NEW.id, 'action', 'process'));
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_entity_insert_enqueue
+  AFTER INSERT ON public.entities
+  FOR EACH ROW EXECUTE FUNCTION public.enqueue_entity_processing();
+
+-- Lock down trigger functions: not callable via PostgREST RPC by anon/authenticated.
+-- service_role needs EXECUTE because it's the role inserting thoughts (triggers need caller permission).
+REVOKE ALL ON FUNCTION public.enqueue_thought_processing() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.enqueue_thought_processing() TO postgres, service_role;
+
+REVOKE ALL ON FUNCTION public.enqueue_entity_processing() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.enqueue_entity_processing() TO postgres, service_role;
+
+-- 6. RLS + policies (critical: must be in same migration as table creation)
+ALTER TABLE public.hub_agents ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.hub_workspaces ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.hub_problems ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.hub_proposals ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.hub_consensus_markers ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.hub_channels ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.hub_channel_messages ENABLE ROW LEVEL SECURITY;
+
+-- Service role full access (bypasses RLS for MCP server - matches existing SupabaseStorage pattern)
+CREATE POLICY "service_role_full_access" ON public.hub_agents FOR ALL TO service_role USING (true) WITH CHECK (true);
+CREATE POLICY "service_role_full_access" ON public.hub_workspaces FOR ALL TO service_role USING (true) WITH CHECK (true);
+CREATE POLICY "service_role_full_access" ON public.hub_problems FOR ALL TO service_role USING (true) WITH CHECK (true);
+CREATE POLICY "service_role_full_access" ON public.hub_proposals FOR ALL TO service_role USING (true) WITH CHECK (true);
+CREATE POLICY "service_role_full_access" ON public.hub_consensus_markers FOR ALL TO service_role USING (true) WITH CHECK (true);
+CREATE POLICY "service_role_full_access" ON public.hub_channels FOR ALL TO service_role USING (true) WITH CHECK (true);
+CREATE POLICY "service_role_full_access" ON public.hub_channel_messages FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- Tenant member read (matches existing workspace_member_access pattern)
+CREATE POLICY "tenant_member_read" ON public.hub_workspaces
+  FOR SELECT TO authenticated
+  USING (tenant_workspace_id IN (
+    SELECT workspace_id FROM public.workspace_memberships WHERE user_id = auth.uid()
+  ));
+
+-- Repeat similar policies for other hub tables (abbreviated for brevity - expand in full implementation)
+-- ... (similar policies for hub_problems, hub_proposals, etc.)
+
+-- 7. Realtime publication (thoughts already in publication per 20260407020000_thoughts_postgres_changes.sql)
+ALTER PUBLICATION supabase_realtime ADD TABLE hub_agents, hub_workspaces, hub_problems,
+  hub_proposals, hub_consensus_markers, hub_channels, hub_channel_messages, entities, observations;
+
+-- 8. Queue worker invocation helpers
+-- Configure Vault secrets separately, for example:
+--   SELECT vault.create_secret('https://<project-ref>.supabase.co', 'project_url');
+--   SELECT vault.create_secret('<anon-or-publishable-key>', 'anon_key');
+-- Then schedule with:
+--   SELECT public.schedule_process_thought_queue();
+
+CREATE OR REPLACE FUNCTION public.invoke_process_thought_queue_from_vault(
+  project_url_secret_name text DEFAULT 'project_url',
+  function_bearer_secret_name text DEFAULT 'anon_key',
+  body jsonb DEFAULT '{"source":"pg_cron"}'::jsonb
+)
+RETURNS bigint
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, vault, net
+AS $$
+DECLARE
+  project_url text;
+  function_bearer text;
+BEGIN
+  SELECT decrypted_secret
+  INTO project_url
+  FROM vault.decrypted_secrets
+  WHERE name = project_url_secret_name
+  LIMIT 1;
+
+  SELECT decrypted_secret
+  INTO function_bearer
+  FROM vault.decrypted_secrets
+  WHERE name = function_bearer_secret_name
+  LIMIT 1;
+
+  IF project_url IS NULL THEN
+    RAISE EXCEPTION 'Missing Vault secret for project URL: %', project_url_secret_name;
+  END IF;
+
+  IF function_bearer IS NULL THEN
+    RAISE EXCEPTION 'Missing Vault secret for function bearer token: %', function_bearer_secret_name;
+  END IF;
+
+  RETURN net.http_post(
+    url := rtrim(project_url, '/') || '/functions/v1/process-thought-queue',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'Authorization', 'Bearer ' || function_bearer
+    ),
+    body := body
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.invoke_process_thought_queue_from_vault(text, text, jsonb) FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.invoke_process_thought_queue_from_vault(text, text, jsonb) TO postgres;
+
+CREATE OR REPLACE FUNCTION public.schedule_process_thought_queue(
+  job_name text DEFAULT 'process-thought-queue-every-minute',
+  cron_expr text DEFAULT '* * * * *',
+  project_url_secret_name text DEFAULT 'project_url',
+  function_bearer_secret_name text DEFAULT 'anon_key'
+)
+RETURNS bigint
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, cron
+AS $$
+DECLARE
+  schedule_sql text;
+BEGIN
+  schedule_sql := format(
+    'SELECT public.invoke_process_thought_queue_from_vault(%L, %L, %L::jsonb);',
+    project_url_secret_name,
+    function_bearer_secret_name,
+    '{"source":"pg_cron"}'
+  );
+
+  RETURN cron.schedule(job_name, cron_expr, schedule_sql);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.schedule_process_thought_queue(text, text, text, text) FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.schedule_process_thought_queue(text, text, text, text) TO postgres;
+
+-- Indexes for performance (best practices)
+CREATE INDEX IF NOT EXISTS idx_hub_problems_workspace ON public.hub_problems(workspace_id);
+CREATE INDEX IF NOT EXISTS idx_hub_problems_tenant ON public.hub_problems(tenant_workspace_id);
+CREATE INDEX IF NOT EXISTS idx_hub_proposals_workspace ON public.hub_proposals(workspace_id);
+CREATE INDEX IF NOT EXISTS idx_hub_consensus_workspace ON public.hub_consensus_markers(workspace_id);
+CREATE INDEX IF NOT EXISTS idx_hub_channels_workspace ON public.hub_channels(workspace_id);
+CREATE INDEX IF NOT EXISTS idx_hub_channel_messages_channel ON public.hub_channel_messages(channel_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_hub_channel_messages_tenant ON public.hub_channel_messages(tenant_workspace_id);
+
+-- Update timestamps trigger (standard pattern)
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+CREATE TRIGGER update_hub_workspaces_updated_at BEFORE UPDATE ON hub_workspaces
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER update_hub_problems_updated_at BEFORE UPDATE ON hub_problems
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER update_hub_proposals_updated_at BEFORE UPDATE ON hub_proposals
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+COMMENT ON TABLE public.hub_agents IS 'Persistent agent registry for stateless Hub coordination (replaces in-memory Maps)';
+COMMENT ON TABLE public.hub_workspaces IS 'Hub workspace state for multi-agent collaboration';
+COMMENT ON TABLE public.thoughts IS 'Enhanced with embedding for semantic intelligence plane';
+
+-- Status
+SELECT 'Migration complete: Hub tables, vector columns/indexes, pgmq queues, RLS, Realtime publication, and queue scheduling helpers added.' as status;

--- a/supabase/migrations/20260408033928_add_hub_tables_vectors_pgmq_realtime.sql
+++ b/supabase/migrations/20260408033928_add_hub_tables_vectors_pgmq_realtime.sql
@@ -229,8 +229,10 @@ CREATE POLICY "tenant_member_read" ON public.hub_workspaces
     SELECT workspace_id FROM public.workspace_memberships WHERE user_id = auth.uid()
   ));
 
--- Repeat similar policies for other hub tables (abbreviated for brevity - expand in full implementation)
--- ... (similar policies for hub_problems, hub_proposals, etc.)
+-- NOTE: tenant_member_read policies for hub_problems, hub_proposals,
+-- hub_consensus_markers, hub_channels, hub_channel_messages are NOT yet defined.
+-- These tables are service-role-only until Hub frontend/authenticated access ships.
+-- Track as follow-up before exposing Hub data to non-service-role clients.
 
 -- 7. Realtime publication (thoughts already in publication per 20260407020000_thoughts_postgres_changes.sql)
 ALTER PUBLICATION supabase_realtime ADD TABLE hub_agents, hub_workspaces, hub_problems,

--- a/supabase/migrations/20260408033928_add_hub_tables_vectors_pgmq_realtime.sql
+++ b/supabase/migrations/20260408033928_add_hub_tables_vectors_pgmq_realtime.sql
@@ -242,6 +242,13 @@ ALTER PUBLICATION supabase_realtime ADD TABLE hub_agents, hub_workspaces, hub_pr
 --   SELECT vault.create_secret('<anon-or-publishable-key>', 'anon_key');
 -- Then schedule with:
 --   SELECT public.schedule_process_thought_queue();
+--
+-- IMPORTANT: if CRON_SECRET is set on the process-thought-queue function,
+-- store that secret in Vault under a separate name and pass it here:
+--   SELECT public.schedule_process_thought_queue(
+--     function_bearer_secret_name := 'cron_secret'
+--   );
+-- The default 'anon_key' only satisfies Supabase gateway auth, not CRON_SECRET.
 
 CREATE OR REPLACE FUNCTION public.invoke_process_thought_queue_from_vault(
   project_url_secret_name text DEFAULT 'project_url',

--- a/supabase/migrations/20260408145447_add_branches_table.sql
+++ b/supabase/migrations/20260408145447_add_branches_table.sql
@@ -27,6 +27,9 @@ ALTER TABLE public.branches ENABLE ROW LEVEL SECURITY;
 CREATE POLICY "service_role_full_access" ON public.branches
   FOR ALL TO service_role USING (true) WITH CHECK (true);
 
+COMMENT ON TABLE public.branches IS
+  'Branch metadata is currently service-role-only; authenticated clients read branch state through the backend API.';
+
 -- 3. Partial unique indexes on thoughts for branch-scoped numbering
 -- Main track: unique thought number per session (where no branch)
 CREATE UNIQUE INDEX IF NOT EXISTS thoughts_main_track_unique

--- a/supabase/migrations/20260408145447_add_branches_table.sql
+++ b/supabase/migrations/20260408145447_add_branches_table.sql
@@ -1,0 +1,71 @@
+-- Migration: Add branches table for parallel branch exploration
+-- Supports SPEC-BRANCH-WORKERS.md: edge function branch workers with spawn/merge lifecycle
+
+-- 1. Branches table
+CREATE TABLE IF NOT EXISTS public.branches (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  session_id uuid NOT NULL REFERENCES public.sessions(id) ON DELETE CASCADE,
+  workspace_id uuid NOT NULL REFERENCES public.workspaces(id),
+  branch_id text NOT NULL,
+  description text,
+  branch_from_thought integer NOT NULL,
+  status text NOT NULL DEFAULT 'active'
+    CHECK (status IN ('active', 'completed', 'merged', 'rejected', 'abandoned')),
+  spawned_at timestamptz NOT NULL DEFAULT now(),
+  completed_at timestamptz,
+  merge_thought_number integer,
+  created_by text,
+  UNIQUE(session_id, branch_id)
+);
+
+CREATE INDEX idx_branches_session ON public.branches(session_id);
+CREATE INDEX idx_branches_workspace ON public.branches(workspace_id);
+
+-- 2. RLS
+ALTER TABLE public.branches ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "service_role_full_access" ON public.branches
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- 3. Partial unique indexes on thoughts for branch-scoped numbering
+-- Main track: unique thought number per session (where no branch)
+CREATE UNIQUE INDEX IF NOT EXISTS thoughts_main_track_unique
+  ON public.thoughts(session_id, thought_number)
+  WHERE branch_id IS NULL;
+
+-- Per branch: unique thought number per session + branch
+CREATE UNIQUE INDEX IF NOT EXISTS thoughts_branch_unique
+  ON public.thoughts(session_id, branch_id, thought_number)
+  WHERE branch_id IS NOT NULL;
+
+-- 4. Auto-complete branch when final thought is written
+CREATE OR REPLACE FUNCTION public.auto_complete_branch()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF NEW.branch_id IS NOT NULL AND NEW.next_thought_needed = false THEN
+    UPDATE public.branches
+    SET status = 'completed', completed_at = now()
+    WHERE session_id = NEW.session_id
+      AND branch_id = NEW.branch_id
+      AND status = 'active';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.auto_complete_branch() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.auto_complete_branch() TO postgres, service_role;
+
+CREATE TRIGGER trg_auto_complete_branch
+  AFTER INSERT ON public.thoughts
+  FOR EACH ROW
+  EXECUTE FUNCTION public.auto_complete_branch();
+
+-- 5. Realtime
+ALTER PUBLICATION supabase_realtime ADD TABLE public.branches;
+
+SELECT 'Migration complete: branches table, scoped numbering indexes, auto-complete trigger.' as status;


### PR DESCRIPTION
## Summary

- **Intelligence pipeline**: pgmq-based queue processing for thoughts. Insert triggers enqueue, edge function worker processes and archives. No mock embeddings — real provider slot left as TODO.
- **Branch module**: 4 operations on main MCP — `spawn` (returns edge function worker URL), `merge` (records synthesis thought, updates branch statuses), `list`, `get`. Wired into Code Mode SDK as `tb.branch.*`.
- **Branch worker edge function**: Stateless MCP JSON-RPC server on Supabase Edge Functions. Writes branch-scoped thoughts directly to Postgres with independent numbering. Eliminates the ThoughtHandler singleton concurrency problem for parallel branch exploration.
- **Schema**: branches table with lifecycle tracking (active → completed → merged/rejected/abandoned), auto-complete trigger, partial unique indexes for scoped numbering.
- **Migration**: hub tables, pgmq queues, vector columns, RLS, Realtime publication, SECURITY DEFINER functions with correct Supabase role grants.

## Architecture

```
Parent Agent → tb.branch.spawn() → returns edge function URL
  ├─ Subagent A → tb-branch/mcp?branch=approach-a → writes to Postgres
  ├─ Subagent B → tb-branch/mcp?branch=approach-b → writes to Postgres
  └─ Subagent C → tb-branch/mcp?branch=approach-c → writes to Postgres
Parent Agent → tb.branch.merge() → synthesis thought + status updates
```

## Test plan

- [x] `tsc --noEmit` passes
- [x] `oxlint` clean
- [x] 6 intelligence pipeline integration tests pass (insert → enqueue → worker → archive)
- [x] `supabase db reset` applies both migrations cleanly
- [ ] Post-deploy: full convergence E2E (spawn 3 branches → parallel writes → merge with selection)
- [ ] Post-deploy: `supabase functions deploy tb-branch` and `process-thought-queue`

🤖 Generated with [Claude Code](https://claude.com/claude-code)