### PR TITLE
docs: add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,3 +163,46 @@ Use these only when relevant to the task; do not bulk-load them by default:
 - Local state: `.claude/state/*`
 
 The intent is to inherit the project's accumulated operating context without pretending the Claude/Gemini runtime integrations are literally active in Codex.
+
+## Cursor Cloud specific instructions
+
+### Environment
+
+- **Node.js ≥22** (`.nvmrc` pins 22.21.1; any 22.x works).
+- **pnpm 9.15.4** — declared in `packageManager` field; already available after `corepack enable`.
+- Dependencies: `pnpm install` at repo root (builds native `better-sqlite3`).
+- Build for dev: `pnpm build:local` (embeds templates → compiles TS → copies assets).
+
+### Running the dev server
+
+```bash
+THOUGHTBOX_OBSERVATORY_ENABLED=true pnpm dev
+```
+
+- MCP server on `:1731`, Observatory UI on `:1729`.
+- Health check: `GET http://localhost:1731/health`.
+- Hub HTTP API: `POST http://localhost:1731/hub/api` with JSON body `{ "operation": "...", ... }`.
+
+**Known issue (pre-existing):** MCP session creation (`POST /mcp`) crashes with `supabaseUrl is required` because `BranchHandler` in `src/branch/handlers.ts` unconditionally calls `createClient()` with an empty URL when `SUPABASE_URL` is not set. The HTTP server starts fine and the Hub API works — only the MCP protocol endpoint fails per-session. Do **not** set `SUPABASE_URL` to a placeholder — `ensureStaticWorkspace` in `src/auth/static-workspace.ts` will then try to connect and crash the whole server.
+
+### Lint / Type-check / Test
+
+| Command | What it does |
+|---------|-------------|
+| `pnpm check:lint` | oxlint over `src/` |
+| `pnpm check:types` | `tsc --noEmit` |
+| `npx vitest run` | Unit tests (474 pass, 3 pre-existing Supabase failures, 54 skipped) |
+| `pnpm test` | Build + vitest (full suite) |
+
+### Storage modes
+
+- Default (`THOUGHTBOX_STORAGE=fs`): filesystem at `~/.thoughtbox/`.
+- Memory (`THOUGHTBOX_STORAGE=memory`): volatile, no external deps.
+- Supabase (`THOUGHTBOX_STORAGE=supabase`): requires `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY`.
+
+### Sub-packages (independently managed)
+
+- `plugins/thoughtbox-claude-code/` — Claude Code plugin (own `pnpm-lock.yaml`).
+- `observability/mcp-sidecar-observability/` — MCP observability proxy (own `pnpm-lock.yaml`).
+
+These have separate `pnpm install` steps; root install does not cover them.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` for future cloud agents working on this codebase.

### What's included

- Environment requirements (Node 22+, pnpm 9.15.4)
- Dev server startup command with Observatory (`THOUGHTBOX_OBSERVATORY_ENABLED=true pnpm dev`)
- Documented pre-existing bug: `BranchHandler` crashes MCP sessions when `SUPABASE_URL` is not set (server starts fine, Hub API works, only `/mcp` endpoint fails)
- Lint / type-check / test command reference table
- Storage mode summary (fs, memory, supabase)
- Sub-package independence notes

### Dev Environment Verification

| Check | Result |
|-------|--------|
| `pnpm install` | All 427 packages installed |
| `pnpm build:local` | Build successful (TS compile + template embed + asset copy) |
| `pnpm check:lint` | 0 warnings, 0 errors (175 files, 128 rules) |
| `pnpm check:types` | Clean (`tsc --noEmit`) |
| `npx vitest run` | 474 pass / 3 fail (pre-existing) / 54 skipped |
| Dev server | MCP on `:1731`, Observatory on `:1729` |
| Hub API | Agent registration, workspace creation, problem tracking all functional |

### Demo

[observatory_hub_demo.mp4](https://cursor.com/agents/bc-92fd398d-db36-41e1-b48a-d233692d8752/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fobservatory_hub_demo.mp4)

Observatory UI showing the Hub workspace created via the REST API.

[Observatory digest tab showing workspace summary](https://cursor.com/agents/bc-92fd398d-db36-41e1-b48a-d233692d8752/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fobservatory_digest_tab.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92fd398d-db36-41e1-b48a-d233692d8752"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92fd398d-db36-41e1-b48a-d233692d8752"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

