### PR TITLE
fix(auth): create user in claim page instead of webhook

### DIFF
--- a/apps/web/src/app/(auth)/sign-up/claim/page.tsx
+++ b/apps/web/src/app/(auth)/sign-up/claim/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next'
 import { redirect } from 'next/navigation'
+import { createClient as createAdminClient } from '@supabase/supabase-js'
 import { getStripe } from '@/lib/stripe/server'
+import { getSiteUrl } from '@/lib/thoughtbox-config'
 import { ClaimPanel } from './ClaimPanel'
 
 export const metadata: Metadata = {
@@ -12,51 +14,136 @@ interface Props {
   searchParams: Promise<{ stripe_session_id?: string }>
 }
 
-// Landing page after Stripe Checkout. The Stripe webhook is the authoritative
-// account creator (see /api/stripe/webhook); this page only confirms the
-// payment went through and points the user at the set-password email.
-//
-// If the user closes the browser before this page renders, no harm done: the
-// webhook still creates the account and emails the password-set link.
+function adminClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!url || !key) throw new Error('Supabase admin env vars missing')
+  return createAdminClient(url, key)
+}
+
+async function findAuthUserByEmail(email: string): Promise<{ id: string } | null> {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!url || !key) return null
+  const r = await fetch(
+    `${url}/auth/v1/admin/users?email=${encodeURIComponent(email)}`,
+    { headers: { apikey: key, Authorization: `Bearer ${key}` } },
+  )
+  if (!r.ok) return null
+  const body = (await r.json()) as { users?: Array<{ id: string }> } | Array<{ id: string }>
+  const users = Array.isArray(body) ? body : (body.users ?? [])
+  return users[0] ?? null
+}
+
+// Claim page is the account creator. Stripe redirects here after Checkout with
+// the session id; we verify the session is paid, create (or find) the auth user,
+// update the workspace with Stripe ids, and send a set-password email. This
+// replaces the webhook-based account-creation path, which was fragile in prod.
 export default async function ClaimPage({ searchParams }: Props) {
   const { stripe_session_id: sessionId } = await searchParams
 
-  // No session id → this page was hit directly, not via Stripe redirect.
   if (!sessionId) {
     redirect('/pricing')
   }
 
-  // Server-side verify: was this Stripe session actually paid?
-  // `status === 'complete'` covers both the paid path (`payment_status === 'paid'`)
-  // and the 100%-comped path (`payment_status === 'no_payment_required'`).
   const stripe = getStripe()
-  let email: string | null = null
-  let valid = false
+  let session
   try {
-    const session = await stripe.checkout.sessions.retrieve(sessionId)
-    valid = session.status === 'complete'
-    email = session.customer_details?.email ?? null
+    session = await stripe.checkout.sessions.retrieve(sessionId)
   } catch (err) {
     console.error('Failed to retrieve Stripe session on claim page:', err)
+    return <ClaimError />
   }
 
-  if (!valid || !email) {
-    return (
-      <div className="w-full max-w-md">
-        <div className="rounded-2xl border border-red-200 bg-red-50 p-8 text-center">
-          <h1 className="text-xl font-bold text-red-800">We couldn&apos;t verify your payment</h1>
-          <p className="mt-2 text-sm text-red-700">
-            If you just completed checkout and Stripe is still processing, try refreshing in a
-            minute. If you think this is an error, contact{' '}
-            <a href="mailto:thoughtboxsupport@kastalienresearch.ai" className="underline">
-              support
-            </a>
-            .
-          </p>
-        </div>
-      </div>
-    )
+  // `status === 'complete'` covers the paid path (`payment_status === 'paid'`)
+  // and the 100%-comped path (`payment_status === 'no_payment_required'`).
+  const paid = session.status === 'complete'
+  const email = session.customer_details?.email ?? null
+  const customerId = typeof session.customer === 'string' ? session.customer : null
+  const subscriptionId = typeof session.subscription === 'string' ? session.subscription : null
+  const planId = session.metadata?.plan_id ?? 'founding'
+
+  if (!paid || !email || !customerId || !subscriptionId) {
+    return <ClaimError />
+  }
+
+  const admin = adminClient()
+
+  // Create-or-find: createUser errors on duplicate email (refresh of this page,
+  // or retry after a previous run partially completed).
+  let userId: string
+  const { data: createData, error: createError } = await admin.auth.admin.createUser({
+    email,
+    email_confirm: true,
+    user_metadata: {
+      signup_source: 'stripe_checkout',
+      stripe_session_id: sessionId,
+    },
+  })
+
+  if (createError) {
+    const existing = await findAuthUserByEmail(email)
+    if (!existing) {
+      console.error('Claim: user creation failed and no existing user:', createError)
+      return <ClaimError />
+    }
+    userId = existing.id
+  } else {
+    userId = createData.user.id
+  }
+
+  // DB trigger `handle_new_user` creates a workspace row on auth.users insert.
+  // Update it with Stripe state. Idempotent — re-running writes the same values.
+  // `.select('id')` lets us detect the zero-rows case (trigger didn't fire,
+  // user pre-dates the trigger) and surface it instead of silently continuing.
+  const { data: updated, error: updateError } = await admin
+    .from('workspaces')
+    .update({
+      stripe_customer_id: customerId,
+      stripe_subscription_id: subscriptionId,
+      plan_id: planId,
+      subscription_status: 'active',
+    })
+    .eq('owner_user_id', userId)
+    .select('id')
+
+  if (updateError || !updated || updated.length === 0) {
+    console.error('Claim: workspace update failed:', {
+      userId,
+      email,
+      rowsUpdated: updated?.length ?? 0,
+      updateError,
+    })
+    return <ClaimError />
+  }
+
+  // Send the set-password link. Non-fatal if it fails — the claim page exposes
+  // a "Resend the email" button that calls the same action.
+  const siteUrl = getSiteUrl()
+  const { error: mailError } = await admin.auth.resetPasswordForEmail(email, {
+    redirectTo: `${siteUrl}/api/auth/callback?next=/reset-password`,
+  })
+  if (mailError) {
+    console.error('Claim: welcome email failed:', mailError)
   }
 
   return <ClaimPanel email={email} stripeSessionId={sessionId} />
+}
+
+function ClaimError() {
+  return (
+    <div className="w-full max-w-md">
+      <div className="rounded-2xl border border-red-200 bg-red-50 p-8 text-center">
+        <h1 className="text-xl font-bold text-red-800">We couldn&apos;t verify your payment</h1>
+        <p className="mt-2 text-sm text-red-700">
+          If you just completed checkout and Stripe is still processing, try refreshing in a
+          minute. If you think this is an error, contact{' '}
+          <a href="mailto:thoughtboxsupport@kastalienresearch.ai" className="underline">
+            support
+          </a>
+          .
+        </p>
+      </div>
+    </div>
+  )
 }

--- a/apps/web/src/app/(auth)/sign-up/claim/page.tsx
+++ b/apps/web/src/app/(auth)/sign-up/claim/page.tsx
@@ -70,8 +70,12 @@ export default async function ClaimPage({ searchParams }: Props) {
   const admin = adminClient()
 
   // Create-or-find: createUser errors on duplicate email (refresh of this page,
-  // or retry after a previous run partially completed).
+  // or retry after a previous run partially completed). Only fall back to the
+  // existing-user lookup on duplicate-email errors — other failures (rate
+  // limits, validation, transient 5xx) must not silently overwrite an
+  // unrelated existing user's workspace with this session's Stripe state.
   let userId: string
+  let userWasJustCreated = false
   const { data: createData, error: createError } = await admin.auth.admin.createUser({
     email,
     email_confirm: true,
@@ -82,6 +86,14 @@ export default async function ClaimPage({ searchParams }: Props) {
   })
 
   if (createError) {
+    const isDuplicate =
+      createError.code === 'email_exists' ||
+      createError.code === 'user_already_exists' ||
+      createError.status === 422
+    if (!isDuplicate) {
+      console.error('Claim: user creation failed (non-duplicate):', createError)
+      return <ClaimError />
+    }
     const existing = await findAuthUserByEmail(email)
     if (!existing) {
       console.error('Claim: user creation failed and no existing user:', createError)
@@ -89,7 +101,12 @@ export default async function ClaimPage({ searchParams }: Props) {
     }
     userId = existing.id
   } else {
+    if (!createData.user) {
+      console.error('Claim: createUser returned no user and no error')
+      return <ClaimError />
+    }
     userId = createData.user.id
+    userWasJustCreated = true
   }
 
   // DB trigger `handle_new_user` creates a workspace row on auth.users insert.
@@ -117,14 +134,18 @@ export default async function ClaimPage({ searchParams }: Props) {
     return <ClaimError />
   }
 
-  // Send the set-password link. Non-fatal if it fails — the claim page exposes
-  // a "Resend the email" button that calls the same action.
-  const siteUrl = getSiteUrl()
-  const { error: mailError } = await admin.auth.resetPasswordForEmail(email, {
-    redirectTo: `${siteUrl}/api/auth/callback?next=/reset-password`,
-  })
-  if (mailError) {
-    console.error('Claim: welcome email failed:', mailError)
+  // Send the set-password link only on fresh creation. Refreshes, retries, and
+  // bookmarked revisits skip the send to avoid duplicate emails and tripping
+  // GoTrue's per-email rate limit. The "Resend the email" button in ClaimPanel
+  // is the supported path for getting another link.
+  if (userWasJustCreated) {
+    const siteUrl = getSiteUrl()
+    const { error: mailError } = await admin.auth.resetPasswordForEmail(email, {
+      redirectTo: `${siteUrl}/api/auth/callback?next=/reset-password`,
+    })
+    if (mailError) {
+      console.error('Claim: welcome email failed:', mailError)
+    }
   }
 
   return <ClaimPanel email={email} stripeSessionId={sessionId} />

--- a/apps/web/src/app/api/stripe/webhook/route.ts
+++ b/apps/web/src/app/api/stripe/webhook/route.ts
@@ -2,7 +2,6 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getStripe } from '@/lib/stripe/server'
 import { createClient } from '@supabase/supabase-js'
 import type Stripe from 'stripe'
-import { getSiteUrl } from '@/lib/thoughtbox-config'
 
 // Use service role client — webhooks run without user context.
 function createServiceClient() {
@@ -10,25 +9,6 @@ function createServiceClient() {
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY
   if (!url || !key) throw new Error('Supabase env vars missing')
   return createClient(url, key)
-}
-
-// Look up an existing auth user by email via Supabase admin API.
-// Returns the user or null. As of @supabase/supabase-js 2.99.1, the JS SDK
-// admin surface does not expose a direct getUserByEmail helper (only
-// getUserById and listUsers); we call the GoTrue REST endpoint directly.
-// Revisit if a future SDK upgrade adds a typed email lookup.
-async function findAuthUserByEmail(email: string): Promise<{ id: string } | null> {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
-  const key = process.env.SUPABASE_SERVICE_ROLE_KEY
-  if (!url || !key) return null
-  const r = await fetch(
-    `${url}/auth/v1/admin/users?email=${encodeURIComponent(email)}`,
-    { headers: { apikey: key, Authorization: `Bearer ${key}` } },
-  )
-  if (!r.ok) return null
-  const body = await r.json()
-  const users = Array.isArray(body?.users) ? body.users : Array.isArray(body) ? body : []
-  return users[0] ?? null
 }
 
 export async function POST(request: NextRequest) {
@@ -64,113 +44,11 @@ export async function POST(request: NextRequest) {
   switch (event.type) {
     case 'checkout.session.completed': {
       const session = event.data.object as Stripe.Checkout.Session
-      const signupFlow = session.metadata?.signup_flow
       const planId = session.metadata?.plan_id
 
-      // Public signup flow: webhook is the authoritative account creator.
-      // This branch creates the Supabase auth user and updates the auto-
-      // provisioned workspace with Stripe state. No workspace_id is expected
-      // in metadata because the workspace does not exist yet at checkout time.
-      if (signupFlow === 'public') {
-        const email = session.customer_details?.email
-        const customerId = session.customer as string | null
-        const subscriptionId = session.subscription as string | null
-
-        // All three guards return 500 (not 400) so Stripe retries with
-        // exponential backoff for up to ~3 days. 4xx would make Stripe give up
-        // immediately, which is catastrophic here: the user has already been
-        // charged, so we need a recovery window to either auto-heal (transient
-        // race) or manually intervene (genuine anomaly surfaced in logs).
-        if (!email) {
-          console.error('public signup webhook missing customer_details.email:', session.id)
-          return NextResponse.json({ error: 'missing email' }, { status: 500 })
-        }
-        if (!customerId || !subscriptionId) {
-          console.error('public signup webhook missing customer or subscription:', session.id)
-          return NextResponse.json({ error: 'missing stripe ids' }, { status: 500 })
-        }
-
-        // Find or create the auth user. createUser is idempotent from our side:
-        // if the email already exists (e.g. webhook re-delivery), we fetch the
-        // existing user and proceed.
-        let userId: string
-        const { data: createData, error: createError } =
-          await supabase.auth.admin.createUser({
-            email,
-            email_confirm: true,
-            user_metadata: {
-              signup_source: 'stripe_checkout',
-              stripe_session_id: session.id,
-            },
-          })
-
-        if (createError) {
-          // Common case: user already exists (webhook redelivery). Look up.
-          const existing = await findAuthUserByEmail(email)
-          if (!existing) {
-            console.error('Failed to create user and no existing user found:', createError)
-            return NextResponse.json({ error: 'user creation failed' }, { status: 500 })
-          }
-          userId = existing.id
-        } else {
-          userId = createData.user.id
-        }
-
-        // The auto-provisioning trigger (handle_new_user) creates the
-        // workspace row synchronously when createUser inserts into
-        // auth.users, so the UPDATE below will find it. For the re-delivery
-        // path (existing user), we still update to reflect latest Stripe state.
-        //
-        // We chain .select('id') so we can detect the zero-rows-matched case
-        // (e.g. the auto-provisioning trigger failed silently, or the user
-        // pre-dates the trigger). PostgREST does NOT raise an error on a
-        // zero-row UPDATE; without this check the webhook would return 200 to
-        // Stripe and leave the user charged but without Stripe IDs populated
-        // on their workspace. Returning 500 lets Stripe's at-least-once
-        // retry handle the gap.
-        const { data: updatedRows, error: updateError } = await supabase
-          .from('workspaces')
-          .update({
-            stripe_customer_id: customerId,
-            stripe_subscription_id: subscriptionId,
-            plan_id: planId ?? 'founding',
-            subscription_status: 'active',
-          })
-          .eq('owner_user_id', userId)
-          .select('id')
-
-        if (updateError || !updatedRows || updatedRows.length === 0) {
-          console.error('Failed to update workspace after public signup:', {
-            userId,
-            email,
-            rowsUpdated: updatedRows?.length ?? 0,
-            updateError,
-          })
-          return NextResponse.json(
-            { error: 'workspace update failed — no rows matched owner_user_id' },
-            { status: 500 },
-          )
-        }
-
-        // Send the user a set-password link. We use resetPasswordForEmail rather
-        // than inviteUserByEmail because the user already exists (just-created
-        // above) and because recovery links are the supported flow for setting
-        // the initial password on an admin-created account. Failure here is
-        // logged but non-fatal: the user can request a fresh link from the
-        // claim page.
-        const { error: mailError } = await supabase.auth.resetPasswordForEmail(email, {
-          redirectTo: `${getSiteUrl()}/api/auth/callback?next=/reset-password`,
-        })
-        if (mailError) {
-          console.error('Failed to send welcome email:', mailError)
-        }
-
-        console.log(`Public signup completed for ${email} → user ${userId}`)
-        break
-      }
-
-      // In-app upgrade flow (authenticated user clicked Upgrade on the billing
-      // page). Workspace already exists; metadata carries workspace_id.
+      // Only the in-app upgrade flow goes through the webhook. Public-signup
+      // account creation lives on /sign-up/claim — see that file for the
+      // create-user + workspace-update flow.
       const workspaceId = session.metadata?.workspace_id
       if (!workspaceId || !planId) {
         console.error('checkout.session.completed missing metadata:', session.id)


### PR DESCRIPTION
## Summary

Stripe webhook signature verification has been failing in prod with `No signatures found matching the expected signature` on every delivery. Secret has been rotated/re-pasted multiple times from Workbench into Vercel — still fails. Local reproduction with \`stripe listen\` confirms the code path is correct, so the bug is somewhere in the Vercel env/runtime pairing, not the code.

Rather than keep debugging that, pivot: **make the claim page do what the webhook was supposed to do.**

The claim page already retrieves the Stripe session server-side to verify payment. This PR extends that to also:

1. Create (or find) the Supabase auth user via admin API
2. Update the workspace with \`stripe_customer_id\`, \`stripe_subscription_id\`, \`plan_id\`, \`subscription_status='active'\`
3. Send the set-password email via \`resetPasswordForEmail\`

All synchronously, in the request the browser makes right after Checkout redirects back.

The webhook handler still exists for in-app upgrades (\`signup_flow !== 'public'\`) and subscription lifecycle events. Those are not launch-blocking.

## Test plan

- [ ] Merge → Vercel auto-deploys
- [ ] Make a test purchase via /pricing
- [ ] Verify redirect to /sign-up/claim?stripe_session_id=...
- [ ] Verify "Payment received, check your email" UI renders
- [ ] Verify Supabase \`auth.users\` has a row for the test email
- [ ] Verify \`workspaces\` has a row with correct stripe ids + plan_id=founding + subscription_status=active
- [ ] Verify set-password email arrives (check spam)
- [ ] Verify clicking the link lands in \`/reset-password\`, setting password signs the user in and lands in their workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)