### PR TITLE
fix(plugin): drop doctor reference from init success output

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "thoughtbox-claude-code",
       "source": "./plugins/thoughtbox-claude-code",
       "description": "Observability hooks, protocol enforcement, and the thoughtbox CLI",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "category": "observability",
       "keywords": ["thoughtbox", "observability", "otlp", "protocols"]
     }

--- a/plugins/thoughtbox-claude-code/.claude-plugin/plugin.json
+++ b/plugins/thoughtbox-claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "thoughtbox-claude-code",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Thoughtbox observability, protocol enforcement, and CLI for Claude Code",
   "author": {
     "name": "Kastalien Research"

--- a/plugins/thoughtbox-claude-code/dist/cli/main.js
+++ b/plugins/thoughtbox-claude-code/dist/cli/main.js
@@ -36,7 +36,7 @@ async function handleInit(args, runtime) {
     if (gitignoreWarning) {
         runtime.writeStderr(gitignoreWarning);
     }
-    runtime.writeStdout('next: thoughtbox doctor');
+    runtime.writeStdout('next: restart your Claude Code session to load the Thoughtbox MCP server');
     return 0;
 }
 export async function runCli(argv, runtime = {}) {

--- a/plugins/thoughtbox-claude-code/package.json
+++ b/plugins/thoughtbox-claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thoughtbox-claude-code",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "module",
   "description": "Thoughtbox plugin for Claude Code — hooks, channel, and CLI",
   "bin": {

--- a/plugins/thoughtbox-claude-code/src/cli/main.ts
+++ b/plugins/thoughtbox-claude-code/src/cli/main.ts
@@ -65,7 +65,7 @@ async function handleInit(
   if (gitignoreWarning) {
     runtime.writeStderr(gitignoreWarning);
   }
-  runtime.writeStdout('next: thoughtbox doctor');
+  runtime.writeStdout('next: restart your Claude Code session to load the Thoughtbox MCP server');
 
   return 0;
 }


### PR DESCRIPTION
## Summary
- `thoughtbox init` on 0.1.4 printed `next: thoughtbox doctor` as its final line, pointing users at a command that was cut as synthetic.
- Replaces the line with an actually-useful next step: `next: restart your Claude Code session to load the Thoughtbox MCP server`.
- Bumps plugin + marketplace to 0.1.5.

## Verification
End-to-end tested with 0.1.4 in a separate repo by user — init wrote the correct `.claude/settings.local.json` with `mcpServers.thoughtbox` + 5 OTEL env vars, and the gitignore warning fired correctly. The only issue was the stale doctor reference. This PR fixes that one line.

Expected output after merge:
```
configured local Thoughtbox settings
mcp: https://mcp.kastalienresearch.ai/mcp?key=...
otel: https://mcp.kastalienresearch.ai/v1/logs
next: restart your Claude Code session to load the Thoughtbox MCP server
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)