### PR TITLE
docs(specs): preserve v1 finalstretch + hub-deployed specs

### DIFF
--- a/.specs/hub-deployed/SCOPE-LAYER-2-SUPABASE-HUB-STORAGE.md
+++ b/.specs/hub-deployed/SCOPE-LAYER-2-SUPABASE-HUB-STORAGE.md
@@ -1,0 +1,382 @@
+# Layer 2 Scope: SupabaseHubStorage + Migration
+
+Status: SCOPED
+Date: 2026-04-07
+
+## Context
+
+Hub coordination (27 operations across workspaces, problems, proposals, consensus, channels) currently uses FileSystemHubStorage only. Cloud Run containers are stateless — hub state vanishes on restart. This layer implements Supabase-backed hub storage so the hub works deployed.
+
+## Prior Decisions
+
+- Cloud Run is the execution plane (non-negotiable)
+- Supabase is the persistence/intelligence plane (non-negotiable)
+- Edge Functions are background processing only, NOT a second MCP surface
+- `broadcast_changes()` triggers handle event fan-out (Layer 3, separate scope)
+- Hub identity stored in Supabase, not in-memory Maps
+- `SupabaseKnowledgeStorage` does NOT exist yet — only template is `SupabaseStorage` in `src/persistence/supabase-storage.ts`
+
+## HubStorage Interface (source of truth: `src/hub/hub-types.ts:222-251`)
+
+```typescript
+interface HubStorage {
+  // Agent registry (workspace-agnostic)
+  getAgents(): Promise<AgentIdentity[]>;
+  saveAgent(agent: AgentIdentity): Promise<void>;
+  getAgent(agentId: string): Promise<AgentIdentity | null>;
+
+  // Workspace operations
+  getWorkspace(workspaceId: string): Promise<Workspace | null>;
+  saveWorkspace(workspace: Workspace): Promise<void>;
+  listWorkspaces(): Promise<Workspace[]>;
+
+  // Problem operations
+  getProblem(workspaceId: string, problemId: string): Promise<Problem | null>;
+  saveProblem(problem: Problem): Promise<void>;
+  listProblems(workspaceId: string): Promise<Problem[]>;
+
+  // Proposal operations
+  getProposal(workspaceId: string, proposalId: string): Promise<Proposal | null>;
+  saveProposal(proposal: Proposal): Promise<void>;
+  listProposals(workspaceId: string): Promise<Proposal[]>;
+
+  // Consensus operations
+  getConsensusMarker(workspaceId: string, markerId: string): Promise<ConsensusMarker | null>;
+  saveConsensusMarker(marker: ConsensusMarker): Promise<void>;
+  listConsensusMarkers(workspaceId: string): Promise<ConsensusMarker[]>;
+
+  // Channel operations
+  getChannel(workspaceId: string, problemId: string): Promise<Channel | null>;
+  saveChannel(channel: Channel): Promise<void>;
+}
+```
+
+**17 methods** across 6 domains. All async. All workspace-scoped except agent registry.
+
+## Domain Types (source of truth: `src/hub/hub-types.ts`)
+
+### AgentIdentity (lines 12-19)
+```typescript
+{ agentId: string; name: string; role: 'coordinator' | 'contributor';
+  profile?: string; clientInfo?: string; registeredAt: string; }
+```
+
+### Workspace (lines 25-44)
+```typescript
+{ id: string; name: string; description: string; createdBy: string;
+  mainSessionId: string; agents: WorkspaceAgent[]; createdAt: string; updatedAt: string; }
+
+// WorkspaceAgent (nested)
+{ agentId: string; role: 'coordinator' | 'contributor'; joinedAt: string;
+  status: 'online' | 'offline'; lastSeenAt: string; currentWork?: string; }
+```
+
+### Problem (lines 49-74)
+```typescript
+{ id: string; workspaceId: string; title: string; description: string;
+  createdBy: string; assignedTo?: string; status: ProblemStatus;
+  branchId?: string; branchFromThought?: number; resolution?: string;
+  dependsOn?: string[]; parentId?: string; comments: Comment[];
+  createdAt: string; updatedAt: string; }
+
+// Comment (nested)
+{ id: string; agentId: string; content: string; createdAt: string; }
+```
+
+### Proposal (lines 80-111)
+```typescript
+{ id: string; workspaceId: string; title: string; description: string;
+  createdBy: string; sourceBranch: string; problemId?: string;
+  status: ProposalStatus; reviews: Review[]; mergeThoughtNumber?: number;
+  createdAt: string; updatedAt: string; }
+
+// Review (nested)
+{ id: string; proposalId: string; reviewerId: string; verdict: ReviewVerdict;
+  reasoning: string; thoughtRefs?: number[]; createdAt: string; }
+```
+
+### ConsensusMarker (lines 117-126)
+```typescript
+{ id: string; workspaceId: string; name: string; description: string;
+  thoughtRef: number; branchId?: string; agreedBy: string[]; createdAt: string; }
+```
+
+### Channel (lines 132-149)
+```typescript
+{ id: string; workspaceId: string; problemId: string; messages: ChannelMessage[]; }
+
+// ChannelMessage (nested)
+{ id: string; agentId: string; content: string; timestamp: string;
+  ref?: { sessionId?: string; thoughtNumber?: number; branchId?: string; }; }
+```
+
+## Deliverables
+
+### 1. Supabase Migration
+
+File: `supabase/migrations/YYYYMMDDHHMMSS_add_hub_tables.sql`
+
+**Design decision: nested arrays vs normalized tables.**
+
+The filesystem storage stores `comments`, `reviews`, `messages`, `agents` (on workspace), `agreedBy`, and `dependsOn` as JSON arrays inside the parent object. Two options:
+
+| Approach | Pros | Cons |
+|----------|------|------|
+| **JSONB columns** for nested arrays | Matches domain types 1:1, simpler mapping code, fewer tables | No FK constraints on nested items, harder to query individually |
+| **Normalized tables** for nested items | FK integrity, queryable, indexable | More tables (4-5 extra), more complex mapping, more joins |
+
+**Recommendation: JSONB for comments, reviews, agreed_by, depends_on. Normalized table for channel_messages only** (messages grow unboundedly and need pagination; the others are bounded small arrays).
+
+#### Tables
+
+```sql
+-- 1. Hub agents (workspace-agnostic, global registry)
+CREATE TABLE public.hub_agents (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id text UNIQUE NOT NULL,
+  name text NOT NULL,
+  role text NOT NULL DEFAULT 'contributor',
+  profile text,
+  client_info text,
+  registered_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- 2. Hub workspaces (distinct from SaaS workspaces table)
+CREATE TABLE public.hub_workspaces (
+  id text PRIMARY KEY,  -- matches domain type (string ID, not uuid)
+  tenant_workspace_id uuid NOT NULL REFERENCES public.workspaces(id),
+  name text NOT NULL,
+  description text NOT NULL DEFAULT '',
+  created_by text NOT NULL REFERENCES public.hub_agents(agent_id),
+  main_session_id text,
+  agents jsonb NOT NULL DEFAULT '[]',  -- WorkspaceAgent[]
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- 3. Hub problems
+CREATE TABLE public.hub_problems (
+  id text PRIMARY KEY,
+  workspace_id text NOT NULL REFERENCES public.hub_workspaces(id),
+  tenant_workspace_id uuid NOT NULL REFERENCES public.workspaces(id),
+  title text NOT NULL,
+  description text NOT NULL DEFAULT '',
+  created_by text NOT NULL,
+  assigned_to text,
+  status text NOT NULL DEFAULT 'open',
+  branch_id text,
+  branch_from_thought integer,
+  resolution text,
+  depends_on jsonb DEFAULT '[]',  -- string[]
+  parent_id text REFERENCES public.hub_problems(id),
+  comments jsonb NOT NULL DEFAULT '[]',  -- Comment[]
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- 4. Hub proposals
+CREATE TABLE public.hub_proposals (
+  id text PRIMARY KEY,
+  workspace_id text NOT NULL REFERENCES public.hub_workspaces(id),
+  tenant_workspace_id uuid NOT NULL REFERENCES public.workspaces(id),
+  title text NOT NULL,
+  description text NOT NULL DEFAULT '',
+  created_by text NOT NULL,
+  source_branch text NOT NULL DEFAULT '',
+  problem_id text REFERENCES public.hub_problems(id),
+  status text NOT NULL DEFAULT 'open',
+  reviews jsonb NOT NULL DEFAULT '[]',  -- Review[]
+  merge_thought_number integer,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- 5. Hub consensus markers
+CREATE TABLE public.hub_consensus_markers (
+  id text PRIMARY KEY,
+  workspace_id text NOT NULL REFERENCES public.hub_workspaces(id),
+  tenant_workspace_id uuid NOT NULL REFERENCES public.workspaces(id),
+  name text NOT NULL,
+  description text NOT NULL DEFAULT '',
+  thought_ref integer NOT NULL,
+  branch_id text,
+  agreed_by jsonb NOT NULL DEFAULT '[]',  -- string[]
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- 6. Hub channels
+CREATE TABLE public.hub_channels (
+  id text PRIMARY KEY,
+  workspace_id text NOT NULL REFERENCES public.hub_workspaces(id),
+  tenant_workspace_id uuid NOT NULL REFERENCES public.workspaces(id),
+  problem_id text NOT NULL REFERENCES public.hub_problems(id)
+);
+
+-- 7. Hub channel messages (normalized — grows unboundedly)
+CREATE TABLE public.hub_channel_messages (
+  id text NOT NULL,
+  channel_id text NOT NULL REFERENCES public.hub_channels(id),
+  tenant_workspace_id uuid NOT NULL REFERENCES public.workspaces(id),
+  agent_id text NOT NULL,
+  content text NOT NULL,
+  ref jsonb,  -- { sessionId?, thoughtNumber?, branchId? }
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (channel_id, id)
+);
+```
+
+#### Indexes
+
+```sql
+CREATE INDEX idx_hub_problems_workspace ON public.hub_problems(workspace_id);
+CREATE INDEX idx_hub_problems_tenant ON public.hub_problems(tenant_workspace_id);
+CREATE INDEX idx_hub_proposals_workspace ON public.hub_proposals(workspace_id);
+CREATE INDEX idx_hub_consensus_workspace ON public.hub_consensus_markers(workspace_id);
+CREATE INDEX idx_hub_channels_workspace ON public.hub_channels(workspace_id);
+CREATE INDEX idx_hub_channel_messages_channel ON public.hub_channel_messages(channel_id, created_at);
+CREATE INDEX idx_hub_channel_messages_tenant ON public.hub_channel_messages(tenant_workspace_id);
+```
+
+#### RLS Policies
+
+```sql
+-- Enable RLS on all tables
+ALTER TABLE public.hub_agents ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.hub_workspaces ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.hub_problems ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.hub_proposals ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.hub_consensus_markers ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.hub_channels ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.hub_channel_messages ENABLE ROW LEVEL SECURITY;
+
+-- Service role: full access (MCP server uses service_role key)
+-- Pattern: one policy per table, matches existing convention
+CREATE POLICY "service_role_full_access" ON public.hub_agents
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+-- (repeat for each table)
+
+-- Authenticated users: read within their tenant workspace
+CREATE POLICY "tenant_member_read" ON public.hub_problems
+  FOR SELECT TO authenticated
+  USING (tenant_workspace_id IN (
+    SELECT workspace_id FROM public.workspace_memberships
+    WHERE user_id = auth.uid()
+  ));
+-- (repeat pattern for each table with tenant_workspace_id)
+```
+
+### 2. SupabaseHubStorage Implementation
+
+File: `src/hub/supabase-hub-storage.ts` (~350-450 LOC estimated)
+
+```typescript
+interface SupabaseHubStorageConfig {
+  supabaseUrl: string;
+  serviceRoleKey: string;
+  tenantWorkspaceId: string;  // SaaS workspace for tenant isolation
+}
+```
+
+**Method mapping (17 methods):**
+
+| Method | Supabase Query |
+|--------|---------------|
+| `getAgents()` | `from('hub_agents').select()` |
+| `saveAgent(agent)` | `from('hub_agents').upsert(row, { onConflict: 'agent_id' })` |
+| `getAgent(agentId)` | `from('hub_agents').select().eq('agent_id', agentId).maybeSingle()` |
+| `getWorkspace(id)` | `from('hub_workspaces').select().eq('id', id).eq('tenant_workspace_id', this.tenantId).maybeSingle()` |
+| `saveWorkspace(ws)` | `from('hub_workspaces').upsert(row)` |
+| `listWorkspaces()` | `from('hub_workspaces').select().eq('tenant_workspace_id', this.tenantId)` |
+| `getProblem(wsId, id)` | `from('hub_problems').select().eq('id', id).eq('workspace_id', wsId).maybeSingle()` |
+| `saveProblem(p)` | `from('hub_problems').upsert(row)` |
+| `listProblems(wsId)` | `from('hub_problems').select().eq('workspace_id', wsId)` |
+| `getProposal(wsId, id)` | `from('hub_proposals').select().eq('id', id).eq('workspace_id', wsId).maybeSingle()` |
+| `saveProposal(p)` | `from('hub_proposals').upsert(row)` |
+| `listProposals(wsId)` | `from('hub_proposals').select().eq('workspace_id', wsId)` |
+| `getConsensusMarker(wsId, id)` | `from('hub_consensus_markers').select().eq('id', id).eq('workspace_id', wsId).maybeSingle()` |
+| `saveConsensusMarker(m)` | `from('hub_consensus_markers').upsert(row)` |
+| `listConsensusMarkers(wsId)` | `from('hub_consensus_markers').select().eq('workspace_id', wsId)` |
+| `getChannel(wsId, probId)` | `from('hub_channels').select().eq('workspace_id', wsId).eq('problem_id', probId).maybeSingle()` + join messages |
+| `saveChannel(ch)` | Upsert channel row + upsert messages to `hub_channel_messages` |
+
+**Row mappers needed (private methods):**
+- `rowToAgent()` / `agentToRow()`
+- `rowToWorkspace()` / `workspaceToRow()`
+- `rowToProblem()` / `problemToRow()`
+- `rowToProposal()` / `proposalToRow()`
+- `rowToConsensusMarker()` / `consensusMarkerToRow()`
+- `rowToChannel()` / `channelToRow()` (includes message join)
+
+**Channel.messages special handling:** `getChannel()` must join `hub_channel_messages` ordered by `created_at`. `saveChannel()` must diff messages and insert only new ones (or upsert by id).
+
+### 3. Wiring in index.ts
+
+Current (`src/index.ts:71-74,104,117,157`):
+```typescript
+hubStorage: createFileSystemHubStorage(baseDir),
+```
+
+Change: In the `supabase` storage branch, replace with:
+```typescript
+hubStorage: createSupabaseHubStorage({
+  supabaseUrl: process.env.SUPABASE_URL!,
+  serviceRoleKey: process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  tenantWorkspaceId: workspaceId,
+}),
+```
+
+**Note:** HubStorage is created ONCE in the StorageBundle (not per-request). The `tenantWorkspaceId` scopes all queries. Agent registry (`hub_agents`) is global across tenants.
+
+### 4. Hub Identity: No Changes Needed
+
+Research finding: `hub-tool-handler.ts` session-scoped Maps (`sessionDefaults`, `sessionRegistries`) track which agents are registered within a given MCP session. These are SESSION state, not persistent state. They serve a different purpose than the hub_agents table.
+
+- `hub_agents` table: persistent registry of all agents that have ever registered
+- `sessionDefaults`/`sessionRegistries`: which agent this MCP session is acting as
+
+**No changes to hub-tool-handler.ts.** The session Maps are correct for their purpose. SupabaseHubStorage handles persistence. The tool handler handles session binding.
+
+## What This Does NOT Include
+
+- `broadcast_changes()` triggers (Layer 3)
+- Background intelligence pipeline / embeddings (Layer 4)
+- Plugin packaging (Layer 5)
+- `tb.hub` Code Mode wiring (Layer 1, separate scope)
+- Edge Function queue processors
+- pgvector columns on hub tables (deferred to Layer 4)
+- Changes to HubStorage interface (additive implementation only)
+- Changes to hub-handler.ts or hub-tool-handler.ts
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `supabase/migrations/YYYYMMDDHHMMSS_add_hub_tables.sql` | NEW — 7 tables, indexes, RLS |
+| `src/hub/supabase-hub-storage.ts` | NEW — ~400 LOC |
+| `src/index.ts` | MODIFY — 3 lines (storage selection in supabase branch) |
+| `src/database.types.ts` | REGENERATE — `supabase gen types typescript` after migration |
+
+## Dependencies
+
+- Supabase CLI for migrations (`supabase db push`)
+- Existing `SupabaseStorage` pattern in `src/persistence/supabase-storage.ts` as template
+- No changes to HubStorage interface — new implementation only
+
+## Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| Hub operations assume fast reads (filesystem was sync-like) | All hub operations already async; Supabase queries add ~5-20ms |
+| JSONB columns for comments/reviews lose FK integrity | Bounded arrays (<100 items typically); integrity enforced at application layer |
+| `hub_workspaces.id` is `text` not `uuid` (matches domain type) | Consistent with how hub generates IDs; PK still enforced |
+| Existing `workspaces` table name collision | Hub tables prefixed `hub_*`; tenant FK via `tenant_workspace_id` |
+| Channel messages grow unbounded | Normalized table with pagination; index on `(channel_id, created_at)` |
+
+## Acceptance Criteria
+
+1. `THOUGHTBOX_STORAGE=supabase` creates `SupabaseHubStorage` instead of filesystem
+2. All 27 hub operations work through Supabase storage
+3. Hub state persists across Cloud Run container restarts
+4. Tenant isolation: workspace A cannot see workspace B's hub data
+5. FileSystemHubStorage still works for local dev (`THOUGHTBOX_STORAGE=fs`)
+6. `supabase gen types typescript` produces updated `database.types.ts`

