### PR TITLE
Simplify Thoughtbox plugin to CLI-only setup

### DIFF
--- a/plugins/thoughtbox-claude-code/.claude-plugin/plugin.json
+++ b/plugins/thoughtbox-claude-code/.claude-plugin/plugin.json
@@ -1,25 +1,11 @@
 {
   "name": "thoughtbox-claude-code",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Thoughtbox observability, protocol enforcement, and CLI for Claude Code",
   "author": {
     "name": "Kastalien Research"
   },
   "repository": "https://github.com/kastalien-research/thoughtbox",
   "license": "MIT",
-  "keywords": ["thoughtbox", "observability", "otlp", "protocols"],
-  "mcpServers": {
-    "thoughtbox-channel": {
-      "command": "node",
-      "args": ["${CLAUDE_PLUGIN_ROOT}/dist/thoughtbox-channel.js"],
-      "env": {
-        "THOUGHTBOX_URL": "https://mcp.kastalienresearch.ai"
-      }
-    }
-  },
-  "channels": [
-    {
-      "server": "thoughtbox-channel"
-    }
-  ]
+  "keywords": ["thoughtbox", "observability", "otlp", "protocols"]
 }

--- a/plugins/thoughtbox-claude-code/dist/cli/main.js
+++ b/plugins/thoughtbox-claude-code/dist/cli/main.js
@@ -1,5 +1,5 @@
 import process from 'node:process';
-import { DEFAULT_BASE_URL, extractApiKeyFromLocalConfig, findOtelEndpoint, findThoughtboxMcpUrl, hasRequiredOtelConfig, loadLocalThoughtboxConfig, mergeThoughtboxInitConfig, normalizeBaseUrl, saveLocalThoughtboxConfig, warnIfClaudeDirNotGitignored, } from './config.js';
+import { DEFAULT_BASE_URL, extractApiKeyFromLocalConfig, findOtelEndpoint, findThoughtboxMcpUrl, hasRequiredOtelConfig, loadLocalThoughtboxConfig, mergeThoughtboxInitConfig, saveLocalThoughtboxConfig, warnIfClaudeDirNotGitignored, } from './config.js';
 import { validateApiKey, } from './http.js';
 function createDefaultWriter(stream) {
     return (line) => {
@@ -13,8 +13,8 @@ function flagValue(args, flag) {
     return args[index + 1];
 }
 function printHelp(writeStdout) {
-    writeStdout('thoughtbox init --key <api_key> [--base-url <url>]');
-    writeStdout('thoughtbox doctor [--key <api_key>] [--base-url <url>]');
+    writeStdout('thoughtbox init --key <api_key>');
+    writeStdout('thoughtbox doctor [--key <api_key>]');
 }
 async function handleInit(args, runtime) {
     const apiKey = flagValue(args, '--key');
@@ -22,7 +22,7 @@ async function handleInit(args, runtime) {
         runtime.writeStderr('error: thoughtbox init requires --key <api_key>');
         return 1;
     }
-    const baseUrl = normalizeBaseUrl(flagValue(args, '--base-url') ?? DEFAULT_BASE_URL);
+    const baseUrl = DEFAULT_BASE_URL;
     let validation;
     try {
         validation = await validateApiKey({
@@ -56,8 +56,7 @@ async function handleInit(args, runtime) {
 async function handleDoctor(args, runtime) {
     const config = await loadLocalThoughtboxConfig(runtime.cwd);
     const configuredKey = flagValue(args, '--key') ?? extractApiKeyFromLocalConfig(config.settingsLocal);
-    const configuredBaseUrl = normalizeBaseUrl(flagValue(args, '--base-url')
-        ?? findOtelEndpoint(config.settingsLocal)
+    const configuredBaseUrl = findOtelEndpoint(config.settingsLocal)
         ?? (() => {
             const mcpUrl = findThoughtboxMcpUrl(config.settingsLocal);
             if (!mcpUrl)
@@ -68,7 +67,7 @@ async function handleDoctor(args, runtime) {
             catch {
                 return DEFAULT_BASE_URL;
             }
-        })());
+        })();
     const mcpUrl = findThoughtboxMcpUrl(config.settingsLocal);
     if (!mcpUrl) {
         runtime.writeStderr('mcp_missing: Thoughtbox MCP server configuration is missing');

--- a/plugins/thoughtbox-claude-code/package.json
+++ b/plugins/thoughtbox-claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thoughtbox-claude-code",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "description": "Thoughtbox plugin for Claude Code — hooks, channel, and CLI",
   "bin": {

--- a/plugins/thoughtbox-claude-code/src/cli/main.ts
+++ b/plugins/thoughtbox-claude-code/src/cli/main.ts
@@ -7,7 +7,6 @@ import {
   hasRequiredOtelConfig,
   loadLocalThoughtboxConfig,
   mergeThoughtboxInitConfig,
-  normalizeBaseUrl,
   saveLocalThoughtboxConfig,
   warnIfClaudeDirNotGitignored,
 } from './config.js';
@@ -41,8 +40,8 @@ function flagValue(args: string[], flag: string): string | undefined {
 }
 
 function printHelp(writeStdout: (line: string) => void): void {
-  writeStdout('thoughtbox init --key <api_key> [--base-url <url>]');
-  writeStdout('thoughtbox doctor [--key <api_key>] [--base-url <url>]');
+  writeStdout('thoughtbox init --key <api_key>');
+  writeStdout('thoughtbox doctor [--key <api_key>]');
 }
 
 async function handleInit(
@@ -55,9 +54,7 @@ async function handleInit(
     return 1;
   }
 
-  const baseUrl = normalizeBaseUrl(
-    flagValue(args, '--base-url') ?? DEFAULT_BASE_URL,
-  );
+  const baseUrl = DEFAULT_BASE_URL;
 
   let validation;
   try {
@@ -102,19 +99,16 @@ async function handleDoctor(
   const config = await loadLocalThoughtboxConfig(runtime.cwd);
   const configuredKey =
     flagValue(args, '--key') ?? extractApiKeyFromLocalConfig(config.settingsLocal);
-  const configuredBaseUrl = normalizeBaseUrl(
-    flagValue(args, '--base-url')
-      ?? findOtelEndpoint(config.settingsLocal)
-      ?? (() => {
-        const mcpUrl = findThoughtboxMcpUrl(config.settingsLocal);
-        if (!mcpUrl) return DEFAULT_BASE_URL;
-        try {
-          return new URL(mcpUrl).origin;
-        } catch {
-          return DEFAULT_BASE_URL;
-        }
-      })(),
-  );
+  const configuredBaseUrl = findOtelEndpoint(config.settingsLocal)
+    ?? (() => {
+      const mcpUrl = findThoughtboxMcpUrl(config.settingsLocal);
+      if (!mcpUrl) return DEFAULT_BASE_URL;
+      try {
+        return new URL(mcpUrl).origin;
+      } catch {
+        return DEFAULT_BASE_URL;
+      }
+    })();
 
   const mcpUrl = findThoughtboxMcpUrl(config.settingsLocal);
   if (!mcpUrl) {


### PR DESCRIPTION
## Summary
- remove the plugin channel surface from the manifest
- remove the CLI base-url override and keep the fixed Thoughtbox URL
- bump the plugin version for the next installable release

## Verification
- claude plugin validate .
- node plugins/thoughtbox-claude-code/bin/thoughtbox --help
- node plugins/thoughtbox-claude-code/bin/thoughtbox doctor