### PR TITLE
feat(prototypes): preserve thought-processing-worker prototype

### DIFF
--- a/prototypes/thought-processing-worker/.env.example
+++ b/prototypes/thought-processing-worker/.env.example
@@ -1,0 +1,20 @@
+# Supabase project (REST + Realtime)
+SUPABASE_URL=https://xxxx.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=eyJ...
+
+# Direct Postgres (required for pgmq_public.* — not exposed via PostgREST by default)
+# Supabase Dashboard → Project Settings → Database → Connection string (URI), service role / postgres
+DATABASE_URL=postgresql://postgres.[ref]:[password]@aws-0-[region].pooler.supabase.com:6543/postgres
+
+# Worker tuning
+QUEUE_NAME=thought_processing
+POLL_VT_SECONDS=30
+POLL_BATCH_SIZE=5
+POLL_IDLE_MS=2000
+SIMILARITY_THRESHOLD=0.35
+
+# EMBEDDING_MODE=stub | xenova (xenova requires: pnpm add @xenova/transformers)
+EMBEDDING_MODE=stub
+
+# Cloud Run sets PORT; optional health check
+PORT=8080

--- a/prototypes/thought-processing-worker/.gitignore
+++ b/prototypes/thought-processing-worker/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.env

--- a/prototypes/thought-processing-worker/Dockerfile
+++ b/prototypes/thought-processing-worker/Dockerfile
@@ -1,0 +1,15 @@
+# Cloud Run worker image (prototype — not part of root monolith build)
+FROM node:22-slim
+
+WORKDIR /app
+RUN corepack enable && corepack prepare pnpm@9.15.4 --activate
+
+COPY package.json pnpm-lock.yaml* ./
+RUN pnpm install --frozen-lockfile
+
+COPY tsconfig.json ./
+COPY src ./src
+
+ENV NODE_ENV=production
+EXPOSE 8080
+CMD ["pnpm", "exec", "tsx", "src/index.ts"]

