### PR TITLE
fix: pre-ship audit bug fixes

### DIFF
--- a/src/code-mode/execute-tool.ts
+++ b/src/code-mode/execute-tool.ts
@@ -95,6 +95,36 @@ function unwrapToolResult(raw: unknown): unknown {
   }
 }
 
+/**
+ * Flatten notebook handler responses.
+ * Handlers return { success, notebook/cell/cells/content/execution: ... }.
+ * SDK consumers expect the inner value directly with `id` at top level.
+ */
+function flattenNotebookResult(raw: unknown): unknown {
+  if (!raw || typeof raw !== "object") return raw;
+  const obj = raw as Record<string, unknown>;
+  if (obj.notebook && typeof obj.notebook === "object") {
+    return obj.notebook;
+  }
+  if (obj.cell && typeof obj.cell === "object") {
+    return obj.cell;
+  }
+  return raw;
+}
+
+/**
+ * Normalize knowledge entity responses so `id` is always present.
+ * Handlers return `entity_id`; SDK consumers expect `id`.
+ */
+function normalizeEntityResult(raw: unknown): unknown {
+  if (!raw || typeof raw !== "object") return raw;
+  const obj = raw as Record<string, unknown>;
+  if (obj.entity_id && !obj.id) {
+    return { id: obj.entity_id, ...obj };
+  }
+  return raw;
+}
+
 interface TbContext {
   sessionId?: string;
 }