--- a/.specs/thoughtbox-v1-finalstretch/SPEC-CORRELATION-CONTRACT.md
+++ b/.specs/thoughtbox-v1-finalstretch/SPEC-CORRELATION-CONTRACT.md
@@ -1,0 +1,88 @@
+# SPEC-CORRELATION-CONTRACT: Canonical Audit Correlation
+
+## Status: DRAFT
+
+## Summary
+
+Thoughtbox auditability depends on a single canonical contract for joining
+reasoning data and activity telemetry. The system must not infer correlation
+from absence, guessed equality, or parser-side reconstruction.
+
+For the current release, the canonical join path is:
+
+1. a Thoughtbox reasoning session exists
+2. a `runs` row exists for the work period
+3. OTEL events arrive with the raw OTEL session identifier
+4. a required hook-side binding event carries both the Thoughtbox session
+   identity and OTEL session identity
+5. the backend reconciles the `runs` row
+6. all audit queries resolve through `runs`
+
+For the current release, a run enters `binding_missing` only after both
+reasoning and telemetry exist without a canonical binding for a bounded window.
+
+## Requirements
+
+1. `runs` is the only authoritative bridge between Thoughtbox session data and
+   OTEL-backed telemetry.
+2. Thoughtbox session identity and OTEL `session.id` must be treated as
+   different external identifiers.
+3. The system must not rely on raw equality between those identifiers.
+4. The binding event emitted by the hook path is required product
+   infrastructure for this release.
+5. Reconciliation must update the canonical `runs` row, not attach ad hoc joins
+   inside query handlers.
+6. Observability and cost queries must resolve telemetry through `runs`, not by
+   guessing or bypassing the binding layer.
+7. If binding has not happened, the system must surface `binding_missing`
+   explicitly rather than returning an empty or misleading healthy view.
+8. The binding timeout clock starts only once both reasoning and telemetry
+   exist for the same work period and no canonical binding has been recorded.
+9. The bounded timeout for the release is 15 seconds from that point.
+
+## Acceptance Criteria
+
+- [ ] One real work period creates one canonical `runs` row
+- [ ] OTEL rows persist the raw OTEL session identifier
+- [ ] Binding event ingestion can populate or update the `runs` row with the
+      OTEL session identifier
+- [ ] Timeline and cost queries read OTEL data through `runs`
+- [ ] No release-path query assumes a fake shared session key
+- [ ] When reasoning and telemetry both exist without a binding, the product
+      surfaces `binding_missing`
+
+## Invariants
+
+1. No run is `healthy` without a bound `runs` row.
+2. No query may claim a correlated audit trail without a canonical binding.
+3. No fallback parser-side inference is allowed for the release path.
+4. Hook-side binding failure is a product-visible failure, not a debug-only
+   condition.
+5. Reconciliation is idempotent by exact value match only.
+
+## Non-Goals
+
+- Replacing hooks with a daemon runtime
+- Inferring correlation from repository structure
+- Solving multi-connection merge heuristics for this cutline
+
+## Dependencies
+
+- `runs` schema and persistence support
+- Hook-side binding event emission
+- OTEL ingestion of raw session identifiers
+- Failure state machine for explicit health reporting
+
+## Decisions
+
+- Reconciliation is idempotent by exact value match only. There is no relaxed
+  “equivalent payload” tolerance mode for the release.
+- A run is promoted to `binding_missing` 15 seconds after both reasoning and
+  telemetry exist without a canonical binding.
+- The timeout clock does not start at session creation. It starts only once both
+  sides of the correlation are present and the binding is still absent.
+
+## Remaining Investigation
+
+- Validate whether 15 seconds is generous enough to absorb normal async hook,
+  network, and ingestion latency without masking real binding failures.

