### PR TITLE
fix(supabase): trim ship migration scope

### DIFF
--- a/src/__tests__/intelligence-pipeline.test.ts
+++ b/src/__tests__/intelligence-pipeline.test.ts
@@ -28,12 +28,12 @@ describe('Intelligence Pipeline', () => {
   });
 
   describe('Migration validation', () => {
-    it('thoughts table has embedding column', async () => {
+    it('thoughts table remains writable without embedding columns', async () => {
       if (!available) return expect(true).toBe(true); // skip gracefully
       const client = createServiceClient();
-      const { data, error } = await client
+      const { error } = await client
         .from('thoughts')
-        .select('embedding')
+        .select('id')
         .limit(0);
       expect(error).toBeNull();
     });

--- a/supabase/functions/process-thought-queue/index.ts
+++ b/supabase/functions/process-thought-queue/index.ts
@@ -4,13 +4,11 @@
  * NOT an MCP surface — invoke only from cron, pg_net, or internal automation (see SUPABASE-INTELLIGENCE.md).
  *
  * Prerequisites:
- * - Migration 20260408033928_add_hub_tables_vectors_pgmq_realtime.sql applied (queue + thoughts.embedding).
+ * - Migration 20260408033928_add_hub_tables_vectors_pgmq_realtime.sql applied (queue + trigger + RPC wrappers).
  * - RPC wrappers in same migration: pgmq_read_queue, pgmq_archive_queue_message.
  *
- * Embeddings: NOT generated here. The embedding column exists on thoughts but is populated
- * only when a real embedding provider is wired (external API or Cloud Run worker).
  * This worker processes the queue, broadcasts a Realtime event, and archives the message.
- * Embedding generation can be added as a step in processOneMessage when ready.
+ * Embedding generation can be added later as a separate step when the ship scope expands.
  *
  * Env:
  * - SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY (auto in hosted Edge)
@@ -36,7 +34,6 @@ type ThoughtRow = {
   workspace_id: string;
   session_id: string;
   thought: string;
-  embedding: string | null;
 };
 
 function assertAuthorized(req: Request): void {
@@ -122,7 +119,7 @@ async function processOneMessage(
 
   const { data: thought, error: fetchErr } = await supabase
     .from("thoughts")
-    .select("id, workspace_id, session_id, thought, embedding")
+    .select("id, workspace_id, session_id, thought")
     .eq("id", thoughtId)
     .maybeSingle();
 
@@ -141,15 +138,9 @@ async function processOneMessage(
   const t = thought as ThoughtRow;
 
   try {
-    // TODO: Wire real embedding provider here.
-    // When ready, generate embedding and write to thoughts.embedding:
-    //   const vec = await generateEmbedding(t.thought);
-    //   await supabase.from("thoughts").update({ embedding: vec }).eq("id", t.id);
-
     await broadcastProcessingEvent(supabase, t.workspace_id, {
       thought_id: t.id,
       session_id: t.session_id,
-      has_embedding: t.embedding != null,
       msg_id: msgId,
     });
 

--- a/supabase/migrations/20260408033928_add_hub_tables_vectors_pgmq_realtime.sql
+++ b/supabase/migrations/20260408033928_add_hub_tables_vectors_pgmq_realtime.sql
@@ -1,136 +1,18 @@
--- Migration: Add hub tables, vector foundations, pgmq queues, and Realtime for Supabase Intelligence Plane
--- Layer 2 + initial intelligence (follows .specs/hub-deployed/SCOPE-LAYER-2-SUPABASE-HUB-STORAGE.md exactly)
--- Follows supabase-postgres-best-practices: indexes on FKs/join columns, RLS in same migration, HNSW for vectors, service_role bypass
+-- Migration: Add pgmq-based intelligence pipeline foundations for branch release
+-- Ship scope: keep processing queues and worker invocation helpers; defer hub and embeddings.
 
--- 1. Enable extensions (if not already)
-CREATE EXTENSION IF NOT EXISTS vector;
+-- 1. Enable extensions required for queue processing and scheduled worker invocation.
 CREATE EXTENSION IF NOT EXISTS pgmq;
 CREATE EXTENSION IF NOT EXISTS pg_cron;
 CREATE EXTENSION IF NOT EXISTS pg_net;
 
--- 2. Hub tables (exact match to Layer 2 spec)
-CREATE TABLE IF NOT EXISTS public.hub_agents (
-  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  agent_id text UNIQUE NOT NULL,
-  name text NOT NULL,
-  role text NOT NULL DEFAULT 'contributor' CHECK (role IN ('coordinator', 'contributor')),
-  profile text,
-  client_info text,
-  registered_at timestamptz NOT NULL DEFAULT now()
-);
-
-CREATE TABLE IF NOT EXISTS public.hub_workspaces (
-  id text PRIMARY KEY,
-  tenant_workspace_id uuid NOT NULL REFERENCES public.workspaces(id),
-  name text NOT NULL,
-  description text NOT NULL DEFAULT '',
-  created_by text NOT NULL REFERENCES public.hub_agents(agent_id),
-  main_session_id text,
-  agents jsonb NOT NULL DEFAULT '[]',
-  created_at timestamptz NOT NULL DEFAULT now(),
-  updated_at timestamptz NOT NULL DEFAULT now()
-);
-
-CREATE TABLE IF NOT EXISTS public.hub_problems (
-  id text PRIMARY KEY,
-  workspace_id text NOT NULL REFERENCES public.hub_workspaces(id),
-  tenant_workspace_id uuid NOT NULL REFERENCES public.workspaces(id),
-  title text NOT NULL,
-  description text NOT NULL DEFAULT '',
-  created_by text NOT NULL,
-  assigned_to text REFERENCES public.hub_agents(agent_id),
-  status text NOT NULL DEFAULT 'open',
-  branch_id text,
-  branch_from_thought integer,
-  resolution text,
-  depends_on jsonb NOT NULL DEFAULT '[]',
-  parent_id text REFERENCES public.hub_problems(id),
-  comments jsonb NOT NULL DEFAULT '[]',
-  created_at timestamptz NOT NULL DEFAULT now(),
-  updated_at timestamptz NOT NULL DEFAULT now()
-);
-
-CREATE TABLE IF NOT EXISTS public.hub_proposals (
-  id text PRIMARY KEY,
-  workspace_id text NOT NULL REFERENCES public.hub_workspaces(id),
-  tenant_workspace_id uuid NOT NULL REFERENCES public.workspaces(id),
-  title text NOT NULL,
-  description text NOT NULL DEFAULT '',
-  created_by text NOT NULL,
-  source_branch text NOT NULL DEFAULT '',
-  problem_id text REFERENCES public.hub_problems(id),
-  status text NOT NULL DEFAULT 'open',
-  reviews jsonb NOT NULL DEFAULT '[]',
-  merge_thought_number integer,
-  created_at timestamptz NOT NULL DEFAULT now(),
-  updated_at timestamptz NOT NULL DEFAULT now()
-);
-
-CREATE TABLE IF NOT EXISTS public.hub_consensus_markers (
-  id text PRIMARY KEY,
-  workspace_id text NOT NULL REFERENCES public.hub_workspaces(id),
-  tenant_workspace_id uuid NOT NULL REFERENCES public.workspaces(id),
-  name text NOT NULL,
-  description text NOT NULL DEFAULT '',
-  thought_ref integer NOT NULL,
-  branch_id text,
-  agreed_by jsonb NOT NULL DEFAULT '[]',
-  created_at timestamptz NOT NULL DEFAULT now()
-);
-
-CREATE TABLE IF NOT EXISTS public.hub_channels (
-  id text PRIMARY KEY,
-  workspace_id text NOT NULL REFERENCES public.hub_workspaces(id),
-  tenant_workspace_id uuid NOT NULL REFERENCES public.workspaces(id),
-  problem_id text NOT NULL REFERENCES public.hub_problems(id)
-);
-
-CREATE TABLE IF NOT EXISTS public.hub_channel_messages (
-  id text NOT NULL,
-  channel_id text NOT NULL REFERENCES public.hub_channels(id),
-  tenant_workspace_id uuid NOT NULL REFERENCES public.workspaces(id),
-  agent_id text NOT NULL REFERENCES public.hub_agents(agent_id),
-  content text NOT NULL,
-  ref jsonb,
-  created_at timestamptz NOT NULL DEFAULT now(),
-  PRIMARY KEY (channel_id, id)
-);
-
--- 3. Vector columns + indexes (gte-small dimension = 384, cosine similarity)
-ALTER TABLE public.thoughts 
-  ADD COLUMN IF NOT EXISTS embedding vector(384);
-
-ALTER TABLE public.entities 
-  ADD COLUMN IF NOT EXISTS embedding vector(384);
-
-ALTER TABLE public.observations 
-  ADD COLUMN IF NOT EXISTS embedding vector(384);
-
--- HNSW indexes for fast ANN (best practices: create after data or use with care on large tables)
-CREATE INDEX IF NOT EXISTS thoughts_embedding_hnsw ON public.thoughts 
-  USING hnsw (embedding vector_cosine_ops);
-
-CREATE INDEX IF NOT EXISTS entities_embedding_hnsw ON public.entities 
-  USING hnsw (embedding vector_cosine_ops);
-
-CREATE INDEX IF NOT EXISTS observations_embedding_hnsw ON public.observations 
-  USING hnsw (embedding vector_cosine_ops);
-
--- Existing tsvector for hybrid search (already present on observations)
--- Add similar for thoughts/entities if not present (best practice for hybrid)
-ALTER TABLE public.thoughts 
-  ADD COLUMN IF NOT EXISTS content_tsv tsvector 
-  GENERATED ALWAYS AS (to_tsvector('english', coalesce(thought, ''))) STORED;
-
-CREATE INDEX IF NOT EXISTS thoughts_content_tsv ON public.thoughts USING gin (content_tsv);
-
--- 4. pgmq queues for intelligence pipeline
+-- 2. pgmq queues for intelligence pipeline.
 SELECT FROM pgmq.create('thought_processing');
 SELECT FROM pgmq.create('entity_processing');
 SELECT FROM pgmq.create('session_closing');
 
--- 4a. RPC wrappers: expose pgmq.read / pgmq.archive to PostgREST for Edge Function queue workers.
--- service_role only — Edge Functions use service role key.
+-- 3. RPC wrappers: expose pgmq.read / pgmq.archive to PostgREST for Edge Function queue workers.
+-- service_role only — Edge Functions use the service role key.
 CREATE OR REPLACE FUNCTION public.pgmq_read_queue(
   queue_name text,
   vt integer DEFAULT 30,
@@ -162,7 +44,7 @@ $$;
 REVOKE ALL ON FUNCTION public.pgmq_archive_queue_message(text, bigint) FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION public.pgmq_archive_queue_message(text, bigint) TO service_role;
 
--- 5. Triggers to enqueue on INSERT (intelligence plane: "agent writes thoughts, everything else automatic")
+-- 4. Triggers to enqueue work after writes.
 CREATE OR REPLACE FUNCTION public.enqueue_thought_processing()
 RETURNS trigger
 LANGUAGE plpgsql
@@ -175,11 +57,11 @@ BEGIN
 END;
 $$;
 
+DROP TRIGGER IF EXISTS trg_thought_insert_enqueue ON public.thoughts;
 CREATE TRIGGER trg_thought_insert_enqueue
   AFTER INSERT ON public.thoughts
   FOR EACH ROW EXECUTE FUNCTION public.enqueue_thought_processing();
 
--- Similar for entities (add as needed)
 CREATE OR REPLACE FUNCTION public.enqueue_entity_processing()
 RETURNS trigger
 LANGUAGE plpgsql
@@ -192,53 +74,18 @@ BEGIN
 END;
 $$;
 
+DROP TRIGGER IF EXISTS trg_entity_insert_enqueue ON public.entities;
 CREATE TRIGGER trg_entity_insert_enqueue
   AFTER INSERT ON public.entities
   FOR EACH ROW EXECUTE FUNCTION public.enqueue_entity_processing();
 
--- Lock down trigger functions: not callable via PostgREST RPC by anon/authenticated.
--- service_role needs EXECUTE because it's the role inserting thoughts (triggers need caller permission).
 REVOKE ALL ON FUNCTION public.enqueue_thought_processing() FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION public.enqueue_thought_processing() TO postgres, service_role;
 
 REVOKE ALL ON FUNCTION public.enqueue_entity_processing() FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION public.enqueue_entity_processing() TO postgres, service_role;
 
--- 6. RLS + policies (critical: must be in same migration as table creation)
-ALTER TABLE public.hub_agents ENABLE ROW LEVEL SECURITY;
-ALTER TABLE public.hub_workspaces ENABLE ROW LEVEL SECURITY;
-ALTER TABLE public.hub_problems ENABLE ROW LEVEL SECURITY;
-ALTER TABLE public.hub_proposals ENABLE ROW LEVEL SECURITY;
-ALTER TABLE public.hub_consensus_markers ENABLE ROW LEVEL SECURITY;
-ALTER TABLE public.hub_channels ENABLE ROW LEVEL SECURITY;
-ALTER TABLE public.hub_channel_messages ENABLE ROW LEVEL SECURITY;
-
--- Service role full access (bypasses RLS for MCP server - matches existing SupabaseStorage pattern)
-CREATE POLICY "service_role_full_access" ON public.hub_agents FOR ALL TO service_role USING (true) WITH CHECK (true);
-CREATE POLICY "service_role_full_access" ON public.hub_workspaces FOR ALL TO service_role USING (true) WITH CHECK (true);
-CREATE POLICY "service_role_full_access" ON public.hub_problems FOR ALL TO service_role USING (true) WITH CHECK (true);
-CREATE POLICY "service_role_full_access" ON public.hub_proposals FOR ALL TO service_role USING (true) WITH CHECK (true);
-CREATE POLICY "service_role_full_access" ON public.hub_consensus_markers FOR ALL TO service_role USING (true) WITH CHECK (true);
-CREATE POLICY "service_role_full_access" ON public.hub_channels FOR ALL TO service_role USING (true) WITH CHECK (true);
-CREATE POLICY "service_role_full_access" ON public.hub_channel_messages FOR ALL TO service_role USING (true) WITH CHECK (true);
-
--- Tenant member read (matches existing workspace_member_access pattern)
-CREATE POLICY "tenant_member_read" ON public.hub_workspaces
-  FOR SELECT TO authenticated
-  USING (tenant_workspace_id IN (
-    SELECT workspace_id FROM public.workspace_memberships WHERE user_id = auth.uid()
-  ));
-
--- NOTE: tenant_member_read policies for hub_problems, hub_proposals,
--- hub_consensus_markers, hub_channels, hub_channel_messages are NOT yet defined.
--- These tables are service-role-only until Hub frontend/authenticated access ships.
--- Track as follow-up before exposing Hub data to non-service-role clients.
-
--- 7. Realtime publication (thoughts already in publication per 20260407020000_thoughts_postgres_changes.sql)
-ALTER PUBLICATION supabase_realtime ADD TABLE hub_agents, hub_workspaces, hub_problems,
-  hub_proposals, hub_consensus_markers, hub_channels, hub_channel_messages, entities, observations;
-
--- 8. Queue worker invocation helpers
+-- 5. Queue worker invocation helpers.
 -- Configure Vault secrets separately, for example:
 --   SELECT vault.create_secret('https://<project-ref>.supabase.co', 'project_url');
 --   SELECT vault.create_secret('<anon-or-publishable-key>', 'anon_key');
@@ -251,7 +98,6 @@ ALTER PUBLICATION supabase_realtime ADD TABLE hub_agents, hub_workspaces, hub_pr
 --     function_bearer_secret_name := 'cron_secret'
 --   );
 -- The default 'anon_key' only satisfies Supabase gateway auth, not CRON_SECRET.
-
 CREATE OR REPLACE FUNCTION public.invoke_process_thought_queue_from_vault(
   project_url_secret_name text DEFAULT 'project_url',
   function_bearer_secret_name text DEFAULT 'anon_key',
@@ -328,36 +174,4 @@ $$;
 REVOKE ALL ON FUNCTION public.schedule_process_thought_queue(text, text, text, text) FROM PUBLIC, anon, authenticated, service_role;
 GRANT EXECUTE ON FUNCTION public.schedule_process_thought_queue(text, text, text, text) TO postgres;
 
--- Indexes for performance (best practices)
-CREATE INDEX IF NOT EXISTS idx_hub_problems_workspace ON public.hub_problems(workspace_id);
-CREATE INDEX IF NOT EXISTS idx_hub_problems_tenant ON public.hub_problems(tenant_workspace_id);
-CREATE INDEX IF NOT EXISTS idx_hub_proposals_workspace ON public.hub_proposals(workspace_id);
-CREATE INDEX IF NOT EXISTS idx_hub_consensus_workspace ON public.hub_consensus_markers(workspace_id);
-CREATE INDEX IF NOT EXISTS idx_hub_channels_workspace ON public.hub_channels(workspace_id);
-CREATE INDEX IF NOT EXISTS idx_hub_channel_messages_channel ON public.hub_channel_messages(channel_id, created_at);
-CREATE INDEX IF NOT EXISTS idx_hub_channel_messages_tenant ON public.hub_channel_messages(tenant_workspace_id);
-
--- Update timestamps trigger (standard pattern)
-CREATE OR REPLACE FUNCTION update_updated_at_column()
-RETURNS TRIGGER AS $$
-BEGIN
-  NEW.updated_at = now();
-  RETURN NEW;
-END;
-$$ language 'plpgsql';
-
-CREATE TRIGGER update_hub_workspaces_updated_at BEFORE UPDATE ON hub_workspaces
-  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
-
-CREATE TRIGGER update_hub_problems_updated_at BEFORE UPDATE ON hub_problems
-  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
-
-CREATE TRIGGER update_hub_proposals_updated_at BEFORE UPDATE ON hub_proposals
-  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
-
-COMMENT ON TABLE public.hub_agents IS 'Persistent agent registry for stateless Hub coordination (replaces in-memory Maps)';
-COMMENT ON TABLE public.hub_workspaces IS 'Hub workspace state for multi-agent collaboration';
-COMMENT ON TABLE public.thoughts IS 'Enhanced with embedding for semantic intelligence plane';
-
--- Status
-SELECT 'Migration complete: Hub tables, vector columns/indexes, pgmq queues, RLS, Realtime publication, and queue scheduling helpers added.' as status;
+SELECT 'Migration complete: pgmq queues, enqueue triggers, and queue worker invocation helpers added.' as status;


### PR DESCRIPTION
## Summary
Reduce the pending Supabase release scope to the branch ship path that is actually intended.
Keep the pgmq-based processing pipeline and branch-worker migration, while removing hub and embedding work from `20260408033928`.
Align the `process-thought-queue` worker and intelligence pipeline test with the no-embeddings release scope.

## Test plan
- `pnpm check:cycles`
- `pnpm check:lint`
- `pnpm vitest run src/__tests__/intelligence-pipeline.test.ts` (currently fails locally because the local Supabase runtime has not been rebuilt/reapplied against the rewritten migration)


Made with [Cursor](https://cursor.com)