--- a/prototypes/thought-processing-worker/README.md
+++ b/prototypes/thought-processing-worker/README.md
@@ -1,0 +1,104 @@
+# Thought processing worker (prototype)
+
+Isolated prototype for draining the Supabase **pgmq** queue `thought_processing`, aligned with the repo’s **Cloud Run execution plane** and **Supabase intelligence plane** split (`CLAUDE.md`, `supabase/SUPABASE-INTELLIGENCE.md`).
+
+This package is **not** wired into the root `@kastalien-research/thoughtbox` build.
+
+## References
+
+| Artifact | Role |
+|----------|------|
+| `supabase/migrations/20260408033928_add_hub_tables_vectors_pgmq_realtime.sql` | Creates `thought_processing` queue, `AFTER INSERT` trigger on `thoughts`, `vector(384)` + HNSW on `thoughts`, Realtime publication including `thoughts`. |
+| `.specs/hub-deployed/SCOPE-LAYER-2-SUPABASE-HUB-STORAGE.md` | Hub tables + `SupabaseHubStorage`; **explicitly excludes** Edge queue processors — workers belong next to or behind the execution plane, not as a second MCP surface. |
+| Dual-backend (`THOUGHTBOX_STORAGE`) | **FileSystemStorage** (local/self-hosted) does not use this Postgres queue. **SupabaseStorage** paths that persist `thoughts` to Supabase do; run this worker only when the database is the source of truth for thoughts. |
+
+## Code layout
+
+```
+src/
+  index.ts              # Poll loop, poison handling, orchestration
+  config.ts             # env
+  db/
+    pool.ts             # node-postgres pool (DATABASE_URL)
+    pgmq.ts             # pgmq_public.read / archive / delete
+    supabase.ts         # service-role Supabase client (REST)
+  pipeline/
+    embed.ts            # stub 384-d vectors + optional Xenova path
+    embed-xenova.ts     # optional @xenova/transformers (not installed by default)
+    intel.ts            # UPDATE embedding, ANN neighbors, evolution/contradiction hints
+  realtime/
+    monitor.ts          # optional postgres_changes subscription on thoughts
+  http/
+    health.ts           # GET /health for Cloud Run
+```
+
+### Queue contract
+
+Trigger payload (from migration):
+
+```json
+{ "thought_id": "<uuid>", "action": "process" }
+```
+
+### Why `pg` + `DATABASE_URL`?
+
+PostgREST exposes `public` RPCs by default. `pgmq_public.read` / `archive` / `delete` live outside `public` (see `20260320191032_remote_schema.sql`). A worker typically uses the **direct Postgres connection string** (pooler or session mode) for queue I/O, and `@supabase/supabase-js` for row reads and Realtime.
+
+Alternative: thin `SECURITY DEFINER` wrappers in `public` that delegate to `pgmq_public.*` if you want a single client.
+
+### Realtime
+
+Updating `thoughts.embedding` (or any column) emits **Postgres Changes** to subscribers because `thoughts` is in `supabase_realtime` (migration §7). This worker does not need to publish manually for clients to see updates.
+
+Optional `REALTIME_MONITOR=1` logs change events for debugging.
+
+### Evolution / contradiction (stub level)
+
+- **Evolution:** detects revision chains via `is_revision` + `revises_thought` (feeds higher layers like `.claude/skills/thoughtbox-evolution`).
+- **Contradiction:** heuristic flags when `decision_frame` / `belief_snapshot` has semantic neighbors under a configurable distance threshold (`SIMILARITY_THRESHOLD`). Production would write to tables such as `pending_contradictions` / `pending_evolutions` described in `SUPABASE-INTELLIGENCE.md` (not present in the Layer 2 migration).
+
+## Run locally
+
+```bash
+cd prototypes/thought-processing-worker
+cp .env.example .env
+# fill SUPABASE_*, DATABASE_URL
+pnpm install
+REALTIME_MONITOR=0 pnpm start
+```
+
+- **Stub embeddings** (default): deterministic 384-d vectors — good for plumbing, not semantics.
+- **Xenova:** `pnpm add @xenova/transformers` and `EMBEDDING_MODE=xenova` — cold start downloads weights; size and CPU matter on Cloud Run.
+
+## Deploy as Cloud Run worker
+
+1. Build image from this directory (`Dockerfile`).
+2. Deploy with the same **non-negotiables** as the main server: **stateless container**, **no local durable queue state** — all work is backed by PGMQ + Postgres.
+3. Set secrets: `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `DATABASE_URL`.
+4. **Concurrency:** set Cloud Run concurrency **1** if each replica runs one tight poll loop (avoids duplicate embedding work on the same row; PGMQ visibility timeout already reduces double consumption).
+5. **CPU/memory:** embedding models dominate; stub mode is cheap.
+6. **Health:** platform probes `PORT` (default 8080) → `GET /health`.
+7. **SIGTERM:** handler closes the pool (extend with in-flight drain as needed).
+
+### pg_cron note
+
+The sample migration schedules `pgmq.read('thought_processing', …)` on a timer **without** a consumer that archives messages. That pattern only hides messages for the VT window. **Production** should either remove that cron in favor of this worker, or add a SQL consumer that archives — avoid “read-only” polling.
+
+## Cloud Run Node worker vs Supabase Edge
+
+| | **Cloud Run (this prototype)** | **Supabase Edge Functions** |
+|--|-------------------------------|------------------------------|
+| **Runtime** | Node 22, full `pg`, long-lived loop | Deno, shorter requests, no raw TCP in some setups |
+| **Embeddings** | ONNX / native addons / large deps feasible | WASM models OK; heavy models tighter |
+| **Cold start** | Configurable min instances | Per-invocation cold starts |
+| **Alignment** | Matches **execution plane** mandate: same org patterns as the MCP server container, VPC egress controls, shared secret management | Fits “next to data” but is **not** the MCP surface; spec warns Edge is for background-only roles |
+| **Risk** | Another service to operate | Couples compute to Supabase project limits |
+
+**Recommendation:** treat **queue + embedding + ANN** as a **dedicated worker service on Cloud Run** (or Cloud Run Job + scheduler for batch drains), keep **Edge** for tiny webhooks or Supabase-native hooks if latency/cost wins are clear.
+
+## Operational checklist
+
+- [ ] Service role key never shipped to browsers.
+- [ ] `DATABASE_URL` uses pooler appropriately for many short queries; consider session mode for long transactions if added later.
+- [ ] RLS: service role bypasses RLS on `thoughts` — worker must only run in trusted environments.
+- [ ] After applying the Layer 2+ migration, regenerate `src/database.types.ts` in the main app (`supabase gen types typescript`).

--- a/prototypes/thought-processing-worker/package.json
+++ b/prototypes/thought-processing-worker/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@thoughtbox-proto/thought-processing-worker",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "description": "Isolated prototype: Cloud Run–style worker for pgmq thought_processing (not wired into main package)",
+  "scripts": {
+    "start": "node --import tsx src/index.ts",
+    "dev": "node --watch --import tsx src/index.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.99.1",
+    "dotenv": "^17.2.3",
+    "pg": "^8.14.1"
+  },
+  "devDependencies": {
+    "@types/node": "^22.18.12",
+    "@types/pg": "^8.11.11",
+    "tsx": "^4.20.6",
+    "typescript": "^5.3.3"
+  }
+}

--- a/prototypes/thought-processing-worker/pnpm-lock.yaml
+++ b/prototypes/thought-processing-worker/pnpm-lock.yaml
@@ -1,0 +1,576 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@supabase/supabase-js':
+        specifier: ^2.99.1
+        version: 2.102.1
+      dotenv:
+        specifier: ^17.2.3
+        version: 17.4.1
+      pg:
+        specifier: ^8.14.1
+        version: 8.20.0
+    devDependencies:
+      '@types/node':
+        specifier: ^22.18.12
+        version: 22.19.17
+      '@types/pg':
+        specifier: ^8.11.11
+        version: 8.20.0
+      tsx:
+        specifier: ^4.20.6
+        version: 4.21.0
+      typescript:
+        specifier: ^5.3.3
+        version: 5.9.3
+
+packages:
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@supabase/auth-js@2.102.1':
+    resolution: {integrity: sha512-2uH2WB0H98TOGDtaFWhxIcR42Dro/VB7VDZanz/4bVJsqioIue1m3TUqu3xciDm2W9r+1LXQvYNsYbQfWmD+uQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/functions-js@2.102.1':
+    resolution: {integrity: sha512-UcrcKTPnAIo+Yp9Jjq9XXwFbsmgRYY637mwka9ZjmTIWcX/xr1pote4OVvaGQycVY1KTiQgjMvpC0Q0yJhRq3w==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/phoenix@0.4.0':
+    resolution: {integrity: sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw==}
+
+  '@supabase/postgrest-js@2.102.1':
+    resolution: {integrity: sha512-InLvXKAYf8BIqiv9jWOYudWB3rU8A9uMbcip5BQ5sLLNPrbO1Ekkr79OvlhZBgMNSppxVyC7wPPGzLxMcTZhlA==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/realtime-js@2.102.1':
+    resolution: {integrity: sha512-h2fCumib/v6u7XMwSPgxnpfimjX4xCEayUHrxWLC7UurfQjUZJ0pmJDgm6yj80DnUerxuulRghwm5zXYysFG/Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/storage-js@2.102.1':
+    resolution: {integrity: sha512-eCL9T4Xpe40nmKlkUJ7Zq/hk34db1xPiT0WL3Iv5MbJqHuCAe5TxhV8Rjqd6DNZrzjtfYObZtYl9jKJaHrivqw==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/supabase-js@2.102.1':
+    resolution: {integrity: sha512-bChxPVeLDnYN9M2d/u4fXsvylwSQG5grAl+HN8f+ZD9a9PuVU+Ru+xGmEsk+b9Iz3rJC9ZQnQUJYQ28fApdWYA==}
+    engines: {node: '>=20.0.0'}
+
+  '@types/node@22.19.17':
+    resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
+
+  '@types/pg@8.20.0':
+    resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
+  dotenv@17.4.1:
+    resolution: {integrity: sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw==}
+    engines: {node: '>=12'}
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  get-tsconfig@4.13.7:
+    resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
+
+  iceberg-js@0.8.1:
+    resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
+    engines: {node: '>=20.0.0'}
+
+  pg-cloudflare@1.3.0:
+    resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
+
+  pg-connection-string@2.12.0:
+    resolution: {integrity: sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.13.0:
+    resolution: {integrity: sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.13.0:
+    resolution: {integrity: sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.20.0:
+    resolution: {integrity: sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@supabase/auth-js@2.102.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/functions-js@2.102.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/phoenix@0.4.0': {}
+
+  '@supabase/postgrest-js@2.102.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/realtime-js@2.102.1':
+    dependencies:
+      '@supabase/phoenix': 0.4.0
+      '@types/ws': 8.18.1
+      tslib: 2.8.1
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@supabase/storage-js@2.102.1':
+    dependencies:
+      iceberg-js: 0.8.1
+      tslib: 2.8.1
+
+  '@supabase/supabase-js@2.102.1':
+    dependencies:
+      '@supabase/auth-js': 2.102.1
+      '@supabase/functions-js': 2.102.1
+      '@supabase/postgrest-js': 2.102.1
+      '@supabase/realtime-js': 2.102.1
+      '@supabase/storage-js': 2.102.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@types/node@22.19.17':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@types/pg@8.20.0':
+    dependencies:
+      '@types/node': 22.19.17
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 22.19.17
+
+  dotenv@17.4.1: {}
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
+  fsevents@2.3.3:
+    optional: true
+
+  get-tsconfig@4.13.7:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  iceberg-js@0.8.1: {}
+
+  pg-cloudflare@1.3.0:
+    optional: true
+
+  pg-connection-string@2.12.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.13.0(pg@8.20.0):
+    dependencies:
+      pg: 8.20.0
+
+  pg-protocol@1.13.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.20.0:
+    dependencies:
+      pg-connection-string: 2.12.0
+      pg-pool: 3.13.0(pg@8.20.0)
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.3.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
+
+  resolve-pkg-maps@1.0.0: {}
+
+  split2@4.2.0: {}
+
+  tslib@2.8.1: {}
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.13.7
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  ws@8.20.0: {}
+
+  xtend@4.0.2: {}

--- a/prototypes/thought-processing-worker/src/config.ts
+++ b/prototypes/thought-processing-worker/src/config.ts
@@ -1,0 +1,25 @@
+import "dotenv/config";
+
+function req(name: string): string {
+  const v = process.env[name];
+  if (!v) throw new Error(`Missing required env: ${name}`);
+  return v;
+}
+
+export const config = {
+  supabaseUrl: req("SUPABASE_URL"),
+  supabaseServiceRoleKey: req("SUPABASE_SERVICE_ROLE_KEY"),
+  databaseUrl: req("DATABASE_URL"),
+
+  queueName: process.env.QUEUE_NAME ?? "thought_processing",
+  pollVtSeconds: Number(process.env.POLL_VT_SECONDS ?? 30),
+  pollBatchSize: Number(process.env.POLL_BATCH_SIZE ?? 5),
+  pollIdleMs: Number(process.env.POLL_IDLE_MS ?? 2000),
+
+  /** Cosine distance threshold for "close neighbor" (pgvector `<=>` on normalized vectors ~ [0,2]) */
+  similarityThreshold: Number(process.env.SIMILARITY_THRESHOLD ?? 0.35),
+
+  embeddingMode: (process.env.EMBEDDING_MODE ?? "stub") as "stub" | "xenova",
+
+  port: Number(process.env.PORT ?? 8080),
+};

--- a/prototypes/thought-processing-worker/src/db/pgmq.ts
+++ b/prototypes/thought-processing-worker/src/db/pgmq.ts
@@ -1,0 +1,46 @@
+import type pg from "pg";
+
+/** Matches pgmq `message_record` shape returned by `pgmq_public.read`. */
+export type PgmqMessage = {
+  msg_id: string;
+  read_ct: string;
+  enqueued_at: Date;
+  vt: Date;
+  message: Record<string, unknown>;
+};
+
+export async function pgmqRead(
+  pool: pg.Pool,
+  queueName: string,
+  vtSeconds: number,
+  batch: number
+): Promise<PgmqMessage[]> {
+  const { rows } = await pool.query<PgmqMessage>(
+    `SELECT * FROM pgmq_public.read($1::text, $2::integer, $3::integer)`,
+    [queueName, vtSeconds, batch]
+  );
+  return rows;
+}
+
+export async function pgmqArchive(
+  pool: pg.Pool,
+  queueName: string,
+  msgId: bigint
+): Promise<void> {
+  await pool.query(`SELECT pgmq_public.archive($1::text, $2::bigint)`, [
+    queueName,
+    msgId.toString(),
+  ]);
+}
+
+/** Permanent removal (e.g. poison message after max retries). */
+export async function pgmqDelete(
+  pool: pg.Pool,
+  queueName: string,
+  msgId: bigint
+): Promise<void> {
+  await pool.query(`SELECT pgmq_public.delete($1::text, $2::bigint)`, [
+    queueName,
+    msgId.toString(),
+  ]);
+}

--- a/prototypes/thought-processing-worker/src/db/pool.ts
+++ b/prototypes/thought-processing-worker/src/db/pool.ts
@@ -1,0 +1,10 @@
+import pg from "pg";
+
+export function createPool(databaseUrl: string): pg.Pool {
+  return new pg.Pool({
+    connectionString: databaseUrl,
+    max: 4,
+    idleTimeoutMillis: 10_000,
+    connectionTimeoutMillis: 15_000,
+  });
+}

--- a/prototypes/thought-processing-worker/src/db/supabase.ts
+++ b/prototypes/thought-processing-worker/src/db/supabase.ts
@@ -1,0 +1,10 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+export function createServiceClient(
+  url: string,
+  serviceRoleKey: string
+): SupabaseClient {
+  return createClient(url, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}

--- a/prototypes/thought-processing-worker/src/http/health.ts
+++ b/prototypes/thought-processing-worker/src/http/health.ts
@@ -1,0 +1,18 @@
+import http from "node:http";
+
+/** Cloud Run expects a listening port; keep a minimal GET /health. */
+export function startHealthServer(port: number): http.Server {
+  const server = http.createServer((req, res) => {
+    if (req.url === "/health" && req.method === "GET") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true, service: "thought-processing-worker" }));
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+  server.listen(port, () => {
+    console.info(`health listening on :${port}`);
+  });
+  return server;
+}

--- a/prototypes/thought-processing-worker/src/index.ts
+++ b/prototypes/thought-processing-worker/src/index.ts
@@ -1,0 +1,140 @@
+import { config } from "./config.js";
+import { createPool } from "./db/pool.js";
+import { pgmqArchive, pgmqDelete, pgmqRead } from "./db/pgmq.js";
+import { createServiceClient } from "./db/supabase.js";
+import { embedText } from "./pipeline/embed.js";
+import { runIntelPipeline, type ThoughtRow } from "./pipeline/intel.js";
+import { subscribeThoughtsChanges } from "./realtime/monitor.js";
+import { startHealthServer } from "./http/health.js";
+
+const MAX_READ_CT = 8;
+
+function parseQueueMessage(raw: Record<string, unknown>): { thoughtId: string } | null {
+  const thoughtId = raw.thought_id;
+  if (typeof thoughtId === "string" && thoughtId.length > 0) {
+    return { thoughtId };
+  }
+  return null;
+}
+
+async function loadThought(
+  supabase: ReturnType<typeof createServiceClient>,
+  thoughtId: string
+): Promise<ThoughtRow | null> {
+  const { data, error } = await supabase
+    .from("thoughts")
+    .select(
+      "id, session_id, workspace_id, thought, thought_number, thought_type, is_revision, revises_thought"
+    )
+    .eq("id", thoughtId)
+    .maybeSingle();
+
+  if (error) {
+    console.error("loadThought error", error);
+    return null;
+  }
+  if (!data) return null;
+  return data as ThoughtRow;
+}
+
+async function main(): Promise<void> {
+  const pool = createPool(config.databaseUrl);
+  const supabase = createServiceClient(
+    config.supabaseUrl,
+    config.supabaseServiceRoleKey
+  );
+
+  const health = startHealthServer(config.port);
+
+  const realtimeOn = process.env.REALTIME_MONITOR === "1";
+  if (realtimeOn) {
+    subscribeThoughtsChanges(supabase, "intel-worker");
+  }
+
+  const shutdown = (): void => {
+    health.close();
+    void pool.end().then(() => process.exit(0));
+  };
+  process.on("SIGTERM", shutdown);
+  process.on("SIGINT", shutdown);
+
+  console.info("thought-processing worker started", {
+    queue: config.queueName,
+    vt: config.pollVtSeconds,
+    batch: config.pollBatchSize,
+    embeddingMode: config.embeddingMode,
+  });
+
+  for (;;) {
+    let messages;
+    try {
+      messages = await pgmqRead(
+        pool,
+        config.queueName,
+        config.pollVtSeconds,
+        config.pollBatchSize
+      );
+    } catch (e) {
+      console.error("pgmq read failed", e);
+      await sleep(config.pollIdleMs);
+      continue;
+    }
+
+    if (messages.length === 0) {
+      await sleep(config.pollIdleMs);
+      continue;
+    }
+
+    for (const row of messages) {
+      const msgId = BigInt(String(row.msg_id));
+      const readCt = Number(row.read_ct ?? 0);
+      const parsed = parseQueueMessage(row.message ?? {});
+
+      if (!parsed) {
+        console.warn("skip invalid message", row.message);
+        await pgmqDelete(pool, config.queueName, msgId);
+        continue;
+      }
+
+      if (readCt >= MAX_READ_CT) {
+        console.error("poison message, deleting", { msgId: String(msgId), readCt });
+        await pgmqDelete(pool, config.queueName, msgId);
+        continue;
+      }
+
+      try {
+        const thought = await loadThought(supabase, parsed.thoughtId);
+        if (!thought) {
+          console.warn("thought not found, archiving", parsed.thoughtId);
+          await pgmqArchive(pool, config.queueName, msgId);
+          continue;
+        }
+
+        const result = await runIntelPipeline(pool, thought, embedText);
+        console.info("processed", {
+          thoughtId: thought.id,
+          dims: result.embeddingDims,
+          neighbors: result.neighbors.length,
+          evolution: result.evolutionHints,
+          contradiction: result.contradictionHints,
+        });
+
+        await pgmqArchive(pool, config.queueName, msgId);
+      } catch (e) {
+        console.error("process failed (will retry after VT)", {
+          msgId: String(msgId),
+          err: e,
+        });
+      }
+    }
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/prototypes/thought-processing-worker/src/pipeline/embed-xenova.ts
+++ b/prototypes/thought-processing-worker/src/pipeline/embed-xenova.ts
@@ -1,0 +1,15 @@
+/**
+ * Optional path: `pnpm add @xenova/transformers` and set EMBEDDING_MODE=xenova.
+ * Model download on first cold start — size/CPU implications for Cloud Run.
+ */
+export async function embedGteSmall(text: string): Promise<number[]> {
+  const { pipeline } = await import("@xenova/transformers");
+  const extractor = await pipeline("feature-extraction", "Xenova/gte-small");
+  const out = await extractor(text, { pooling: "mean", normalize: true });
+  const data = out.data as Float32Array | number[];
+  const arr = Array.from(data);
+  if (arr.length !== 384) {
+    throw new Error(`Expected 384-d embedding, got ${arr.length}`);
+  }
+  return arr;
+}

--- a/prototypes/thought-processing-worker/src/pipeline/embed.ts
+++ b/prototypes/thought-processing-worker/src/pipeline/embed.ts
@@ -1,0 +1,35 @@
+import { createHash } from "node:crypto";
+import { config } from "../config.js";
+
+const DIM = 384;
+
+/**
+ * Deterministic 384-d unit vector. Replace with Xenova `gte-small` (or hosted API)
+ * for production semantic quality. Migration targets `vector(384)` per
+ * `20260408033928_add_hub_tables_vectors_pgmq_realtime.sql`.
+ */
+export function stubEmbedding384(text: string): number[] {
+  const out = new Array<number>(DIM);
+  let buf = createHash("sha256").update(text, "utf8").digest();
+  for (let i = 0; i < DIM; i++) {
+    if (i > 0 && i % 32 === 0) {
+      buf = createHash("sha256").update(buf).update(String(i)).digest();
+    }
+    const b = buf[i % 32]! ^ buf[(i + 7) % 32]!;
+    out[i] = (b / 255) * 2 - 1;
+  }
+  const norm = Math.sqrt(out.reduce((s, x) => s + x * x, 0)) || 1;
+  return out.map((x) => x / norm);
+}
+
+export async function embedText(text: string): Promise<number[]> {
+  if (config.embeddingMode === "xenova") {
+    const mod = await import("./embed-xenova.js");
+    return mod.embedGteSmall(text);
+  }
+  return stubEmbedding384(text);
+}
+
+export function vectorLiteral(values: number[]): string {
+  return `[${values.map((v) => Number(v.toFixed(8))).join(",")}]`;
+}

--- a/prototypes/thought-processing-worker/src/pipeline/intel.ts
+++ b/prototypes/thought-processing-worker/src/pipeline/intel.ts
@@ -1,0 +1,109 @@
+import type pg from "pg";
+import { config } from "../config.js";
+import { vectorLiteral } from "./embed.js";
+
+export type ThoughtRow = {
+  id: string;
+  session_id: string;
+  workspace_id: string;
+  thought: string;
+  thought_number: number;
+  thought_type: string;
+  is_revision: boolean | null;
+  revises_thought: number | null;
+};
+
+export type IntelResult = {
+  embeddingDims: number;
+  neighbors: Array<{ id: string; dist: number; thought_number: number }>;
+  evolutionHints: string[];
+  contradictionHints: string[];
+};
+
+async function fetchNeighbors(
+  pool: pg.Pool,
+  sessionId: string,
+  excludeId: string,
+  vec: number[]
+): Promise<Array<{ id: string; dist: number; thought_number: number }>> {
+  const literal = vectorLiteral(vec);
+  const { rows } = await pool.query<{
+    id: string;
+    dist: number;
+    thought_number: number;
+  }>(
+    `
+    SELECT id,
+           (embedding <=> $1::vector) AS dist,
+           thought_number
+    FROM public.thoughts
+    WHERE session_id = $2::uuid
+      AND id <> $3::uuid
+      AND embedding IS NOT NULL
+    ORDER BY embedding <=> $1::vector
+    LIMIT 8
+    `,
+    [literal, sessionId, excludeId]
+  );
+  return rows.map((r) => ({
+    id: r.id,
+    dist: Number(r.dist),
+    thought_number: r.thought_number,
+  }));
+}
+
+function evolutionHintsFor(row: ThoughtRow): string[] {
+  const hints: string[] = [];
+  if (row.is_revision && row.revises_thought != null) {
+    hints.push(
+      `revision_chain:revises_thought=${row.revises_thought} (run thoughtbox-evolution classifier on pair)`
+    );
+  }
+  return hints;
+}
+
+function contradictionHintsFor(
+  row: ThoughtRow,
+  neighbors: IntelResult["neighbors"]
+): string[] {
+  const hints: string[] = [];
+  const close = neighbors.filter((n) => n.dist < config.similarityThreshold);
+  if (close.length === 0) return hints;
+
+  if (row.thought_type === "decision_frame") {
+    hints.push(
+      `near_duplicate_decision: ${close.length} neighbors within cosine-distance threshold — manual or LLM contradiction review`
+    );
+  }
+  if (row.thought_type === "belief_snapshot") {
+    hints.push(
+      `belief_overlap: semantic neighbors present — check CONTRADICTS relations in knowledge graph`
+    );
+  }
+  return hints;
+}
+
+export async function runIntelPipeline(
+  pool: pg.Pool,
+  row: ThoughtRow,
+  embed: (text: string) => Promise<number[]>
+): Promise<IntelResult> {
+  const vec = await embed(row.thought);
+  const literal = vectorLiteral(vec);
+
+  await pool.query(`UPDATE public.thoughts SET embedding = $1::vector WHERE id = $2::uuid`, [
+    literal,
+    row.id,
+  ]);
+
+  const neighbors = await fetchNeighbors(pool, row.session_id, row.id, vec);
+  const evolutionHints = evolutionHintsFor(row);
+  const contradictionHints = contradictionHintsFor(row, neighbors);
+
+  return {
+    embeddingDims: vec.length,
+    neighbors,
+    evolutionHints,
+    contradictionHints,
+  };
+}

--- a/prototypes/thought-processing-worker/src/realtime/monitor.ts
+++ b/prototypes/thought-processing-worker/src/realtime/monitor.ts
@@ -1,0 +1,32 @@
+import type { SupabaseClient, RealtimeChannel } from "@supabase/supabase-js";
+
+/**
+ * Optional: subscribe to Postgres Changes on `thoughts` (table is in Realtime publication
+ * per `20260408033928_add_hub_tables_vectors_pgmq_realtime.sql`).
+ *
+ * Use for observability or coalescing work — not required for correctness, since this
+ * worker is already driven by PGMQ. MCP / web clients consume the same Realtime stream
+ * when `thoughts` rows update (e.g. after embedding write).
+ */
+export function subscribeThoughtsChanges(
+  supabase: SupabaseClient,
+  logLabel: string
+): RealtimeChannel {
+  return supabase
+    .channel("thought-processing-worker-monitor")
+    .on(
+      "postgres_changes",
+      { event: "*", schema: "public", table: "thoughts" },
+      (payload) => {
+        const id =
+          (payload.new as { id?: string } | null)?.id ??
+          (payload.old as { id?: string } | null)?.id;
+        console.info(`[${logLabel}] realtime ${payload.eventType} thought_id=${id ?? "?"}`);
+      }
+    )
+    .subscribe((status) => {
+      if (status === "SUBSCRIBED") {
+        console.info(`[${logLabel}] realtime subscribed`);
+      }
+    });
+}

--- a/prototypes/thought-processing-worker/src/types/xenova-transformers.d.ts
+++ b/prototypes/thought-processing-worker/src/types/xenova-transformers.d.ts
@@ -1,0 +1,1 @@
+declare module "@xenova/transformers";

--- a/prototypes/thought-processing-worker/tsconfig.json
+++ b/prototypes/thought-processing-worker/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts"]
+}


### PR DESCRIPTION
## Summary
Preserves a Supabase sleep-time compute prototype (pgmq + embeddings + Docker) that was never committed — lived only in a local stash before this branch.

Implements the research direction in `.specs/agent-governance-substrate/SPEC-THOUGHTBOX-SLEEP-TIME.md`.

Not wired into any deploy path. Pure prototype code, 17 source files.

## What's in
- Dockerfile, package.json, pnpm-lock.yaml, tsconfig.json
- src/index.ts, src/config.ts
- src/db/{pool,pgmq,supabase}.ts
- src/http/health.ts
- src/pipeline/{embed,embed-xenova,intel}.ts
- src/realtime/monitor.ts
- src/types/xenova-transformers.d.ts
- README.md, .env.example, .gitignore

## Test plan
- [ ] CI passes (additive-only, no existing code touched)
- [ ] No unintended files in diff

Additive preservation — zero risk to existing code paths.