--- a/.specs/thoughtbox-v1-finalstretch/SPEC-DRIFT-PREVENTION-HOOKS.md
+++ b/.specs/thoughtbox-v1-finalstretch/SPEC-DRIFT-PREVENTION-HOOKS.md
@@ -1,0 +1,259 @@
+# SPEC-DRIFT-PREVENTION-HOOKS: Agent Drift Prevention Hook Stack
+
+## Status: DRAFT
+
+## Summary
+
+A stack of Claude Code plugin hooks that mitigate the specific agent failure
+class documented in this project's research session
+`e74954cd-0984-488e-a830-54a77259bc45`: losing user-stated decisions across
+turns, re-proposing rejected architecture, reverting to removed configuration,
+asserting repo state without verification, and flipping positions under
+pressure without grounded evidence.
+
+The hooks ship inside `plugins/thoughtbox-claude-code/` and use Thoughtbox's
+existing `decision_frame` thought type as durable storage. They operate via
+Claude Code's documented hook surface (`UserPromptSubmit`, `Stop`) and do not
+modify `.claude/settings.json`. None of the hooks alter agent capabilities;
+they only add reminders, audits, and termination gates.
+
+## Motivation
+
+Frontier LLMs exhibit a measurable, documented failure class in long
+conversational coding sessions:
+
+- **Instruction fade-out** (OpenDev, arXiv 2603.05344): stated rules lose
+  influence over turn distance.
+- **Recursive self-deception** (Anthropic issue #26650): agent acknowledges
+  a rule, proposes a compliant plan, executes a violation of that plan,
+  and repeats the same pattern on the proposed fix.
+- **Epistemic flattening** (Zenodo defensive-linguistics taxonomy): agent
+  delivers speculation and verified fact in the same confident register.
+- **Sycophancy flip under pressure** (arXiv 2505.23840 SYCON Bench):
+  sustained user pushback induces position reversal regardless of evidence.
+- **Multi-tier instruction conflict failure** (arXiv 2604.09443 ManyIH):
+  frontier models score ~40% at resolving conflicts across many privilege
+  tiers; a codebase with CLAUDE.md + AGENTS.md + `.claude/rules/` + session
+  instructions + per-turn corrections is exactly such a multi-tier stack.
+
+Anthropic's own Opus 4.7 launch announcement reports "similar low rates" of
+sycophancy versus 4.6 — the model upgrade does not resolve this class.
+
+The user's existing scaffolding (CLAUDE.md, AGENTS.md, rules, memory, skills,
+HDD/Ulysses/Theseus protocols, hooks) already matches the architectural shape
+the literature endorses. The gap is specifically: **no mechanism captures
+stated decisions and forces them back into the model's context at later
+turn boundaries, and no mechanism audits the model's assertions against
+the verification history of the current turn.** This spec fills that gap.
+
+## Requirements
+
+### 1. Hook Surface
+
+1. All hooks are declared in
+   `plugins/thoughtbox-claude-code/hooks/hooks.json`, inside the existing
+   plugin manifest. No additions to `.claude/settings.json`.
+2. All hooks are implemented as subcommands of the `thoughtbox` CLI already
+   shipped by the plugin, invoked via the plugin's `bin/` PATH. No new
+   standalone scripts.
+3. Hooks that post to Thoughtbox use the hosted Cloud Run endpoint configured
+   via the plugin's existing `userConfig.thoughtbox_url` and
+   `userConfig.thoughtbox_api_key`. No new credentials.
+4. Hooks fail open. A Thoughtbox server outage must never block the user's
+   turn; it may degrade the reminder quality for that turn.
+
+### 2. `thoughtbox hook capture-user-turn` (UserPromptSubmit, async)
+
+1. Reads the hook payload from stdin.
+2. Extracts the user's submitted prompt text and the current Claude Code
+   session id.
+3. Ensures an active Thoughtbox reasoning session exists for this Claude
+   Code session; creates one if not.
+4. Writes the user prompt as a `context_snapshot` thought in the Thoughtbox
+   session, tagged with `['user-turn', claudeSessionId]`.
+5. Runs asynchronously (`curl ... &` style) so it does not add latency to
+   the turn.
+6. Must be idempotent across duplicate hook invocations for the same turn.
+
+### 3. `thoughtbox hook surface-decisions` (UserPromptSubmit, sync)
+
+1. Reads the hook payload from stdin.
+2. Queries Thoughtbox for thoughts in the active session with thoughtType in
+   {`decision_frame`, `assumption_update`} where assumption_update has
+   `newStatus: "refuted"`. Orders by recency. Limit configurable via
+   `userConfig.drift_reminder_limit` (default 10).
+3. Emits a `<system-reminder type="session-decisions">` block via the hook's
+   `additionalContext` output, containing the retrieved items as
+   `Decision #K (turn M): [text]` entries.
+4. Must complete within 500ms p95. Server must expose a cached
+   `/cli/session-decisions` endpoint to meet this bound.
+5. When zero matching items exist for the session, emits no block.
+
+### 4. `thoughtbox hook promote-to-decision` (UserPromptSubmit, async)
+
+1. Reads the hook payload from stdin.
+2. Evaluates whether the user's prompt matches correction-language patterns
+   (configurable, default set: leading `no`, `stop`, `don't`, `actually`,
+   `we removed`, `that's wrong`, explicit imperative negation).
+3. On match, issues a Thoughtbox revision that rewrites the user-turn
+   thought recorded by `capture-user-turn` as an `assumption_update` thought
+   with `newStatus: "refuted"` and the `text` field populated from the
+   user's prompt. This is lighter than promoting to `decision_frame`
+   (which requires structured `options`) while still flagging the turn as
+   a durable correction that surface-decisions should re-inject.
+4. Runs asynchronously. Failure to reclassify must not block the turn.
+5. False positives on this hook are less harmful than false negatives
+   because the surface-decisions hook only injects recency-ordered items;
+   a noisy frame falls out of the top-N quickly.
+
+### 5. `thoughtbox hook audit-response` (Stop, sync)
+
+1. Reads the hook payload from stdin, including the response text and the
+   tool-use history for the just-completed turn.
+2. Scans the response for assertion patterns referencing repo state.
+   Minimum patterns: `the [path] [is|contains|has]`, `[path] still [verb]`,
+   `the current state of [path]`, `package.json [verb]`,
+   `the file [path] [verb]`, and a configurable regex list extensible via
+   `userConfig.audit_patterns`.
+3. For each matched assertion, verifies that the turn's tool-use history
+   contains at least one `Read`, `Grep`, `Glob`, or `Bash` call referencing
+   a path or symbol consistent with the assertion.
+4. If any assertion fails verification, the hook returns a blocking JSON
+   response that refuses turn termination and returns to the model a
+   message of the form: `Assertion about {target} was not verified in this
+   turn. Either cite the file:line you read, or remove the claim.`
+5. Must complete within 800ms p95. Pattern scanning is local; no network.
+
+### 6. `thoughtbox hook detect-flip` (Stop, sync, optional LLM-as-judge)
+
+1. Reads the hook payload from stdin plus the last N `decision_frame` thoughts
+   AND the user's immediately prior prompt text.
+2. **Trigger gate**: only runs the contradiction check when the prior user
+   prompt contains authority/expertise/consensus pushback language
+   (configurable regex list, default: `^(no|stop|don't|listen to me|I
+   (already )?told you|we (already )?decided|you're wrong|how many times|you
+   need to listen|that's wrong)`). This narrows the hook to the specific
+   condition under which sycophancy-flip is most likely, per the AAAI
+   instruction-hierarchy finding that authority/expertise/consensus framings
+   override system/user role separation. Without the gate, the hook would
+   fire on benign self-corrections.
+3. On trigger, performs a cheap LLM-judge call (Haiku-class) asking whether
+   the current response contradicts any of the provided decision frames.
+4. On detected contradiction, checks whether the response contains a cited
+   verification (file:line reference present in the turn's tool-use history).
+5. If contradiction is detected AND no verification is cited, returns a
+   blocking JSON response with the message: `Response reverses decision #K
+   ("{quote}") under pressure. Verify the reversal with a tool call and cite
+   it, or remove the contradicting claim.`
+6. If Thoughtbox returns zero decision frames for the session, the hook is
+   a no-op.
+7. Gated off by `userConfig.detect_flip_enabled` (default true). Can be
+   disabled when the LLM-judge latency is unacceptable.
+
+### 7. CLI Subcommand Additions
+
+1. Add a `hook` subcommand family to the plugin's `thoughtbox` CLI with
+   the four handlers above (capture-user-turn, surface-decisions,
+   promote-to-decision, audit-response, detect-flip).
+2. These subcommands are distinct from the existing OTLP `hook` family
+   written by the pre-existing `mergeThoughtboxInitConfig` path. The OTLP
+   capture hooks remain in the plugin's shell scripts; these new hooks
+   are the TypeScript-implemented drift-prevention family.
+3. Each subcommand reads JSON from stdin, matching Claude Code's hook
+   payload schema.
+4. Each subcommand exits 0 on success. On blocking cases (hooks 5 and 6),
+   they print a JSON object with `{"decision": "block", "reason": "..."}`
+   on stdout consistent with Claude Code's hook protocol.
+
+### 8. Server Endpoints
+
+The hosted Thoughtbox server must expose:
+
+1. `POST /cli/session-thought` — append a thought to the active session
+   for the authenticated user. Accepts `{thoughtType, content, tags}`.
+2. `GET /cli/session-decisions?sessionId=&limit=` — return recent
+   `decision_frame` thoughts for the given Claude Code session. Cached at
+   the server for ≤2s to meet the latency bound in requirement §3.4.
+3. `POST /cli/session-thought-revise` — revise a thought, used by
+   `promote-to-decision` to change `thoughtType`.
+4. `POST /cli/judge-contradiction` — optional endpoint wrapping the LLM
+   judge for `detect-flip`. Alternative: the hook calls Anthropic's API
+   directly with the user's own key. Implementation choice deferred.
+
+### 9. Configuration
+
+New `userConfig` entries in `plugins/thoughtbox-claude-code/.claude-plugin/plugin.json`:
+
+- `drift_reminder_limit` — number, default 10, max 25. Controls the size of
+  the injected session-decisions block.
+- `audit_patterns` — string array, default empty. Additional regex
+  patterns for `audit-response`.
+- `detect_flip_enabled` — boolean, default true.
+- `decision_patterns` — string array, default documented set. Correction-
+  language regexes for `promote-to-decision`.
+
+## Acceptance Criteria
+
+- [ ] With the hook stack enabled, a session that reproduces today's
+      interaction sequence (npm/hub/channel/server-distribution drifts) has
+      the relevant decision_frames surfaced by thought M and the drift
+      attempts at turn M+1 blocked or auto-retracted.
+- [ ] Hook latency budgets (500ms p95 for surface-decisions, 800ms p95 for
+      audit-response) are met under the hosted Cloud Run default latency.
+- [ ] With Thoughtbox server unreachable, the hooks degrade silently and
+      the user's turns still complete.
+- [ ] Disabling the plugin disables the hooks entirely with no residual
+      effect on `.claude/settings.json`.
+- [ ] `thoughtbox doctor` reports the drift-prevention hooks as an optional
+      informational item, not a required one.
+- [ ] No hook reclassifies user prompts without an accompanying Thoughtbox
+      revision record attributable to the promotion event.
+
+## Non-Goals
+
+- Replacing or altering the existing OTLP tool capture or session tracker
+  hooks.
+- Fine-tuning the model or any training-time intervention.
+- Preventing all classes of agent failure; this spec addresses a specific
+  slice (decision persistence and assertion verification) documented in
+  the motivation.
+- Blocking tool calls. All hooks operate at `UserPromptSubmit` and `Stop`
+  boundaries; `PreToolUse` is untouched.
+- Altering the channel MCP server or its instructions.
+
+## Dependencies
+
+- `plugins/thoughtbox-claude-code/` plugin infrastructure.
+- Thoughtbox hosted server with the endpoints in §8.
+- `decision_frame` thought type already present in Thoughtbox's `thought`
+  module.
+- Claude Code hook protocol for `UserPromptSubmit` and `Stop` events,
+  including the `additionalContext` injection path and the blocking
+  decision JSON schema.
+
+## Decisions
+
+- The plugin's `hooks.json` is the canonical hook surface. No writes to
+  `.claude/settings.json` from `thoughtbox init`.
+- Decisions are stored in Thoughtbox, not in a local file. This aligns
+  with the Supabase-only persistence decision.
+- `capture-user-turn` writes all user prompts as `context_snapshot` first;
+  `promote-to-decision` narrows by pattern. Separation of capture from
+  classification.
+- `audit-response` refuses termination rather than silently logging. The
+  intent is to force correction at the turn boundary, not after-the-fact
+  discovery.
+- `detect-flip` is opt-outable because its LLM-judge cost may be
+  unacceptable for some workloads; `audit-response` is not opt-outable.
+
+## References
+
+- Source research session: Thoughtbox session
+  `e74954cd-0984-488e-a830-54a77259bc45`.
+- OpenDev event-driven reminders: arXiv 2603.05344.
+- AAAI failure-of-instruction-hierarchies paper:
+  `ojs.aaai.org/index.php/AAAI/article/view/40339`.
+- ManyIH benchmark: arXiv 2604.09443.
+- SYCON Bench: arXiv 2505.23840.
+- Anthropic claude-code issue #46646 (self-written failure analysis).
+- Anthropic claude-code issue #26650 (recursive self-deception loop).

--- a/.specs/thoughtbox-v1-finalstretch/SPEC-FAILURE-STATE-MACHINE.md
+++ b/.specs/thoughtbox-v1-finalstretch/SPEC-FAILURE-STATE-MACHINE.md
@@ -1,0 +1,129 @@
+# SPEC-FAILURE-STATE-MACHINE: Evidence-Gated Product Health
+
+## Status: DRAFT
+
+## Summary
+
+Thoughtbox must stop inferring health from missing effects. The product reports
+explicit setup and correlation states backed by persisted evidence.
+
+This state machine is not optional observability polish. It is core product
+behavior for the hosted release.
+
+## Scope
+
+The release needs two related health models:
+
+1. `workspace_setup_status`
+2. `run_correlation_status`
+
+Both models live in persisted backend state and are rendered directly by the CLI
+and UI.
+
+## Requirements
+
+### 1. Evidence-Gated State
+
+1. A state may advance only when the concrete event for that state has been
+   observed.
+2. Success states are illegal without their required evidence.
+3. Missing expected evidence after a bounded wait transitions to an explicit
+   failure state.
+4. For binding specifically, the bounded wait begins only once both reasoning
+   and telemetry evidence exist.
+
+### 2. Workspace Setup Status
+
+Minimum states:
+
+- `unconfigured`
+- `configured`
+- `auth_failed`
+- `mcp_missing`
+- `hook_missing`
+- `otel_missing`
+- `ready`
+
+Semantics:
+
+- `configured` means config files were written successfully
+- `ready` means `doctor` has proven the release path is usable
+
+### 3. Run Correlation Status
+
+Minimum states:
+
+- `session_created`
+- `reasoning_seen`
+- `telemetry_seen`
+- `reasoning_only`
+- `telemetry_only`
+- `binding_missing`
+- `healthy`
+
+Semantics:
+
+- `reasoning_only` means reasoning data exists, but required telemetry proof did
+  not arrive in time
+- `telemetry_only` means telemetry exists without reasoning linkage
+- `binding_missing` means both sides exist, but the canonical binding does not
+  yet exist
+- `healthy` means reasoning + telemetry + canonical binding all exist for the
+  same work period
+
+### 4. Enforcement Surfaces
+
+1. `thoughtbox init` must not report success if required config writes failed.
+2. `thoughtbox doctor` must fail unless the target workspace reaches `ready`.
+3. The UI must render an explicit state instead of a blank neutral dashboard.
+4. Query handlers must return typed health/failure metadata rather than empty
+   arrays that force the user to guess.
+
+### 5. Persistence
+
+1. Health state must live in the backend database.
+2. CLI, server, ingestion, and UI must all read/write through the same shared
+   truth.
+3. State transitions must be timestamped for debugging and support.
+
+## Acceptance Criteria
+
+- [ ] Every release-path failure mode maps to an explicit typed state
+- [ ] No blank dashboard is shown for an unhealthy workspace or run
+- [ ] `doctor` exits nonzero for any non-`ready` setup state
+- [ ] A correlated run reaches `healthy` only with concrete reasoning,
+      telemetry, and binding evidence
+- [ ] Missing evidence transitions to an explicit failure state after a bounded
+      wait
+
+## Suggested Transition Rules
+
+1. `unconfigured -> configured` after `thoughtbox init` writes config
+2. `configured -> ready` only after `doctor` proves the full path
+3. `session_created -> reasoning_seen` when a Thoughtbox session persists
+4. `session_created -> telemetry_seen` when OTEL data lands first
+5. `reasoning_seen -> reasoning_only` if telemetry does not arrive in time
+6. `telemetry_seen -> telemetry_only` if reasoning does not arrive in time
+7. `reasoning_seen + telemetry_seen -> binding_missing` if the canonical binding
+   is absent
+8. `binding_missing -> healthy` when the `runs` row is reconciled
+
+## Non-Goals
+
+- Generic workflow orchestration
+- Automatic repair of every failure mode
+- Long-term support analytics
+
+## Dependencies
+
+- `thoughtbox init`
+- `thoughtbox doctor`
+- canonical run correlation contract
+- UI support for explicit status rendering
+
+## Open Questions
+
+- Should workspace setup state and run correlation state live in dedicated
+  tables, or should one or both piggyback on existing entities? --> `I think they should live in dedicated tables. `
+- What exact timeout windows are acceptable before promoting missing evidence to
+  failure? --> `I'm going to need a clearer picture of what you're picturing beginning to end here before I can answer that question. `

--- a/.specs/thoughtbox-v1-finalstretch/SPEC-WORKSPACE-SCOPING-CUT.md
+++ b/.specs/thoughtbox-v1-finalstretch/SPEC-WORKSPACE-SCOPING-CUT.md
@@ -1,0 +1,69 @@
+# SPEC-WORKSPACE-SCOPING-CUT: Workspace-As-Project Release Cut
+
+## Status: DRAFT
+
+## Summary
+
+For the first usable hosted release, Thoughtbox drops project scoping entirely.
+Each workspace is treated as exactly one effective project. The MCP server does
+not resolve roots, does not call `listRoots`, and does not block the first tool
+call on project discovery.
+
+This is a release cut, not a claim that project scoping is unimportant forever.
+It exists to remove an activation-critical dependency from the product path.
+
+## Requirements
+
+1. The hosted MCP server must not call `listRoots()` or any equivalent root
+   discovery API during normal activation or tool execution.
+2. The first tool call must not depend on project resolution. A user with a
+   valid workspace API key must be able to connect and run without any
+   root-derived metadata.
+3. All persistence and query paths for the current release must scope by
+   `workspace_id`, not `project_id`.
+4. Existing or legacy `project_id` fields may remain nullable for compatibility,
+   but they must not be required for the hosted cutline.
+5. Where compatibility code still expects a project identifier, the backend may
+   use a synthetic workspace-owned `project_id` value as a deterministic shim.
+6. UI and API copy for the current release must describe the primary container
+   as a workspace, not a project.
+7. Documentation must explicitly say that project model upload, root-aware
+   scoping, and multi-project workspaces are deferred.
+
+## Acceptance Criteria
+
+- [ ] MCP activation succeeds without any root discovery call
+- [ ] `src/server-factory.ts` no longer blocks first tool invocation on project
+      resolution
+- [ ] A valid workspace API key is sufficient to create and use a session
+- [ ] Observability and audit queries for the release path work with
+      `workspace_id` alone
+- [ ] Product docs no longer imply that hosted users must have project scoping
+      working before first value
+
+## Non-Goals
+
+- Restoring root-based project resolution
+- Multi-project workspaces
+- Project model upload
+- Structural enrichment from repository roots
+
+## Consequences
+
+- Blast radius and structural analysis remain deferred
+- Anything that currently depends on `project_id` in the mainline product path
+  must be cut, stubbed, or made optional
+- A synthetic workspace-owned `project_id` is acceptable as a compatibility shim
+  if it does not reintroduce activation-time project discovery
+- The release path becomes materially shorter and removes a class of silent
+  first-call failures
+
+## Decisions
+
+- Use a synthetic workspace-owned `project_id` when compatibility code still
+  requires one.
+
+## Remaining Investigation
+
+- Identify every query surface that still assumes real project scoping and
+  rewrite, stub, or cut it for the release.

--- a/.specs/thoughtbox-v1-finalstretch/WEB-APP-OTEL-QUERY-FIX.md
+++ b/.specs/thoughtbox-v1-finalstretch/WEB-APP-OTEL-QUERY-FIX.md
@@ -1,0 +1,74 @@
+# Web App OTEL Query Fix
+
+## Problem
+
+`/w/[workspaceSlug]/runs/[runId]/page.tsx` queries `otel_events` with `.eq('session_id', runId)` — treating the Thoughtbox session UUID as the OTEL session ID. These are different values. OTEL events have `session_id` = Claude Code's session ID (e.g. `e6749f07`), not the Thoughtbox session UUID (e.g. `8a405981`). Result: OTEL events never load.
+
+## Fix
+
+In `src/app/w/[workspaceSlug]/runs/[runId]/page.tsx`, replace the OTEL queries (lines 44-56) with a two-step lookup through the `runs` binding table:
+
+### Step 1: After fetching the session row (line 25-34), fetch the OTEL session IDs from the `runs` table:
+
+```typescript
+const { data: runRows } = await supabase
+  .from('runs')
+  .select('otel_session_id')
+  .eq('session_id', runId)
+  .not('otel_session_id', 'is', null)
+
+const otelSessionIds = [...new Set(
+  (runRows ?? []).map(r => r.otel_session_id).filter(Boolean)
+)]
+```
+
+### Step 2: Replace the OTEL event queries to use the bound IDs:
+
+```typescript
+// Replace .eq('session_id', runId) with .in('session_id', otelSessionIds)
+// Guard: if otelSessionIds is empty, skip the query entirely
+
+const [thoughtsResult, otelResult, otelCountResult] = await Promise.all([
+  supabase
+    .from('thoughts')
+    .select('*')
+    .eq('session_id', runId)
+    .order('thought_number', { ascending: true }),
+  otelSessionIds.length > 0
+    ? supabase
+        .from('otel_events')
+        .select('id, event_type, event_name, severity, timestamp_at, body, metric_value, event_attrs, session_id')
+        .eq('workspace_id', sessionRow.workspace_id)
+        .in('session_id', otelSessionIds)
+        .order('timestamp_at', { ascending: true })
+        .limit(OTEL_PAGE_LIMIT)
+    : Promise.resolve({ data: [], error: null }),
+  otelSessionIds.length > 0
+    ? supabase
+        .from('otel_events')
+        .select('id', { count: 'exact', head: true })
+        .eq('workspace_id', sessionRow.workspace_id)
+        .in('session_id', otelSessionIds)
+    : Promise.resolve({ count: 0, error: null }),
+])
+```
+
+## What stays the same
+
+- Thoughts query: unchanged, still `.eq('session_id', runId)` — thoughts are stored by Thoughtbox session ID
+- All components: unchanged — `SessionTraceExplorer`, `SessionTimeline`, `ThoughtDetailPanel`, `mergeTimeline` all work already
+- The rendering is built and waiting for data
+
+## Verification
+
+After applying, navigate to `/w/<workspace>/runs/8a405981-1830-4a15-96c5-ce09a865d344`. You should see:
+- Thoughts: 5 reasoning thoughts
+- OTEL events: ~946 events from Claude Code session `e6749f07`
+- Merged timeline showing both interleaved by timestamp
+
+## Database context
+
+The `runs` table bridges Thoughtbox sessions to OTEL sessions:
+- `runs.session_id` → Thoughtbox session UUID (FK to `sessions.id`)
+- `runs.otel_session_id` → Claude Code OTEL session ID (matches `otel_events.session_id`)
+- Multiple runs can share the same `otel_session_id` (reconnects)


### PR DESCRIPTION
## Summary
Six spec files that were never committed — lived only in a local stash before this branch.

## What's in
v1 finalstretch (launch scope; CLI-INIT-DOCTOR deliberately excluded as stale):
- SPEC-CORRELATION-CONTRACT.md
- SPEC-DRIFT-PREVENTION-HOOKS.md
- SPEC-FAILURE-STATE-MACHINE.md
- SPEC-WORKSPACE-SCOPING-CUT.md
- WEB-APP-OTEL-QUERY-FIX.md

Hub deployment:
- .specs/hub-deployed/SCOPE-LAYER-2-SUPABASE-HUB-STORAGE.md

## Test plan
- [ ] CI passes (docs-only)

Additive preservation, docs only.