### PR TITLE
fix(observability,ulysses): timeline params and status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,4 @@ thoughtbox-web-two/
 
 
 .specs/channel-daemon/chatgpt01.md
+rlm-code/

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -81,8 +81,10 @@ async () => tb.observability({
 // Chronological event timeline
 async () => tb.observability({
   operation: "session_timeline",
-  sessionId: "session-uuid",
-  limit: 50
+  args: {
+    sessionId: "session-uuid",
+    limit: 50
+  }
 })
 ```
 

--- a/src/observability/operations.ts
+++ b/src/observability/operations.ts
@@ -96,8 +96,10 @@ export const OBSERVABILITY_OPERATIONS: OperationDefinition[] = [
       required: ["sessionId"],
     },
     example: {
-      sessionId: "abc-123-def-456",
-      limit: 100,
+      args: {
+        sessionId: "abc-123-def-456",
+        limit: 100,
+      },
     },
   },
   {

--- a/src/protocol/handler.ts
+++ b/src/protocol/handler.ts
@@ -776,7 +776,21 @@ export class ProtocolHandler {
   async ulyssesStatus(): Promise<Record<string, unknown>> {
     const session = await this.getActiveSession('ulysses');
     if (!session) {
-      return { active: false, protocol: 'ulysses' };
+      // Fetch most recent completed session for context
+      const { data: last } = await this.client
+        .from('protocol_sessions')
+        .select('id, status, completed_at')
+        .eq('protocol', 'ulysses')
+        .neq('status', 'active')
+        .order('completed_at', { ascending: false })
+        .limit(1)
+        .maybeSingle();
+
+      return {
+        active: false,
+        protocol: 'ulysses',
+        ...(last ? { last_session: { session_id: last.id, status: last.status, completed_at: last.completed_at } } : {}),
+      };
     }
 
     const state = session.state_json as {

--- a/src/protocol/in-memory-handler.ts
+++ b/src/protocol/in-memory-handler.ts
@@ -528,7 +528,14 @@ export class InMemoryProtocolHandler {
   async ulyssesStatus(): Promise<Record<string, unknown>> {
     const session = this.getActiveSession('ulysses');
     if (!session) {
-      return { active: false, protocol: 'ulysses' };
+      const last = this.sessions
+        .filter(s => s.protocol === 'ulysses' && s.status !== 'active')
+        .sort((a, b) => (b.completed_at ?? '').localeCompare(a.completed_at ?? ''))[0];
+      return {
+        active: false,
+        protocol: 'ulysses',
+        ...(last ? { last_session: { session_id: last.id, status: last.status, completed_at: last.completed_at } } : {}),
+      };
     }
     const state = session.state_json as {
       S: number;

--- a/src/protocol/ulysses-tool.ts
+++ b/src/protocol/ulysses-tool.ts
@@ -112,9 +112,6 @@ export class UlyssesTool {
       }
       case "status": {
         result = await this.handler.ulyssesStatus();
-        if (result.session_id) {
-          this.activeSessionId = result.session_id as string;
-        }
         break;
       }
       case "complete": {


### PR DESCRIPTION
## Summary

Fixes two documentation-vs-reality gaps found on the current branch:

1. **session_timeline SDK param nesting** — docs showed flat params but schema requires nested `args`
2. **Ulysses status after complete** — no way to distinguish "never started" from "recently completed"

## Changes

- Fix `docs/guides/observability.md` example: `sessionId` must nest under `args` key
- Fix `src/observability/operations.ts` catalog example: use nested `args` structure
- Enhance `ulyssesStatus()` in both `handler.ts` and `in-memory-handler.ts`:
  - When no active session: query most recent completed session for context
  - Return `last_session` info with status and timestamp
  - Distinguishes between "never started" and "recently completed"
- Remove `activeSessionId` repopulation in `ulysses-tool.ts` status case:
  - `status()` is read-only, must not hijack tool's session ownership
  - Only `init()` can set `activeSessionId` to prevent session ID theft
- Add `rlm-code/` to `.gitignore`

## Test plan

- Call `tb.observability({ operation: "session_timeline", args: { sessionId: "<id>", limit: 10 } })` — expect timeline data
- Run Ulysses flow: `init` → `plan` → `outcome` → `complete` → `status`
  - Expect `{ active: false, last_session: { status: "resolved", ... } }` after complete
- Verify `requireSession()` still throws if this tool instance never called `init`
- Run protocol tests to confirm no regressions

🤖 Generated with Claude Code