### PR TITLE
fix(server): skip listRoots when workspaceId is known

### DIFF
--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -305,32 +305,58 @@ Use \`console.log()\` for debugging — output captured in response logs.`;
   const thoughtTool = new ThoughtTool(thoughtHandler);
   const notebookTool = new NotebookTool(notebookHandler);
 
-  // Auto-resolve project scope from MCP roots (or THOUGHTBOX_PROJECT env var)
-  // Deferred: transport isn't connected during createMcpServer()
+  // Resolve project scope.
+  //
+  // Hosted path: args.workspaceId is set by the auth layer. storage and
+  // knowledgeStorage are already workspace-scoped at construction (their
+  // setProject methods are deprecated no-ops). protocolHandler.setProject
+  // still does real work — it assigns the handler's workspaceId. Calling
+  // these synchronously with args.workspaceId gives us correct protocol
+  // scoping AND avoids server.server.listRoots(), which hangs on streamable
+  // HTTP clients that don't cooperate with the relatedRequestId routing
+  // (typescript-sdk#1167). This is the "first tool call on every session
+  // hangs for 300s" bug — with args.workspaceId we never make that call.
+  //
+  // Legacy path (no workspaceId and no env): listRoots retained with a 3s
+  // Promise.race timeout as a seatbelt. Not expected to be reached in any
+  // currently-deployed configuration.
   let projectResolved = false;
   const resolveProject = async (requestId?: string | number) => {
     if (projectResolved) return;
     projectResolved = true;
-    const envProject = process.env.THOUGHTBOX_PROJECT;
-    if (envProject) {
+
+    const project = args.workspaceId || process.env.THOUGHTBOX_PROJECT;
+    if (project) {
       try {
-        await storage.setProject(envProject);
-        if (knowledgeStorage) await knowledgeStorage.setProject(envProject);
-        if (protocolHandler) protocolHandler.setProject(envProject);
-        logger.info(`Project set from THOUGHTBOX_PROJECT: ${envProject}`);
+        await storage.setProject(project);
+        if (knowledgeStorage) await knowledgeStorage.setProject(project);
+        if (protocolHandler) protocolHandler.setProject(project);
+        logger.info(
+          `Project scoped from ${args.workspaceId ? 'workspaceId' : 'THOUGHTBOX_PROJECT'}: ${project}`,
+        );
       } catch (err) {
-        logger.warn('Failed to set project from env:', err);
+        logger.warn('Failed to scope project:', err);
       }
       return;
     }
+
     try {
       // Pass relatedRequestId so the transport routes through the active
       // POST response stream instead of the standalone GET SSE stream,
-      // which hangs over streamable HTTP (typescript-sdk#1167).
+      // which hangs over streamable HTTP (typescript-sdk#1167). Even with
+      // this routing, some clients don't cooperate — the Promise.race with
+      // 3s timeout is a seatbelt that caps the worst case at 3s instead of
+      // the Cloud Run request timeout (300s).
       const options = requestId !== undefined
         ? { relatedRequestId: requestId }
         : undefined;
-      const { roots } = await server.server.listRoots(undefined, options);
+      const timeout = new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('listRoots timed out (3s)')), 3000),
+      );
+      const { roots } = await Promise.race([
+        server.server.listRoots(undefined, options),
+        timeout,
+      ]);
       if (roots.length > 0) {
         const root = roots[0];
         const name = root.name


### PR DESCRIPTION
## Summary
- Stops the 300s first-tool-call hang on every session in hosted production
- Uses `args.workspaceId` (already passed by the auth layer) as project scope instead of calling `listRoots`, which hangs on streamable-HTTP clients that don't cooperate with the `relatedRequestId` routing workaround (typescript-sdk#1167)
- Side effect: `protocolHandler.setProject(workspaceId)` now runs on hosted, which it did not under the hang path — corrects protocol scoping for Theseus/Ulysses enforcement
- Legacy `listRoots` path retained for unauthenticated edge cases with a 3s `Promise.race` seatbelt (caps worst case at 3s, not 300s)

## Why this works
- `SupabaseStorage.setProject` and `SupabaseKnowledgeStorage.setProject` are already deprecated no-ops (verified at `src/persistence/supabase-storage.ts:62-64` and `src/knowledge/supabase-storage.ts:59-61`) — scoping happens at construction via `factory.getStorage(workspaceId)`. So the old `listRoots` path was doing work those layers ignore.
- `ProtocolHandler.setProject` is NOT a no-op (`src/protocol/handler.ts:50-52`) — it assigns `this.workspaceId`. The new code path calls it with the authenticated workspace, which the hang path never reached.
- `args.workspaceId` is always set in hosted mode (`src/index.ts:366-377`, `:422-435`), so the listRoots path is not reached for any currently-deployed user.

## Test plan
- [ ] `pnpm check:types` — clean (verified locally)
- [ ] `pnpm check:lint` — clean (verified locally)
- [ ] Cloud Build deploys to Cloud Run
- [ ] Manual: fresh Claude Code session, first tool call completes within <1s instead of hanging

## What's NOT in this PR
- No lint rule / CI gate to prevent regression — the resolveProject function is the only site affected and is the one being fixed
- Hub `saveBranchThought` / `getBranch` no-ops (separate feature gap, not launch-blocking)
- 84 silent catch blocks across the codebase (separate post-launch ratchet work)
- `ProtocolHandler` constructor refactor to take workspaceId at instantiation (separate cleanup PR, post-launch)

Linear: launch-blocker per today's pre-launch audit.