### PR TITLE
feat(auth): restore invite-code gate on sign-up

### DIFF
--- a/apps/web/src/app/(auth)/actions.ts
+++ b/apps/web/src/app/(auth)/actions.ts
@@ -52,10 +52,19 @@ export async function signUpAction(
   _prevState: AuthFormState,
   formData: FormData,
 ): Promise<AuthFormState> {
+  const inviteCode = (formData.get('inviteCode') as string | null)?.trim() ?? ''
   const email = formData.get('email') as string
   const password = formData.get('password') as string
   const firstName = (formData.get('firstName') as string | null)?.trim() ?? ''
   const lastName = (formData.get('lastName') as string | null)?.trim() ?? ''
+
+  const validCodes = new Set([
+    'DEDALUS25',
+  ])
+
+  if (!validCodes.has(inviteCode.toUpperCase())) {
+    return { error: 'Invalid invite code.' }
+  }
 
   if (password.length < 12) {
     return { error: 'Password must be at least 12 characters.' }

--- a/apps/web/src/app/(auth)/sign-up/SignUpForm.tsx
+++ b/apps/web/src/app/(auth)/sign-up/SignUpForm.tsx
@@ -59,6 +59,21 @@ export function SignUpForm() {
       </div>
 
       <div>
+        <label htmlFor="inviteCode" className="block text-sm font-medium text-foreground">
+          Invite code
+        </label>
+        <input
+          id="inviteCode"
+          name="inviteCode"
+          type="text"
+          required
+          placeholder="Enter your invite code"
+          autoComplete="off"
+          className="mt-1.5 block w-full rounded-none border border-foreground bg-background px-3.5 py-2.5 text-sm text-foreground placeholder-slate-400 focus:border-foreground focus:outline-none focus:ring-2 focus:ring-foreground/20 font-mono tracking-wider"
+        />
+      </div>
+
+      <div>
         <label htmlFor="email" className="block text-sm font-medium text-foreground">
           Work email
         </label>

--- a/apps/web/src/app/(auth)/sign-up/page.tsx
+++ b/apps/web/src/app/(auth)/sign-up/page.tsx
@@ -13,7 +13,7 @@ export default function SignUpPage() {
         <div className="text-center">
           <h1 className="text-2xl font-bold text-foreground">Create your account</h1>
           <p className="mt-1 text-sm text-foreground">
-            Free through May 10, 2026
+            Closed founding beta — invite code required
           </p>
         </div>
 


### PR DESCRIPTION
## Summary
- Reverts \`ddd48a3\` (which removed the invite-code gate on 2026-03-29) now that the closed founding beta requires gating again
- 3 files touched, 25 insertions / 1 deletion. Atomic revert with one subtitle-text tweak to preserve post-ddd48a3 "founding" framing while restoring the invite-required subtitle
- Gate implementation: hardcoded \`Set\` in \`signUpAction\`. Currently accepts \`DEDALUS25\`. To add more codes, add strings to the Set and redeploy. No DB table, no migration, no SQL.

## Test plan
- [ ] Lint / Type Check passes
- [ ] Manual: load \`/sign-up\`, confirm invite code field rendered, subtitle says "Closed founding beta — invite code required"
- [ ] Manual: submit without code → "Invalid invite code." error
- [ ] Manual: submit with \`DEDALUS25\` → account creation proceeds

Closed founding beta launch gate.