@@ -137,13 +167,13 @@ function buildTbObject(deps: ExecuteToolDeps, ctx: TbContext): Record<string, un
 
     knowledge: {
       createEntity: async (args: Record<string, unknown>) =>
-        unwrapToolResult(await knowledgeTool.handle({
+        normalizeEntityResult(unwrapToolResult(await knowledgeTool.handle({
           operation: "knowledge_create_entity", ...args,
-        } as KnowledgeToolInput)),
+        } as KnowledgeToolInput))),
       getEntity: async (entityId: string) =>
-        unwrapToolResult(await knowledgeTool.handle({
+        normalizeEntityResult(unwrapToolResult(await knowledgeTool.handle({
           operation: "knowledge_get_entity", entity_id: entityId,
-        } as KnowledgeToolInput)),
+        } as KnowledgeToolInput))),
       listEntities: async (args?: Record<string, unknown>) =>
         unwrapToolResult(await knowledgeTool.handle({
           operation: "knowledge_list_entities", ...args,
@@ -168,25 +198,25 @@ function buildTbObject(deps: ExecuteToolDeps, ctx: TbContext): Record<string, un
 
     notebook: {
       create: async (args: Record<string, unknown>) =>
-        unwrapToolResult(await notebookTool.handle({
+        flattenNotebookResult(unwrapToolResult(await notebookTool.handle({
           operation: "notebook_create", ...args,
-        } as NotebookToolInput)),
+        } as NotebookToolInput))),
       list: async () =>
         unwrapToolResult(await notebookTool.handle({
           operation: "notebook_list",
         } as NotebookToolInput)),
       load: async (args: Record<string, unknown>) =>
-        unwrapToolResult(await notebookTool.handle({
+        flattenNotebookResult(unwrapToolResult(await notebookTool.handle({
           operation: "notebook_load", ...args,
-        } as NotebookToolInput)),
+        } as NotebookToolInput))),
       addCell: async (args: Record<string, unknown>) =>
-        unwrapToolResult(await notebookTool.handle({
+        flattenNotebookResult(unwrapToolResult(await notebookTool.handle({
           operation: "notebook_add_cell", ...args,
-        } as NotebookToolInput)),
+        } as NotebookToolInput))),
       updateCell: async (args: Record<string, unknown>) =>
-        unwrapToolResult(await notebookTool.handle({
+        flattenNotebookResult(unwrapToolResult(await notebookTool.handle({
           operation: "notebook_update_cell", ...args,
-        } as NotebookToolInput)),
+        } as NotebookToolInput))),
       runCell: async (args: Record<string, unknown>) =>
         unwrapToolResult(await notebookTool.handle({
           operation: "notebook_run_cell", ...args,
@@ -277,30 +307,38 @@ export class ExecuteTool {
 
     let output: CodeModeResult;
     try {
-      const script = new vm.Script(`(${input.code})()`, {
+      // Serialize the result inside the vm to avoid cross-realm object
+      // issues where host JSON.stringify can silently return undefined
+      // for complex objects created inside the sandbox.
+      const script = new vm.Script(`
+        Promise.resolve((${input.code})()).then(
+          r => JSON.stringify(r),
+          e => { throw e; }
+        )
+      `, {
         filename: "codemode-exec.js",
       });
 
       // vm.Script timeout only covers synchronous execution.
       // Promise.race adds a wall-clock timeout for async operations.
       const rawResult = script.runInContext(context, { timeout: TIMEOUT_MS });
-      const result = await Promise.race([
+      const serialized: string = await Promise.race([
         rawResult,
-        new Promise((_, reject) =>
+        new Promise<string>((_, reject) =>
           setTimeout(() => reject(new Error("Execution timed out")), TIMEOUT_MS)
         ),
-      ]);
+      ]) as string;
 
       const durationMs = Date.now() - start;
-      let serialized = JSON.stringify(result, null, 2) ?? "null";
+      let resultJson = serialized ?? "null";
       let truncated = false;
-      if (serialized.length > MAX_RESULT_BYTES) {
-        serialized = serialized.slice(0, MAX_RESULT_BYTES) + "\n... [truncated]";
+      if (resultJson.length > MAX_RESULT_BYTES) {
+        resultJson = resultJson.slice(0, MAX_RESULT_BYTES) + "\n... [truncated]";
         truncated = true;
       }
 
       output = {
-        result: truncated ? serialized : JSON.parse(serialized),
+        result: truncated ? resultJson : JSON.parse(resultJson),
         logs,
         truncated: truncated || undefined,
         durationMs,

--- a/src/code-mode/search-tool.ts
+++ b/src/code-mode/search-tool.ts
@@ -97,30 +97,36 @@ export class SearchTool {
 
     let output: CodeModeResult;
     try {
+      // Serialize the result inside the vm to avoid cross-realm object
+      // issues where host JSON.stringify silently returns undefined for
+      // complex objects created inside the sandbox.
       const script = new vm.Script(`
         const catalog = Object.freeze(JSON.parse(__catalogJson));
-        (${input.code})()
+        Promise.resolve((${input.code})()).then(
+          r => JSON.stringify(r),
+          e => { throw e; }
+        )
       `, {
         filename: "codemode-search.js",
       });
       const rawResult = script.runInContext(context, { timeout: TIMEOUT_MS });
-      const result = await Promise.race([
+      const serialized: string = await Promise.race([
         rawResult,
-        new Promise((_, reject) =>
+        new Promise<string>((_, reject) =>
           setTimeout(() => reject(new Error("Search execution timed out")), TIMEOUT_MS)
         ),
-      ]);
+      ]) as string;
 
       const durationMs = Date.now() - start;
-      let serialized = JSON.stringify(result, null, 2);
+      let resultJson = serialized ?? "null";
       let truncated = false;
-      if (serialized && serialized.length > MAX_RESULT_BYTES) {
-        serialized = serialized.slice(0, MAX_RESULT_BYTES) + "\n... [truncated]";
+      if (resultJson.length > MAX_RESULT_BYTES) {
+        resultJson = resultJson.slice(0, MAX_RESULT_BYTES) + "\n... [truncated]";
         truncated = true;
       }
 
       output = {
-        result: truncated ? serialized : JSON.parse(serialized ?? "null"),
+        result: truncated ? resultJson : JSON.parse(resultJson),
         logs,
         truncated: truncated || undefined,
         durationMs,

--- a/src/observability/gateway-handler.ts
+++ b/src/observability/gateway-handler.ts
@@ -33,12 +33,26 @@ export const ObservabilityArgsSchema = z.object({
   model: z.string().optional(),
 }).optional();
 
+/**
+ * Accept both nested `{ operation, args: { sessionId } }` and flat
+ * `{ operation, sessionId }` calling conventions. Flat params are
+ * merged into args so handlers always receive a consistent shape.
+ */
 export const ObservabilityInputSchema = z.object({
   operation: ObservabilityOperationSchema,
   args: ObservabilityArgsSchema,
+  sessionId: z.string().optional(),
+  limit: z.number().optional(),
+  status: z.enum(['active', 'idle', 'all']).optional(),
+  services: z.array(z.string()).optional(),
+  model: z.string().optional(),
+}).transform((val) => {
+  const { operation, args, ...flatParams } = val;
+  const merged = { ...flatParams, ...args };
+  return { operation, args: Object.keys(merged).length > 0 ? merged : undefined };
 });
 
-export type ObservabilityInput = z.infer<typeof ObservabilityInputSchema>;
+export type ObservabilityInput = z.input<typeof ObservabilityInputSchema>;
 
 export const observabilityToolInputSchema = {
   operation: {

--- a/src/observability/operations/health.ts
+++ b/src/observability/operations/health.ts
@@ -71,25 +71,6 @@ export async function checkHealth(
   };
 }
 
-async function checkThoughtbox(url: string): Promise<ServiceHealth> {
-  try {
-    const response = await fetch(`${url}/health`, {
-      signal: AbortSignal.timeout(5000),
-    });
-
-    if (response.ok) {
-      const data = await response.json().catch(() => ({}));
-      return {
-        status: 'healthy',
-        version: data.version ?? 'unknown',
-      };
-    }
-    return { status: 'unhealthy', error: `HTTP ${response.status}` };
-  } catch (err) {
-    return { status: 'unhealthy', error: err instanceof Error ? err.message : 'Connection failed' };
-  }
-}
-
 async function checkOtelStorage(
   storage: OtelEventStorage | null,
 ): Promise<ServiceHealth> {

--- a/src/observability/operations/health.ts
+++ b/src/observability/operations/health.ts
@@ -35,7 +35,9 @@ export async function checkHealth(
     requestedServices.map(async (service) => {
       switch (service) {
         case 'thoughtbox':
-          return { name: service, health: await checkThoughtbox(thoughtboxUrl) };
+          // If responding to this request, the server is healthy.
+          // External URL checks fail from Cloud Run (no loopback route).
+          return { name: service, health: { status: 'healthy' as const } };
         case 'supabase':
           return { name: service, health: await checkOtelStorage(otelStorage) };
         default:

--- a/src/resources/thought-query-handler.ts
+++ b/src/resources/thought-query-handler.ts
@@ -64,23 +64,22 @@ export class ThoughtQueryHandler {
   }
 
   /**
-   * Query thoughts by type (H/E/C/Q/R/P/O/A/X)
+   * Query thoughts by type.
+   * Accepts cipher chars (H/E/C/Q/R/P/O/A/X) or full thoughtType names
+   * (reasoning, decision_frame, action_report, belief_snapshot,
+   *  assumption_update, context_snapshot, progress).
    */
   private async queryByType(sessionId: string, type: string): Promise<QueryResult> {
-    // Validate type
-    const validTypes = ["H", "E", "C", "Q", "R", "P", "O", "A", "X"];
-    if (!validTypes.includes(type)) {
-      throw new Error(
-        `Invalid type '${type}'. Valid types: ${validTypes.join(", ")}`
-      );
-    }
+    const cipherType = this.normalizeToCipher(type);
 
     const linkedExport = await this.storage.toLinkedExport(sessionId);
-    const typePattern = new RegExp(`^S\\d+\\|${type}\\|`);
 
-    const matchingNodes = linkedExport.nodes.filter((node) =>
-      typePattern.test(node.data.thought)
-    );
+    const matchingNodes = linkedExport.nodes.filter((node) => {
+      const cipherPattern = new RegExp(`^S\\d+\\|${cipherType}\\|`);
+      if (cipherPattern.test(node.data.thought)) return true;
+      if (node.data.thoughtType === type) return true;
+      return false;
+    });
 
     return {
       sessionId,
@@ -200,7 +199,7 @@ export class ThoughtQueryHandler {
     params: Record<string, any>;
   } {
     const patterns: Record<string, RegExp> = {
-      "thoughts-by-type": /^thoughtbox:\/\/thoughts\/([^\/]+)\/([HECQRPOAX])$/,
+      "thoughts-by-type": /^thoughtbox:\/\/thoughts\/([^\/]+)\/([A-Za-z_]+)$/,
       "thought-range": /^thoughtbox:\/\/thoughts\/([^\/]+)\/range\/(\d+)-(\d+)$/,
       "thought-references": /^thoughtbox:\/\/references\/([^\/]+)\/(\d+)$/,
       "revision-history": /^thoughtbox:\/\/revisions\/([^\/]+)\/(\d+)$/,
@@ -253,25 +252,24 @@ export class ThoughtQueryHandler {
   }
 
   /**
-   * Convert ThoughtNode to simplified thought data
+   * Convert ThoughtNode to simplified thought data.
+   * Arrow function to preserve `this` when used as .map() callback.
    */
-  private nodeToThought(node: ThoughtNode): {
+  private nodeToThought = (node: ThoughtNode): {
     thoughtNumber: number;
     thought: string;
     timestamp: string;
     type?: string;
     isRevision: boolean;
     branchId?: string | null;
-  } {
-    return {
-      thoughtNumber: node.data.thoughtNumber,
-      thought: node.data.thought,
-      timestamp: node.data.timestamp,
-      type: this.extractType(node.data.thought),
-      isRevision: node.data.isRevision || false,
-      branchId: node.branchId || null,
-    };
-  }
+  } => ({
+    thoughtNumber: node.data.thoughtNumber,
+    thought: node.data.thought,
+    timestamp: node.data.timestamp,
+    type: this.extractType(node.data.thought),
+    isRevision: node.data.isRevision || false,
+    branchId: node.branchId || null,
+  });
 
   /**
    * Extract thought type from cipher notation
@@ -279,5 +277,26 @@ export class ThoughtQueryHandler {
   private extractType(thought: string): string | undefined {
     const match = thought.match(/^S\d+\|([HECQRPOAX])\|/);
     return match ? match[1] : undefined;
+  }
+
+  private static readonly TYPE_NAME_TO_CIPHER: Record<string, string> = {
+    reasoning: "H",
+    decision_frame: "C",
+    action_report: "A",
+    belief_snapshot: "E",
+    assumption_update: "A",
+    context_snapshot: "O",
+    progress: "P",
+  };
+
+  /**
+   * Normalize a type input to its cipher character.
+   * Accepts both cipher chars (H, E, C) and full names (reasoning, decision_frame).
+   */
+  private normalizeToCipher(type: string): string {
+    if (type.length === 1 && /^[HECQRPOAX]$/.test(type)) {
+      return type;
+    }
+    return ThoughtQueryHandler.TYPE_NAME_TO_CIPHER[type] ?? type;
   }
 }

--- a/src/resources/thought-query-handler.ts
+++ b/src/resources/thought-query-handler.ts
@@ -70,14 +70,19 @@ export class ThoughtQueryHandler {
    *  assumption_update, context_snapshot, progress).
    */
   private async queryByType(sessionId: string, type: string): Promise<QueryResult> {
-    const cipherType = this.normalizeToCipher(type);
-
+    const isCipherChar = type.length === 1 && /^[HECQRPOAX]$/.test(type);
     const linkedExport = await this.storage.toLinkedExport(sessionId);
 
+    // When the caller supplies a full type name, match only on thoughtType
+    // to avoid cipher collisions (action_report and assumption_update both
+    // map to "A"). When a cipher char is supplied, match on cipher prefix.
+    const cipherPattern = isCipherChar
+      ? new RegExp(`^S\\d+\\|${type}\\|`)
+      : null;
+
     const matchingNodes = linkedExport.nodes.filter((node) => {
-      const cipherPattern = new RegExp(`^S\\d+\\|${cipherType}\\|`);
-      if (cipherPattern.test(node.data.thought)) return true;
-      if (node.data.thoughtType === type) return true;
+      if (cipherPattern && cipherPattern.test(node.data.thought)) return true;
+      if (!isCipherChar && node.data.thoughtType === type) return true;
       return false;
     });
 
@@ -279,24 +284,4 @@ export class ThoughtQueryHandler {
     return match ? match[1] : undefined;
   }
 
-  private static readonly TYPE_NAME_TO_CIPHER: Record<string, string> = {
-    reasoning: "H",
-    decision_frame: "C",
-    action_report: "A",
-    belief_snapshot: "E",
-    assumption_update: "A",
-    context_snapshot: "O",
-    progress: "P",
-  };
-
-  /**
-   * Normalize a type input to its cipher character.
-   * Accepts both cipher chars (H, E, C) and full names (reasoning, decision_frame).
-   */
-  private normalizeToCipher(type: string): string {
-    if (type.length === 1 && /^[HECQRPOAX]$/.test(type)) {
-      return type;
-    }
-    return ThoughtQueryHandler.TYPE_NAME_TO_CIPHER[type] ?? type;
-  }
 }


### PR DESCRIPTION
## Summary

- Fix cross-realm vm serialization in both `execute-tool` and `search-tool` — results are now serialized inside the sandbox before crossing the vm boundary, preventing silent `undefined` from `JSON.stringify` on complex cross-realm objects
- Fix 3 broken resource templates (`thoughts-by-type`, `thought-range`, `revision-history`) — `this` binding loss in `.map()` callback and regex that rejected full type names
- Accept flat params in observability gateway (`{ operation, sessionId }`) alongside nested `{ operation, args: { sessionId } }`
- Health check returns healthy intrinsically instead of self-pinging a URL that doesn't resolve from Cloud Run
- Flatten notebook SDK responses — `tb.notebook.create()` now returns `{ id, title, ... }` instead of `{ success, notebook: { id } }`
- Normalize knowledge entity responses — `tb.knowledge.createEntity()` now includes `id` alongside `entity_id`

## Test plan

- [ ] `tsc --noEmit` passes (verified locally)
- [ ] 474 tests pass, 0 regressions (3 pre-existing failures unchanged)
- [ ] Deploy to Cloud Run and verify search-tool full catalog iteration returns results
- [ ] Verify resource templates: `thoughtbox://thoughts/{sessionId}/reasoning` resolves
- [ ] Verify `tb.observability({ operation: "session_timeline", sessionId: "..." })` works with flat params
- [ ] Verify `tb.observability({ operation: "health" })` reports healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)