### PR TITLE
fix(auth): handle recovery email hash flow on reset-password page

### DIFF
--- a/apps/web/src/app/(auth)/actions.ts
+++ b/apps/web/src/app/(auth)/actions.ts
@@ -58,7 +58,7 @@ export async function forgotPasswordAction(
 
   const supabase = await createClient()
   const { error } = await supabase.auth.resetPasswordForEmail(email, {
-    redirectTo: `${siteUrl}/api/auth/callback?next=/reset-password`,
+    redirectTo: `${siteUrl}/reset-password`,
   })
 
   if (error) {
@@ -79,7 +79,7 @@ export async function resendWelcomeEmailAction(email: string): Promise<{ ok: boo
   const siteUrl = getSiteUrl()
   const supabase = await createClient()
   const { error } = await supabase.auth.resetPasswordForEmail(email, {
-    redirectTo: `${siteUrl}/api/auth/callback?next=/reset-password`,
+    redirectTo: `${siteUrl}/reset-password`,
   })
   if (error) {
     console.error('resendWelcomeEmailAction failed:', error)

--- a/apps/web/src/app/(auth)/reset-password/ResetPasswordForm.tsx
+++ b/apps/web/src/app/(auth)/reset-password/ResetPasswordForm.tsx
@@ -1,13 +1,39 @@
 'use client'
 
-import { useActionState } from 'react'
+import { useActionState, useEffect, useState } from 'react'
 import { resetPasswordAction, type AuthFormState } from '../actions'
+import { createClient } from '@/lib/supabase/client'
 
 export function ResetPasswordForm() {
   const [state, formAction, pending] = useActionState<AuthFormState, FormData>(
     resetPasswordAction,
     null,
   )
+  const [ready, setReady] = useState(false)
+
+  // Supabase recovery emails deliver the access/refresh tokens in the URL hash
+  // fragment (implicit flow). The hash is invisible to server code, so the
+  // session has to be established client-side before the server action runs.
+  // Instantiating the browser client triggers detectSessionInUrl, which reads
+  // the hash and writes session cookies. We clear the hash once processed so
+  // a refresh doesn't re-replay tokens.
+  useEffect(() => {
+    const supabase = createClient()
+    supabase.auth.getSession().finally(() => {
+      if (window.location.hash) {
+        window.history.replaceState(null, '', window.location.pathname)
+      }
+      setReady(true)
+    })
+  }, [])
+
+  if (!ready) {
+    return (
+      <div className="mt-6 text-center text-sm text-foreground/60" aria-live="polite">
+        Preparing…
+      </div>
+    )
+  }
 
   return (
     <form action={formAction} className="mt-6 space-y-4" aria-label="Set new password form">

--- a/apps/web/src/app/(auth)/sign-up/claim/page.tsx
+++ b/apps/web/src/app/(auth)/sign-up/claim/page.tsx
@@ -138,10 +138,19 @@ export default async function ClaimPage({ searchParams }: Props) {
   // bookmarked revisits skip the send to avoid duplicate emails and tripping
   // GoTrue's per-email rate limit. The "Resend the email" button in ClaimPanel
   // is the supported path for getting another link.
+  //
+  // redirectTo points at /reset-password directly, not /api/auth/callback.
+  // Supabase recovery emails use the implicit flow — tokens arrive in the URL
+  // hash fragment, which is only visible to client code. The server-side
+  // callback route expects a PKCE `?code=` query param, which recovery emails
+  // don't provide, so routing through it would lose the session. The
+  // reset-password page instantiates the Supabase browser client on mount,
+  // which auto-detects the hash and writes session cookies before the form
+  // submits.
   if (userWasJustCreated) {
     const siteUrl = getSiteUrl()
     const { error: mailError } = await admin.auth.resetPasswordForEmail(email, {
-      redirectTo: `${siteUrl}/api/auth/callback?next=/reset-password`,
+      redirectTo: `${siteUrl}/reset-password`,
     })
     if (mailError) {
       console.error('Claim: welcome email failed:', mailError)


### PR DESCRIPTION
## Summary

Supabase recovery emails deliver tokens via URL hash fragment (implicit flow), but the previous `redirectTo` pointed at `/api/auth/callback`, a server-side route handler that only understands PKCE `?code=` params. The server couldn't see the hash (browsers don't send hash to server), fell through to its error fallback, and bounced users to `/sign-in?error=auth_callback_error` with the tokens stranded in the URL.

Fix: route recovery emails directly to `/reset-password` and let `ResetPasswordForm` process the hash client-side. Instantiating the SSR browser client on mount triggers `detectSessionInUrl`, which reads the hash and writes session cookies; the `resetPasswordAction` server action then runs with an authenticated session as expected.

Three files, ~40 lines:
- `apps/web/src/app/(auth)/sign-up/claim/page.tsx` — `redirectTo` change
- `apps/web/src/app/(auth)/actions.ts` — same change in `resendWelcomeEmailAction` and `forgotPasswordAction`
- `apps/web/src/app/(auth)/reset-password/ResetPasswordForm.tsx` — client hash-processing `useEffect` with a brief "Preparing…" state

`/api/auth/callback` stays in place for OAuth flows (which do use PKCE).

## Test plan

- [ ] Merge → Vercel prod deploys
- [ ] On the ClaimPanel from a fresh Stripe-gated signup, click "Resend the email"
- [ ] Open the new email, click the set-password link
- [ ] Verify you land on `/reset-password` (not `/sign-in?error=auth_callback_error`)
- [ ] Verify the page briefly shows "Preparing…" then renders the two-password form
- [ ] Set a password, submit, confirm redirect into the workspace dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)