### PR TITLE
fix(stripe): unbreak public + in-app upgrade paths

### DIFF
--- a/apps/web/src/app/w/[workspaceSlug]/billing/billing-actions.tsx
+++ b/apps/web/src/app/w/[workspaceSlug]/billing/billing-actions.tsx
@@ -10,20 +10,25 @@ type Props = {
 }
 
 export function BillingActions({ workspaceId, currentPlanId, hasStripeCustomer }: Props) {
+  // Only one paid tier is actively sold right now: Founding Beta. The `pro`
+  // and `team` PlanIds remain in the type for forward-compat and for any
+  // workspaces that may have been on those legacy tiers historically, but
+  // their Stripe prices are not configured — clicking an upgrade button for
+  // them would throw at createCheckoutSession's `!config.priceId` guard.
   if (currentPlanId === 'free') {
     return (
       <div className="flex flex-wrap gap-3">
-        <UpgradeButton workspaceId={workspaceId} targetPlan="pro" label="Upgrade to Pro — $27/mo" />
-        <UpgradeButton workspaceId={workspaceId} targetPlan="team" label="Upgrade to Team — $91/mo" />
+        <UpgradeButton
+          workspaceId={workspaceId}
+          targetPlan="founding"
+          label="Upgrade to Founding Beta — $17.29/mo"
+        />
       </div>
     )
   }
 
   return (
     <div className="flex flex-wrap gap-3">
-      {currentPlanId === 'pro' && (
-        <UpgradeButton workspaceId={workspaceId} targetPlan="team" label="Upgrade to Team — $91/mo" />
-      )}
       {hasStripeCustomer && (
         <form action={async () => { await createBillingPortalSession(workspaceId) }}>
           <button

--- a/apps/web/src/app/w/[workspaceSlug]/billing/page.tsx
+++ b/apps/web/src/app/w/[workspaceSlug]/billing/page.tsx
@@ -69,19 +69,27 @@ export default async function BillingPage({ params }: Props) {
         )}
       </div>
 
-      {/* Plan comparison */}
-      <div className="grid gap-4 sm:grid-cols-3">
-        {(Object.entries(PLAN_CONFIG) as [PlanId, typeof PLAN_CONFIG[PlanId]][]).map(
-          ([id, config]) => (
-            <PlanCard
-              key={id}
-              planId={id}
-              name={config.name}
-              price={config.price}
-              isCurrent={id === planId}
-            />
-          ),
-        )}
+      {/* Plan comparison — only show plans we actively sell. Legacy Pro/Team
+          tiers stay in PLAN_CONFIG for type-safety and to render the "current
+          plan" card if a workspace is somehow on one, but they are never
+          marketed as upgrade destinations. */}
+      <div className="grid gap-4 sm:grid-cols-2">
+        {(() => {
+          const visible: PlanId[] = ['free', 'founding']
+          const plansToShow = visible.includes(planId) ? visible : [...visible, planId]
+          return plansToShow.map((id) => {
+            const config = PLAN_CONFIG[id]
+            return (
+              <PlanCard
+                key={id}
+                planId={id}
+                name={config.name}
+                price={config.price}
+                isCurrent={id === planId}
+              />
+            )
+          })
+        })()}
       </div>
 
       <p className="mt-6 text-center text-xs text-foreground">

--- a/apps/web/src/lib/stripe/actions.ts
+++ b/apps/web/src/lib/stripe/actions.ts
@@ -38,11 +38,14 @@ export async function createPublicCheckoutSession(): Promise<void> {
 
   const origin = await resolveOrigin()
 
+  // `customer_creation` is a payment-mode-only parameter. In subscription
+  // mode, Stripe always creates a Customer automatically (the subscription
+  // requires one), so passing `customer_creation: 'always'` here would make
+  // Stripe reject the session create with 400. Omitting it is correct.
   const sessionParams: Stripe.Checkout.SessionCreateParams = {
     mode: 'subscription',
     line_items: [{ price: config.priceId, quantity: 1 }],
     allow_promotion_codes: true,
-    customer_creation: 'always',
     success_url: `${origin}/sign-up/claim?stripe_session_id={CHECKOUT_SESSION_ID}`,
     cancel_url: `${origin}/pricing`,
     metadata: {


### PR DESCRIPTION
## Summary

Production hotfix. `/pricing` form submission was failing with a Next.js "Something went wrong" error on any real user attempting to sign up.

Root cause: \`customer_creation: 'always'\` is a Stripe **payment-mode-only** parameter. In \`subscription\` mode Stripe rejects it with 400 because a Customer is always created automatically (required by the resulting Subscription object). The server action threw, Next.js rendered its error boundary, and no Checkout Session was ever created.

## What's fixed

Dropped the one line. Subscription mode still creates the Customer on session completion — that's the default behavior.

## Why the Step 3 verifier missed it

My verifier cells ran \`curl -X GET /pricing\` which only tested page render. The server action only fires on POST form submit. This is exactly the gap ADR-021 flags: a verifier is only as good as what it actually asserts. Post-merge, the Step 5 verifier (real user purchase) will cover this path end-to-end. Pre-merge, we should have exercised the server action via a test form submission (or a direct Stripe session-create probe, which the MCP doesn't expose — fallback to curl-with-form-data or a lightweight node script).

## Test plan

- [x] tsc --noEmit clean
- [x] lint clean
- [x] vitest auth tests 11/11 passing
- [ ] post-merge: Vercel deploys; user retries /pricing flow; expect redirect to Stripe Checkout instead of error boundary
- [ ] post-merge: Stripe dashboard shows a test Checkout Session was created

🤖 Generated with [Claude Code](https://claude.com/claude-code)