### PR TITLE
security: identity-binding fixes + MCP SDK CVE patch

### DIFF
--- a/.specs/security/identity-binding-audit.md
+++ b/.specs/security/identity-binding-audit.md
@@ -1,0 +1,621 @@
+# Identity-Binding Bug Class Audit
+
+| Field | Value |
+|---|---|
+| Audit date | 2026-04-22 |
+| Auditor | Claude Opus 4.7 (1M context), interactive session |
+| Specimen | Password-reset incident, 2026-04-22 (User A's recovery hash + User B's stale cookies → `updateUser` ran against User B) |
+| Specimen fix | commit `96bcb4a` on branch `fix/reset-password-hash-flow` |
+| Reasoning trail | Thoughtbox session `f87f023d-5ce8-4281-b6f4-694b70ca94f6` (88 thoughts spanning design + audit) |
+| Audit branch | `fix/reset-password-hash-flow` |
+| Scope | Whole monorepo's auth-touching surface — `apps/web/`, `src/` (MCP server), `supabase/functions/`, `supabase/migrations/`, `plugins/`, `infra/` |
+
+## Method
+
+This audit took the password-reset incident as a *specimen* representing one or more underlying classes of identity-binding violation, then enumerated every instance of those classes across the monorepo's auth-touching surface.
+
+The audit ran as a structured Thoughtbox session in five phases:
+
+0. **Orientation** — `rg` over identity-touching mechanisms produced a canonical 41-file candidate list grouped into web (W), workspace-page (P), MCP-server (M), edge-function (E), and SQL-migration (R) areas.
+1. **Class extraction** — two parallel passes (invariant-driven + counterfactual-driven), synthesized to require both gates pass. Six classes survived (5 fundamental + 1 paradigm-relative). Triaged via the "would a different auth library have this class" test.
+2. **Per-class enumeration** — for each class, the predicate was first written as a thought, then expressed as a tooling query (`rg`/AST-style) where possible to narrow the candidate space; one atomic verdict thought per (candidate, class) cited file:line evidence.
+3. **Formalization** — for each fundamental class, a Boolean predicate or recommended type/wrapper was locked.
+4. **Side-findings sweep** — one round of class re-extraction over off-class evidence accumulated during Phase 2; produced 2 auxiliary classes (A1, A2).
+5. **Synthesis** — this artifact.
+
+The audit terminated with **zero UNCERTAIN debt** — every candidate received a definite MEMBER / NOT-MEMBER verdict with cited evidence.
+
+## Class summary
+
+| ID | Class | Triage | Active members | Specimen | Defense state |
+|---|---|---|---|---|---|
+| **C1** | PRINCIPAL-INSTALLED-AT-MUTATION | Fundamental | 0 active after 2026-04-25 ship pass | ✓ | Reset-password server action now verifies recovery principal before mutation |
+| **C2** | EXPLICIT-MUTATION-TARGET | Fundamental | 1 latent after 2026-04-25 ship pass | ✓ | Reset-password fixed; profile update remains latent/deferred |
+| **C3** | ASYNC-SESSION-RACE | Paradigm-relative | 0 active | ✓ (specimen now defended by 96bcb4a) | Watch list — applies only under @supabase/ssr browser-client + implicit-flow paradigm |
+| **C4** | CROSS-FLOW-COOKIE-CONTAMINATION | Fundamental | 0 active after 2026-04-25 ship pass | ✓ | Reset-password now clears local auth state before explicit recovery install |
+| **C5** | PATH-PARAM-PRINCIPAL-VERIFICATION | Fundamental | 0 | — | RLS-defended by architectural design (membership-join in every workspace-scoped policy) |
+| **C6** | ADMIN-BYPASS-PRINCIPAL-SOURCE | Fundamental | 0 active in `BranchHandlers` after 2026-04-25 ship pass | — | `sessions`, `thoughts`, and `branches` operations now filter by API-key workspace |
+| **A1** | REDIRECT-TARGET-NOT-VERIFIED | Fundamental (aux) | 1 | — | OAuth callback `next` param trusted verbatim |
+| **A2** | OUT-OF-BAND-ACTION-WITHOUT-CALLER-AUTH | Fundamental (aux) | 1 | — | Claim page set-password-email send rate-limited only by GoTrue |
+
+## Ship-pass status — 2026-04-25
+
+This pass ships only the critical/high findings:
+
+- **C6 fixed** in `src/branch/handlers.ts`: every `sessions`, `thoughts`, and `branches` service-role operation in `BranchHandlers` is scoped with `workspace_id = this.workspaceId`; branch worker token issuance uses the API-key-resolved workspace rather than a fetched session workspace. Regression coverage: `src/branch/__tests__/handlers.test.ts` covers cross-workspace `spawn`, `merge`, `list`, and `get`.
+- **C1/C2/C4 fixed** in reset-password flow: `ResetPasswordForm` clears prior local auth state before explicit recovery-token session install, submits recovery token/user proof, and `resetPasswordAction` validates the recovery token with Supabase Auth, compares it to the cookie-resolved user, and rejects mismatch before `updateUser`. Regression coverage: `apps/web/tests/app/auth/actions.test.ts` covers missing proof, invalid proof, proof mismatch, cookie/recovery mismatch, and verified success.
+- **Deferred, not shipped in this pass**: latent profile-update C2, A1 OAuth callback same-origin redirect validation, A2 claim-page email side-effect rate limiting, and the broader MCP C6 sister audit outside `BranchHandlers`.
+
+## Active findings — priority order
+
+### 1. CRITICAL — C6 — `src/branch/handlers.ts:67-91` — Cross-workspace branch spawn via valid API key
+
+`BranchHandlers.handleSpawn` looks up `sessions` by id under service-role (which bypasses RLS) without filtering by `this.workspaceId` (the API-key-resolved workspace). It then mints a tb-branch token bearing the *fetched* `session.workspace_id`. A holder of a valid API key for workspace A can call `branch.spawn` with a `sessionId` belonging to workspace B; the lookup succeeds, a branch row is inserted in B's workspace, and the returned tb-branch worker URL contains a token that authorizes thought writes into B's workspace.
+
+The HMAC-token defense in `supabase/functions/tb-branch/index.ts` is correctly implemented at the edge — the issue is upstream in token issuance.
+
+**Reproduction sketch** — given a valid API key for workspace A and a sessionId belonging to workspace B (e.g., observed in logs, leaked through error messages, or guessed): call the MCP server's `branch.spawn` tool with `{sessionId: "<B's session>", branchId: "x", branchFromThought: 1}`. Receive a `workerUrl` containing a token signed for B's workspace. POST thoughts to that URL — they land in B's `thoughts` table.
+
+**Status 2026-04-25: fixed in ship pass.**
+
+Applied fix:
+
+```ts
+// src/branch/handlers.ts:67 — current
+const { data: session, error: sessErr } = await this.client
+  .from("sessions")
+  .select("id, workspace_id")
+  .eq("id", sessionId)
+  .single();
+
+// Fix: scope the lookup by the API-key-resolved workspace
+const { data: session, error: sessErr } = await this.client
+  .from("sessions")
+  .select("id, workspace_id")
+  .eq("id", sessionId)
+  .eq("workspace_id", this.workspaceId)
+  .single();
+```
+
+The same scope filter was applied to every `sessions`, `thoughts`, and `branches` service-role operation in `handleSpawn`, `handleMerge`, `handleList`, `handleGet`, `insertMainTrackThought`, `resolveBranches`, and `getSessionWorkspaceId`.
+
+### 2. HIGH — C1 + C2 + C4 — `apps/web/src/app/(auth)/actions.ts:109` — `resetPasswordAction` server-side defenses absent
+
+The specimen. Commit `96bcb4a` added client-side gating to `ResetPasswordForm.tsx` (C3 defense) but the server action `resetPasswordAction` remains undefended at three layers:
+
+- **C1 violation** — calls `supabase.auth.updateUser({ password })` under cookie-resolved session without comparing the resolved `user.id` against the principal embedded in the recovery hash that triggered this flow.
+- **C2 violation** — `updateUser({password})` API takes no target user_id; the action accepts whatever principal the cookies resolve to.
+- **C4 violation** — no `signOut({scope:'local'})` precedes the implicit setSession that the browser client performs in the receiving page. (The fix added gating but not signOut.)
+
+**Status 2026-04-25: fixed in ship pass.**
+
+Applied remediation:
+
+- Browser page disables automatic hash detection, parses the recovery hash explicitly, clears prior local auth state with `signOut({ scope: 'local' })`, validates the recovery access token client-side, calls `setSession`, then submits `recoveryToken` and `recoveryUserId` with the form.
+- `resetPasswordAction` requires the proof fields, validates `recoveryToken` via `supabase.auth.getUser(recoveryToken)`, compares the verified recovery user to the submitted proof and the cookie-resolved user, and refuses mutation on mismatch before calling `updateUser`.
+
+### 3. MEDIUM — C2 latent — `apps/web/src/app/w/[workspaceSlug]/settings/account/actions.ts:19` — `updateProfileAction`
+
+**Status 2026-04-25: deferred, not shipped in the critical/high pass.**
+
+Calls `supabase.auth.updateUser({data:{first_name,last_name}})` with no target id and no prior principal verification. Currently *latent* because the routing topology (middleware-gated, no recovery-hash entry to this route) prevents an external principal from reaching this action. But the action itself is undefended — any future flow that contaminates cookies before this route is reached would silently rewrite the wrong user's display name.
+
+**Recommended remediation:** apply the `verifiedSelfMutate(supabase, verifiedUid, fields)` wrapper described in **§ Recommended primitives**. Pass the workspace-scoped current user's id explicitly.
+
+The sibling `updatePasswordAction` at line 52 is *defended* via knowledge-proof reverify (`signInWithPassword(getUser().email, currentPassword)` at line 46) — this is the canonical safe pattern for self-service password changes and is worth reusing.
+
+### 4. MEDIUM — A1 — `apps/web/src/app/api/auth/callback/route.ts:20` — Open redirect via `next` param
+
+**Status 2026-04-25: deferred, not shipped in the critical/high pass.**
+
+```ts
+if (next) {
+  return NextResponse.redirect(`${origin}${next}`);
+}
+```
+
+`next` is trusted verbatim. Origin pinning (`${origin}`) prevents cross-origin redirect, but allows arbitrary same-origin path including `/w/{otherWorkspaceSlug}/...`. An attacker can craft an OAuth callback URL where the `next` param points at a sensitive same-origin destination. RLS will block unauthorized data reads but the user lands somewhere they didn't intend.
+
+**Recommended remediation:** validate `next` against an allow-list pattern.
+
+```ts
+const SAFE_NEXT_PATHS = /^\/(app|w\/[a-z0-9-]+\/(dashboard|sessions|billing|settings\/.*))$/;
+if (next && SAFE_NEXT_PATHS.test(next)) {
+  return NextResponse.redirect(`${origin}${next}`);
+}
+// Otherwise fall through to default redirect (workspace dashboard or /app).
+```
+
+### 5. LOW — A2 — `apps/web/src/app/(auth)/sign-up/claim/page.tsx:152` — Email-bombing via stripe_session_id
+
+**Status 2026-04-25: deferred, not shipped in the critical/high pass.**
+
+`admin.auth.resetPasswordForEmail(email, ...)` is called with `email` derived from a Stripe session retrieved by URL-supplied `stripe_session_id`. An attacker who acquires a `stripe_session_id` (these appear in `success_url`s and may leak via referrer headers, server logs, or screenshots) can trigger an unbounded number of password-reset emails to that customer.
+
+Mitigations partially in place: GoTrue applies per-email rate-limiting on `resetPasswordForEmail`, and the send only fires on `userWasJustCreated` (refreshes/retries skip the send).
+
+**Recommended remediation:** add a server-side rate-limit keyed on `(email, ip, time-window)` independent of GoTrue's; or add CAPTCHA on the claim page if abuse is observed.
+
+---
+
+## Class definitions
+
+### C1 — PRINCIPAL-INSTALLED-AT-MUTATION (fundamental)
+
+**Definition.** A server-side mutation authenticated via the request's session cookies does not verify that the resolved principal matches the principal the UI flow installed for this specific operation.
+
+**Predicate.**
+
+```ts
+// A handler is C1-violating iff:
+//   (a) it constructs a server-side Supabase client from request cookies, AND
+//   (b) it performs at least one mutation against the resolved session principal, AND
+//   (c) it does NOT compare the resolved user.id against an externally-provided
+//       principal-bearing value (recovery hash, OAuth code, signed token, hidden
+//       form field set by the client after a deliberate session install).
+
+type Handler = (formData: FormData) => Promise<unknown>;
+
+function violates_C1(handler: Handler): boolean {
+  return (
+    derives_principal_from_cookies_only(handler) &&
+    mutates_principal_scoped_state(handler) &&
+    !verifies_against_external_source(handler)
+  );
+}
+
+// Suppression rule: handlers whose PURPOSE is to install or destroy the
+// cookie-bound session itself (signIn, signOut, exchangeCodeForSession,
+// middleware session refresh) are exempt — the cookie IS the authorized
+// principal source for those flows by design.
+```
+
+**Members in audited surface:**
+
+| File:line | Verdict | Notes |
+|---|---|---|
+| `apps/web/src/app/(auth)/actions.ts:109` `resetPasswordAction` | FIXED 2026-04-25 | Server action now verifies recovery token principal against cookie-resolved user before `updateUser`. |
+
+**Recommended primitive.** See `verifiedSelfMutate` under § Recommended primitives.
+
+---
+
+### C2 — EXPLICIT-MUTATION-TARGET (fundamental, API-shape dependency)
+
+**Definition.** A self-mutation API call (one that modifies the principal record itself) is invoked without an explicit target identifier, relying on ambient session for target resolution.
+
+**Predicate.**
+
+```ts
+// A call site is C2-violating iff:
+//   (a) the invoked API has the effect "modify the current authenticated user", AND
+//   (b) the API signature does NOT include the target user identifier as a parameter, AND
+//   (c) the call is NOT immediately preceded by a verified comparison establishing
+//       that the ambient session principal IS the intended target.
+
+// AST-grep query (TypeScript):
+//   pattern: ($_).auth.updateUser($_)
+// Then per-site: check for a preceding principal verification.
+//
+// Safe forms:
+//   (a) supabase.auth.admin.updateUserById(verifiedUid, ...) — explicit target under
+//       service-role, with verifiedUid established out-of-band.
+//   (b) supabase.auth.updateUser(...) preceded by knowledge-proof reverify:
+//       const { data: { user } } = await supabase.auth.getUser();
+//       const { error } = await supabase.auth.signInWithPassword({
+//         email: user.email, password: currentPasswordFromForm
+//       });
+//       if (error) return { error: 'Current password is incorrect.' };
+//       await supabase.auth.updateUser({ password: newPassword });
+```
+
+**Members in audited surface:**
+
+| File:line | Verdict | Notes |
+|---|---|---|
+| `apps/web/src/app/(auth)/actions.ts:109` | FIXED 2026-04-25 | Recovery token/user proof establishes the intended target before ambient-session `updateUser`. |
+| `apps/web/src/app/w/[workspaceSlug]/settings/account/actions.ts:19` | **MEMBER** (latent) | `updateProfileAction` — routing currently prevents external principal but action is undefended. |
+| `apps/web/src/app/w/[workspaceSlug]/settings/account/actions.ts:52` | NOT-MEMBER | `updatePasswordAction` — knowledge-proof reverify at line 46 satisfies (c). |
+
+**Recommended primitive.** See `verifiedSelfMutate` under § Recommended primitives.
+
+---
+
+### C3 — ASYNC-SESSION-RACE (paradigm-relative)
+
+**Definition.** A client-side flow installs an authenticated session asynchronously (via `setSession` from URL hash, `exchangeCodeForSession` in a useEffect, or `detectSessionInUrl` auto-detection) but allows user-actionable surfaces (form submission, link click, redirect trigger) to fire before that install has completed.
+
+**Triage rationale.** This class only exists inside the `@supabase/ssr` browser-client + implicit-flow paradigm. A team using PKCE-only auth or server-side recovery-token exchange would never have it. Per user direction, treated as paradigm-relative — enumerated rather than formalized.
+
+**Members in audited surface:**
+
+| File:line | Verdict | Notes |
+|---|---|---|
+| `apps/web/src/app/(auth)/reset-password/ResetPasswordForm.tsx:21` | NOT-MEMBER (post-fix) | Specimen. Pre-fix MEMBER. Fix at lines 12, 20-28, 30-36 gates form render on `getSession()` resolving. |
+| `apps/web/src/lib/session/use-session-realtime.ts:18` | NOT-MEMBER | No install (workspace pages have no hash); no interactive surface. |
+
+**Watch-list trigger.** Any new file under `apps/web/src/app/(auth)/` that imports from `@/lib/supabase/client` AND renders an interactive surface should be re-audited against this predicate. Known future trigger candidates: magic-link landings, email-OTP landings, signup-confirmation landings — Supabase delivers all of these via the same implicit-hash flow by default.
+
+---
+
+### C4 — CROSS-FLOW-COOKIE-CONTAMINATION (fundamental)
+
+**Definition.** A flow that establishes a new authenticated session does not first clear any prior session cookies that could otherwise pollute the server's view of the request when the flow's subsequent server action fires.
+
+**Predicate.**
+
+```ts
+// A flow is C4-violating iff:
+//   (a) it installs a new session (setSession, exchangeCodeForSession, or
+//       implicit detectSessionInUrl), AND
+//   (b) the install is client-side OR followed by a server action that reads cookies, AND
+//   (c) it does NOT call signOut({ scope: 'local' }) BEFORE the install.
+
+// Server-side installs (signInWithPassword in a server action,
+// exchangeCodeForSession in a route handler) are exempt: they are atomic from
+// the cookie perspective — subsequent same-request API calls use in-memory
+// session, not stale cookies.
+
+// Canonical defended client-component shape:
+useEffect(() => {
+  (async () => {
+    const supabase = createClient();
+    await supabase.auth.signOut({ scope: 'local' });        // (1) clear prior
+    // Disable automatic detection so we control timing:
+    //   createBrowserClient(url, key, { auth: { detectSessionInUrl: false } });
+    // Parse hash explicitly:
+    const params = new URLSearchParams(window.location.hash.slice(1));
+    const access_token = params.get('access_token');
+    const refresh_token = params.get('refresh_token');
+    if (access_token && refresh_token) {
+      await supabase.auth.setSession({ access_token, refresh_token });
+    }
+    window.history.replaceState(null, '', window.location.pathname);
+    setReady(true);                                         // (2) only now allow form
+  })();
+}, []);
+```
+
+**Members in audited surface:**
+
+| File:line | Verdict | Notes |
+|---|---|---|
+| `apps/web/src/app/(auth)/reset-password/ResetPasswordForm.tsx:21` | FIXED 2026-04-25 | Recovery flow now clears prior local auth state before explicit `setSession`. |
+| `apps/web/src/app/(auth)/actions.ts:24` `signInAction` | NOT-MEMBER | Server-side install, atomic. |
+| `apps/web/src/app/w/[workspaceSlug]/settings/account/actions.ts:46` | NOT-MEMBER | Same-user re-auth, no contamination vector. |
+| `apps/web/src/app/api/auth/callback/route.ts:17` | NOT-MEMBER | Server-side install, atomic. |
+| `apps/web/src/lib/session/use-session-realtime.ts:18` | NOT-MEMBER | Subscription only, no install. |
+
+**Recommended primitive.** See `useFreshSessionInstall` under § Recommended primitives.
+
+---
+
+### C5 — PATH-PARAM-PRINCIPAL-VERIFICATION (fundamental)
+
+**Definition.** A handler that uses a path parameter (e.g., `:workspaceSlug`, `:userId`) to scope a mutation does not verify that the path parameter resolves to a scope the current session is authorized to mutate.
+
+**Audit result.** **No active members.** The class is *structurally absent* from the audited surface because every workspace-scoped table's RLS policy joins through `workspace_memberships` (or the `is_workspace_member(workspace_id)` SQL helper) and filters by `auth.uid()`. The application code can rely on RLS as the defense layer.
+
+**Predicate.** Defended at the database layer. A SQL guard (runnable as CI):
+
+```sql
+-- C5 CI check — fail if any RLS policy on a table with workspace_id column
+-- doesn't reference workspace_memberships AND auth.uid().
+SELECT
+  p.schemaname,
+  p.tablename,
+  p.polname,
+  p.qual,
+  p.with_check
+FROM pg_policies p
+JOIN information_schema.columns c
+  ON c.table_name = p.tablename
+ AND c.table_schema = p.schemaname
+WHERE c.column_name = 'workspace_id'
+  AND p.schemaname = 'public'
+  -- Allow service-role bypass policies (they're intentional escape hatches)
+  AND 'service_role' <> ALL(COALESCE(p.roles, '{}'))
+  AND (
+    (p.qual !~ '(workspace_memberships|is_workspace_member)' AND p.qual IS NOT NULL)
+    OR p.qual !~ 'auth\.uid\(\)'
+  );
+-- Any row returned indicates a workspace-scoped table with RLS that does not
+-- properly join through membership — investigate before merging.
+```
+
+**Verified safe RLS shapes** (currently in use across the monorepo):
+
+- `workspaces_select_member`, `workspaces_update_admin` (with role filter), `workspaces_delete_owner`, `workspaces_insert_authenticated` — `apps/web/supabase/migrations/20260317000000_core_schema.sql:79-109`.
+- `api_keys_member_access` — `is_workspace_member(workspace_id)` — `supabase/migrations/20260320191032_remote_schema.sql:926`.
+- `sessions_member_access`, `thoughts_member_access` — same helper.
+- `entities`, `relations`, `observations` (knowledge graph) — `workspace_member_access` — `supabase/migrations/20260322153858_add_workspace_id_to_knowledge_tables.sql:67-95`.
+- `otel_events workspace_member_read` — `supabase/migrations/20260327113933_create_otel_events.sql:34`.
+
+**Members verified NOT-MEMBER (RLS-defended):**
+
+| File:line | Verdict | RLS that defends it |
+|---|---|---|
+| `apps/web/src/app/w/[workspaceSlug]/settings/workspace/actions.ts:24` `updateWorkspaceNameAction` | NOT-MEMBER | `workspaces_update_admin` (role-filtered) |
+| `apps/web/src/app/w/[workspaceSlug]/api-keys/actions.ts:19` `createApiKeyAction` | NOT-MEMBER | `workspaces_select_member` + `api_keys_member_access` |
+| `apps/web/src/app/w/[workspaceSlug]/api-keys/actions.ts:74` `revokeApiKeyAction` | NOT-MEMBER | `api_keys_member_access` (silent 0-row on forged keyId — UX issue, see **§ Side-finding SF2**) |
+| `apps/web/src/lib/stripe/actions.ts:63` `createCheckoutSession` | NOT-MEMBER | `workspaces_select_member` |
+| `apps/web/src/lib/stripe/actions.ts:109` `createBillingPortalSession` | NOT-MEMBER | `workspaces_select_member` |
+
+**Note.** RLS sufficiency for C5 depends on the policy joining through `workspace_memberships` for `auth.uid()`. The SQL CI check above enforces this invariant going forward.
+
+---
+
+### C6 — ADMIN-BYPASS-PRINCIPAL-SOURCE (fundamental)
+
+**Definition.** A code path operating with service-role / admin / RLS-bypass privileges derives the target principal from a request-controlled source (cookies, request body, headers, query params) rather than from an out-of-band verified source (signed event payload, verified token, system-generated job descriptor).
+
+**Predicate.**
+
+```ts
+// Recommended context type for service-role handlers:
+type WorkspaceContext = {
+  workspaceId: string;
+  provenance:
+    | { source: 'api-key'; keyPrefix: string }              // bcrypt-verified at edge
+    | { source: 'signed-token'; payloadHash: string }       // HMAC-verified
+    | { source: 'signed-event'; eventId: string; signatureVerifiedAt: string }
+    | { source: 'system-job'; triggerId: string };          // pgmq, postgres trigger
+};
+
+// A handler is C6-violating iff:
+//   (a) it uses a service-role Supabase client, AND
+//   (b) any .from(workspaceScopedTable).{select|update|delete|insert} call inside
+//       it does NOT chain .eq('workspace_id', ctx.workspaceId).
+
+// AST-grep approximation (TypeScript):
+//   pattern: this.client.from($T).$M(...)
+//     where $T ∈ workspaceScopedTables
+//     AND chain does not include .eq('workspace_id', $$$ctx$$$.workspaceId)
+```
+
+**Members in audited surface:**
+
+| File:line | Verdict | Notes |
+|---|---|---|
+| `src/branch/handlers.ts:67-91` `handleSpawn` | FIXED 2026-04-25 | `sessions`, `thoughts`, and `branches` operations now filter by API-key workspace. |
+| `apps/web/src/app/(auth)/sign-up/claim/page.tsx` | NOT-MEMBER | Target email from Stripe-retrieved session (out-of-band verified). Side-finding A2 logged for email-bombing. |
+| `apps/web/src/app/api/stripe/webhook/route.ts` | NOT-MEMBER | Stripe-signed event payload (verified via `STRIPE_WEBHOOK_SECRET`). |
+| `supabase/functions/process-thought-queue/index.ts` | NOT-MEMBER | `thought_id` from pgmq message (DB trigger origin), workspace_id read from `thoughts` row, CRON_SECRET gate. |
+| `supabase/functions/tb-branch/index.ts` | NOT-MEMBER (at edge) | HMAC-signed token, but trust passes upstream to issuer (`src/branch/handlers.ts`). |
+| `src/auth/api-key.ts` | NOT-MEMBER | bcrypt-verified key → `workspace_id` from `api_keys` row. |
+
+**Class-level escalation.** The pattern observed in `src/branch/handlers.ts:handleSpawn` (service-role lookup of a session by id without workspace cross-check) likely repeats across the MCP server's broader handler surface — `handleMerge`, `handleList`, `getSessionWorkspaceId`, and analogously the knowledge/, persistence/, observatory/ handler files. **A sister audit pass over the full MCP handler surface for workspace_id-filter discipline is recommended.**
+
+**Recommended primitive.** See `WorkspaceScopedClient` under § Recommended primitives.
+
+---
+
+### A1 — REDIRECT-TARGET-NOT-VERIFIED (auxiliary, fundamental)
+
+**Definition.** A server route returns `NextResponse.redirect(target)` (or framework equivalent) where `target` is derived from a request-controlled value AND `target` is not validated against an allow-list of expected destinations.
+
+**Predicate.**
+
+```ts
+// Boolean predicate (route-handler level):
+function violates_A1(route: RouteHandler): boolean {
+  return (
+    route.returns_redirect_with_request_derived_target &&
+    !route.target_validated_against_allowlist
+  );
+}
+
+// Defense pattern (allow-list regex):
+const SAFE_NEXT_PATHS = /^\/(app|w\/[a-z0-9-]+\/(dashboard|sessions|billing|settings\/.*))$/;
+if (next && SAFE_NEXT_PATHS.test(next)) {
+  return NextResponse.redirect(`${origin}${next}`);
+}
+```
+
+**Members in audited surface:**
+
+| File:line | Verdict | Notes |
+|---|---|---|
+| `apps/web/src/app/api/auth/callback/route.ts:20` | **MEMBER** | Origin-pinned (no cross-origin) but same-origin path is unrestricted. See **Active findings § 4**. |
+
+---
+
+### A2 — OUT-OF-BAND-ACTION-WITHOUT-CALLER-AUTH (auxiliary, fundamental)
+
+**Definition.** A server endpoint triggers an external side effect (email, SMS, webhook delivery, payment, notification) where the target of the side effect is named by request data AND the endpoint does not authenticate the caller as authorized to trigger that action for that target.
+
+**Predicate.**
+
+```ts
+// Boolean predicate (endpoint level):
+function violates_A2(endpoint: Endpoint): boolean {
+  return (
+    endpoint.triggers_external_side_effect &&
+    endpoint.target_named_by_request_data &&
+    !endpoint.authenticates_caller_for_target
+  );
+}
+
+// Defense patterns (any one suffices):
+//   (a) require authenticated caller AND verify caller has authority over target
+//   (b) rate-limit per-(target, ip, time-window) at application layer (don't trust GoTrue alone)
+//   (c) require CAPTCHA or proof-of-work for unauthenticated callers
+//   (d) require cryptographic proof of target ownership (e.g., signed link)
+```
+
+**Members in audited surface:**
+
+| File:line | Verdict | Notes |
+|---|---|---|
+| `apps/web/src/app/(auth)/sign-up/claim/page.tsx:152` | **MEMBER** | `resetPasswordForEmail` triggered by URL-supplied stripe_session_id. Partially mitigated by GoTrue rate-limit + `userWasJustCreated` gate. See **Active findings § 5**. |
+
+---
+
+## Recommended primitives
+
+Implementing these three reusable primitives collapses the structural enforcement of C1, C2, C4, and C6 into a small surface area that is easy to audit and hard to misuse.
+
+### `verifiedSelfMutate` — closes C1 + C2
+
+```ts
+// apps/web/src/lib/supabase/verified-mutate.ts (new)
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export async function verifiedSelfMutate(
+  supabase: SupabaseClient,
+  expectedUserId: string,
+  fields: { password?: string; email?: string; data?: Record<string, unknown> },
+): Promise<{ data?: unknown; error?: { message: string } }> {
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+  if (authError || !user) {
+    return { error: { message: 'Not authenticated.' } };
+  }
+  if (user.id !== expectedUserId) {
+    // The session principal is not who the calling flow believed it would be.
+    // This is the C1 defense — refuse to proceed under a contaminated session.
+    return { error: { message: 'Session principal mismatch.' } };
+  }
+  return await supabase.auth.updateUser(fields);
+}
+```
+
+Server actions that self-mutate must derive `expectedUserId` from the same external signal that triggered the flow:
+
+- For password-reset: parse the JWT in the URL hash client-side, write `sub` into a hidden form field, server reads it.
+- For email-update: confirm via a signed verification link before applying.
+- For settings: pass the workspace's resolved `currentUser.id` from the page (which was loaded under known cookies).
+
+### `useFreshSessionInstall` — closes C4
+
+```tsx
+// apps/web/src/lib/session/use-fresh-session-install.ts (new)
+'use client';
+import { useEffect, useState } from 'react';
+import { createBrowserClient } from '@supabase/ssr';
+
+type InstallFn = (supabase: ReturnType<typeof createBrowserClient>) => Promise<void>;
+
+export function useFreshSessionInstall(installFn: InstallFn): { ready: boolean } {
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      const supabase = createBrowserClient(
+        process.env.NEXT_PUBLIC_SUPABASE_URL!,
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+        { auth: { detectSessionInUrl: false } },  // C3 defense — explicit timing
+      );
+      await supabase.auth.signOut({ scope: 'local' });   // C4 defense — clear prior
+      await installFn(supabase);                          // caller does explicit setSession
+      setReady(true);
+    })();
+  }, []);
+
+  return { ready };
+}
+```
+
+Refactor `ResetPasswordForm.tsx` to use this hook with an `installFn` that explicitly parses the URL hash and calls `setSession`.
+
+### `WorkspaceScopedClient` — closes C6
+
+```ts
+// src/lib/workspace-scoped-client.ts (new)
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+export type WorkspaceContext = {
+  workspaceId: string;
+  provenance:
+    | { source: 'api-key'; keyPrefix: string }
+    | { source: 'signed-token'; payloadHash: string }
+    | { source: 'signed-event'; eventId: string; signatureVerifiedAt: string }
+    | { source: 'system-job'; triggerId: string };
+};
+
+const WORKSPACE_SCOPED_TABLES = new Set([
+  'workspaces', 'workspace_memberships', 'api_keys',
+  'sessions', 'thoughts', 'branches',
+  'entities', 'relations', 'observations',
+  'otel_events',
+  // Extend when new workspace-scoped tables are added.
+]);
+
+export class WorkspaceScopedClient {
+  private client: SupabaseClient;
+
+  constructor(url: string, serviceRoleKey: string, public readonly ctx: WorkspaceContext) {
+    this.client = createClient(url, serviceRoleKey, {
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
+  }
+
+  // Wrapped from() that auto-injects workspace_id filter for workspace-scoped tables.
+  // For mutations, also enforces workspace_id in the inserted/updated row.
+  from(table: string) {
+    const builder = this.client.from(table);
+    if (WORKSPACE_SCOPED_TABLES.has(table)) {
+      // Return a proxy that injects .eq('workspace_id', ctx.workspaceId) on every
+      // .select/.update/.delete chain, and rejects .insert that doesn't include
+      // workspace_id matching ctx.workspaceId.
+      return wrapForWorkspaceScope(builder, this.ctx.workspaceId);
+    }
+    return builder;
+  }
+
+  // Escape hatch for legitimate cross-workspace operations (system jobs only).
+  // Marked unsafe so call sites are easy to grep.
+  unsafeRawClient(): SupabaseClient {
+    if (this.ctx.provenance.source !== 'system-job') {
+      throw new Error('unsafeRawClient only allowed for system-job provenance');
+    }
+    return this.client;
+  }
+}
+
+// wrapForWorkspaceScope is the workhorse: see implementation notes in the
+// audit's Phase 3 reasoning (Thoughtbox session f87f023d, thought 83).
+```
+
+Refactor `BranchHandlers`, knowledge handlers, persistence handlers, and observatory handlers to use `WorkspaceScopedClient` instead of direct `createClient(url, serviceRoleKey)`. The escape hatch `unsafeRawClient()` is grep-able for audit.
+
+---
+
+## Sister audit recommendation
+
+The C6 enumeration in this audit covered the obvious service-role usage sites but did not exhaustively traverse the MCP server's full handler surface. The pattern that produced the critical finding at `src/branch/handlers.ts:67` — service-role lookup by id without workspace cross-check — is a class of bug that almost certainly recurs in:
+
+- `src/branch/handlers.ts` other methods (`handleMerge`, `handleList`, `getSessionWorkspaceId`)
+- `src/knowledge/supabase-storage.ts`
+- `src/persistence/supabase-storage.ts`
+- `src/otel/otel-storage.ts`
+- `src/observatory/channels/reasoning.ts`
+- `src/server-factory.ts` (depending on how it dispatches to the above)
+
+A sister audit pass should:
+
+1. List every method in those files that performs a `.from()` query.
+2. For each, check whether the chain includes `.eq('workspace_id', this.workspaceId)` or equivalent.
+3. Report any that do not.
+
+This pass could be largely automated via the AST-grep query in **C6 § Predicate** above. The recommended primitive `WorkspaceScopedClient` would, once adopted, make this class of bug structurally impossible — at which point the sister audit becomes a one-time refactor rather than an ongoing concern.
+
+---
+
+## Side-findings excluded from class space
+
+| ID | Description | File:line | Disposition |
+|---|---|---|---|
+| SF2 | Silent 0-row revoke when forged keyId passed to revokeApiKeyAction | `apps/web/src/app/w/[workspaceSlug]/api-keys/actions.ts:74` | **UX, not security** — RLS prevents the cross-workspace mutation; user just sees false success. Recommend checking rowsAffected. |
+| SF4 | MCP handler surface beyond `BranchHandlers` likely contains additional C6 instances | `src/{knowledge,persistence,otel,observatory}/...` | **Absorbed into C6** — see § Sister audit recommendation. |
+
+---
+
+## Provenance
+
+- Thoughtbox session: `f87f023d-5ce8-4281-b6f4-694b70ca94f6` — full reasoning trail with branches, decision frames, belief snapshots, and atomic per-candidate verdicts.
+- Specimen: described in conversation context at audit start; bug fix at commit `96bcb4a` on branch `fix/reset-password-hash-flow`.
+- Canonical candidate list: see Thoughtbox thought 18 (Phase 0 belief_snapshot).
+- Per-class predicate locks: thoughts 23-28 (Phase 1 belief_snapshots).
+- Per-candidate verdicts: thoughts 30-77 (Phase 2 atomic verdicts).
+- Formalizations: thoughts 79-83 (Phase 3 belief_snapshots).
+- Side-findings sweep: thoughts 85-88 (Phase 4).

--- a/apps/web/src/app/(auth)/actions.ts
+++ b/apps/web/src/app/(auth)/actions.ts
@@ -96,6 +96,8 @@ export async function resetPasswordAction(
 ): Promise<AuthFormState> {
   const password = formData.get('password') as string
   const confirmPassword = formData.get('confirmPassword') as string
+  const recoveryToken = formData.get('recoveryToken')
+  const recoveryUserId = formData.get('recoveryUserId')
 
   if (password !== confirmPassword) {
     return { error: 'Passwords do not match.' }
@@ -105,7 +107,35 @@ export async function resetPasswordAction(
     return { error: 'Password must be at least 12 characters.' }
   }
 
+  if (typeof recoveryToken !== 'string' || !recoveryToken) {
+    return { error: 'Password reset proof is missing.' }
+  }
+
+  if (typeof recoveryUserId !== 'string' || !recoveryUserId) {
+    return { error: 'Password reset proof is missing.' }
+  }
+
   const supabase = await createClient()
+  const { data: { user: recoveryUser }, error: recoveryError } = await supabase.auth.getUser(recoveryToken)
+
+  if (recoveryError || !recoveryUser) {
+    return { error: 'Password reset proof is invalid or expired.' }
+  }
+
+  if (recoveryUser.id !== recoveryUserId) {
+    return { error: 'Password reset proof does not match this request.' }
+  }
+
+  const { data: { user: sessionUser }, error: sessionError } = await supabase.auth.getUser()
+
+  if (sessionError || !sessionUser) {
+    return { error: 'Authentication failed' }
+  }
+
+  if (sessionUser.id !== recoveryUser.id) {
+    return { error: 'Password reset session mismatch.' }
+  }
+
   const { data: { user }, error: authError } = await supabase.auth.updateUser({ password })
 
   if (authError) {

--- a/apps/web/src/app/(auth)/reset-password/ResetPasswordForm.tsx
+++ b/apps/web/src/app/(auth)/reset-password/ResetPasswordForm.tsx
@@ -2,32 +2,87 @@
 
 import { useActionState, useEffect, useState } from 'react'
 import { resetPasswordAction, type AuthFormState } from '../actions'
-import { createClient } from '@/lib/supabase/client'
+import { createBrowserClient } from '@supabase/ssr'
+import type { Database } from '@/lib/supabase/database.types'
+
+type RecoveryProof =
+  | { status: 'preparing'; accessToken?: never; userId?: never; error?: never }
+  | { status: 'ready'; accessToken: string; userId: string; error?: never }
+  | { status: 'error'; accessToken?: never; userId?: never; error: string }
 
 export function ResetPasswordForm() {
   const [state, formAction, pending] = useActionState<AuthFormState, FormData>(
     resetPasswordAction,
     null,
   )
-  const [ready, setReady] = useState(false)
+  const [recoveryProof, setRecoveryProof] = useState<RecoveryProof>({ status: 'preparing' })
 
   // Supabase recovery emails deliver the access/refresh tokens in the URL hash
   // fragment (implicit flow). The hash is invisible to server code, so the
-  // session has to be established client-side before the server action runs.
-  // Instantiating the browser client triggers detectSessionInUrl, which reads
-  // the hash and writes session cookies. We clear the hash once processed so
-  // a refresh doesn't re-replay tokens.
+  // session has to be established client-side before the server action runs,
+  // and the recovery access token has to be submitted as server-verifiable proof.
   useEffect(() => {
-    const supabase = createClient()
-    supabase.auth.getSession().finally(() => {
+    let cancelled = false
+
+    async function installRecoverySession() {
+      const supabase = createBrowserClient<Database>(
+        process.env.NEXT_PUBLIC_SUPABASE_URL!,
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+        { auth: { detectSessionInUrl: false } },
+      )
+
+      await supabase.auth.signOut({ scope: 'local' })
+
+      const hashParams = new URLSearchParams(window.location.hash.slice(1))
+      const accessToken = hashParams.get('access_token')
+      const refreshToken = hashParams.get('refresh_token')
+      const type = hashParams.get('type')
+
+      if (!accessToken || !refreshToken || type !== 'recovery') {
+        throw new Error('Invalid or expired password reset link.')
+      }
+
+      const { data: tokenUser, error: tokenError } = await supabase.auth.getUser(accessToken)
+      if (tokenError || !tokenUser.user) {
+        throw new Error('Invalid or expired password reset link.')
+      }
+
+      const { error: sessionError } = await supabase.auth.setSession({
+        access_token: accessToken,
+        refresh_token: refreshToken,
+      })
+      if (sessionError) {
+        throw new Error(sessionError.message)
+      }
+
+      if (!cancelled) {
+        setRecoveryProof({
+          status: 'ready',
+          accessToken,
+          userId: tokenUser.user.id,
+        })
+      }
+    }
+
+    installRecoverySession().catch((error: unknown) => {
+      if (!cancelled) {
+        setRecoveryProof({
+          status: 'error',
+          error: error instanceof Error ? error.message : 'Unable to prepare password reset.',
+        })
+      }
+    }).finally(() => {
       if (window.location.hash) {
         window.history.replaceState(null, '', window.location.pathname)
       }
-      setReady(true)
     })
+
+    return () => {
+      cancelled = true
+    }
   }, [])
 
-  if (!ready) {
+  if (recoveryProof.status === 'preparing') {
     return (
       <div className="mt-6 text-center text-sm text-foreground/60" aria-live="polite">
         Preparing…
@@ -35,8 +90,19 @@ export function ResetPasswordForm() {
     )
   }
 
+  if (recoveryProof.status === 'error') {
+    return (
+      <div className="mt-6 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700" role="alert" aria-live="polite">
+        {recoveryProof.error}
+      </div>
+    )
+  }
+
   return (
     <form action={formAction} className="mt-6 space-y-4" aria-label="Set new password form">
+      <input type="hidden" name="recoveryToken" value={recoveryProof.accessToken} />
+      <input type="hidden" name="recoveryUserId" value={recoveryProof.userId} />
+
       {state?.error && (
         <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700" role="alert" aria-live="polite">
           {state.error}

--- a/apps/web/tests/app/auth/actions.test.ts
+++ b/apps/web/tests/app/auth/actions.test.ts
@@ -15,6 +15,7 @@ vi.mock('next/navigation', () => ({
 const mockSignInWithPassword = vi.fn()
 const mockResetPasswordForEmail = vi.fn()
 const mockUpdateUser = vi.fn()
+const mockGetUser = vi.fn()
 const mockSingle = vi.fn()
 const mockEq = vi.fn(() => ({ single: mockSingle }))
 const mockSelect = vi.fn(() => ({ eq: mockEq }))
@@ -25,6 +26,7 @@ vi.mock('@/lib/supabase/server', () => ({
     auth: {
       signInWithPassword: mockSignInWithPassword,
       resetPasswordForEmail: mockResetPasswordForEmail,
+      getUser: mockGetUser,
       updateUser: mockUpdateUser,
     },
     from: mockFrom,
@@ -86,7 +88,7 @@ describe('Auth Actions', () => {
       const result = await resendWelcomeEmailAction('test@example.com')
 
       expect(mockResetPasswordForEmail).toHaveBeenCalledWith('test@example.com', {
-        redirectTo: 'http://localhost:3000/api/auth/callback?next=/reset-password',
+        redirectTo: 'http://localhost:3000/reset-password',
       })
       expect(result).toEqual({ ok: true })
     })
@@ -117,7 +119,7 @@ describe('Auth Actions', () => {
       const result = await forgotPasswordAction(null, formData)
 
       expect(mockResetPasswordForEmail).toHaveBeenCalledWith('test@example.com', {
-        redirectTo: 'http://localhost:3000/api/auth/callback?next=/reset-password',
+        redirectTo: 'http://localhost:3000/reset-password',
       })
       expect(result).toEqual({ success: true })
     })
@@ -134,15 +136,28 @@ describe('Auth Actions', () => {
 
   describe('resetPasswordAction', () => {
     it('redirects on success', async () => {
+      mockGetUser
+        .mockResolvedValueOnce({
+          data: { user: { id: 'user-123' } },
+          error: null,
+        })
+        .mockResolvedValueOnce({
+          data: { user: { id: 'user-123' } },
+          error: null,
+        })
       mockUpdateUser.mockResolvedValueOnce({
         data: { user: { id: 'user-123' } },
         error: null,
       })
       formData.append('password', 'newpassword123')
       formData.append('confirmPassword', 'newpassword123')
+      formData.append('recoveryToken', 'recovery-token')
+      formData.append('recoveryUserId', 'user-123')
 
       await resetPasswordAction(null, formData)
 
+      expect(mockGetUser).toHaveBeenNthCalledWith(1, 'recovery-token')
+      expect(mockGetUser).toHaveBeenNthCalledWith(2)
       expect(mockUpdateUser).toHaveBeenCalledWith({ password: 'newpassword123' })
       expect(redirect).toHaveBeenCalledWith('/w/demo/dashboard')
     })
@@ -167,13 +182,88 @@ describe('Auth Actions', () => {
       expect(mockUpdateUser).not.toHaveBeenCalled()
     })
 
+    it('returns error if recovery proof is missing', async () => {
+      formData.append('password', 'newpassword123')
+      formData.append('confirmPassword', 'newpassword123')
+
+      const result = await resetPasswordAction(null, formData)
+
+      expect(result).toEqual({ error: 'Password reset proof is missing.' })
+      expect(mockGetUser).not.toHaveBeenCalled()
+      expect(mockUpdateUser).not.toHaveBeenCalled()
+    })
+
+    it('returns error if recovery proof is invalid', async () => {
+      mockGetUser.mockResolvedValueOnce({
+        data: { user: null },
+        error: { message: 'bad token' },
+      })
+      formData.append('password', 'newpassword123')
+      formData.append('confirmPassword', 'newpassword123')
+      formData.append('recoveryToken', 'bad-token')
+      formData.append('recoveryUserId', 'user-123')
+
+      const result = await resetPasswordAction(null, formData)
+
+      expect(result).toEqual({ error: 'Password reset proof is invalid or expired.' })
+      expect(mockUpdateUser).not.toHaveBeenCalled()
+    })
+
+    it('returns error if recovery proof user id does not match the submitted proof', async () => {
+      mockGetUser.mockResolvedValueOnce({
+        data: { user: { id: 'user-456' } },
+        error: null,
+      })
+      formData.append('password', 'newpassword123')
+      formData.append('confirmPassword', 'newpassword123')
+      formData.append('recoveryToken', 'recovery-token')
+      formData.append('recoveryUserId', 'user-123')
+
+      const result = await resetPasswordAction(null, formData)
+
+      expect(result).toEqual({ error: 'Password reset proof does not match this request.' })
+      expect(mockUpdateUser).not.toHaveBeenCalled()
+    })
+
+    it('returns error if cookie session does not match recovery proof', async () => {
+      mockGetUser
+        .mockResolvedValueOnce({
+          data: { user: { id: 'user-123' } },
+          error: null,
+        })
+        .mockResolvedValueOnce({
+          data: { user: { id: 'user-456' } },
+          error: null,
+        })
+      formData.append('password', 'newpassword123')
+      formData.append('confirmPassword', 'newpassword123')
+      formData.append('recoveryToken', 'recovery-token')
+      formData.append('recoveryUserId', 'user-123')
+
+      const result = await resetPasswordAction(null, formData)
+
+      expect(result).toEqual({ error: 'Password reset session mismatch.' })
+      expect(mockUpdateUser).not.toHaveBeenCalled()
+    })
+
     it('returns error message on Supabase failure', async () => {
+      mockGetUser
+        .mockResolvedValueOnce({
+          data: { user: { id: 'user-123' } },
+          error: null,
+        })
+        .mockResolvedValueOnce({
+          data: { user: { id: 'user-123' } },
+          error: null,
+        })
       mockUpdateUser.mockResolvedValueOnce({
         data: { user: null },
         error: { message: 'Token expired' },
       })
       formData.append('password', 'newpassword123')
       formData.append('confirmPassword', 'newpassword123')
+      formData.append('recoveryToken', 'recovery-token')
+      formData.append('recoveryUserId', 'user-123')
 
       const result = await resetPasswordAction(null, formData)
 

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "node": ">=22.0.0"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "1.25.3",
+    "@modelcontextprotocol/sdk": "1.29.0",
     "@supabase/supabase-js": "^2.99.1",
     "bcryptjs": "^3.0.3",
     "better-sqlite3": "^11.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@modelcontextprotocol/sdk':
-        specifier: 1.25.3
-        version: 1.25.3(hono@4.12.5)(zod@3.25.76)
+        specifier: 1.29.0
+        version: 1.29.0(zod@3.25.76)
       '@supabase/supabase-js':
         specifier: ^2.99.1
         version: 2.99.1
@@ -917,8 +917,8 @@ packages:
       '@types/react': '>=16'
       react: '>=16'
 
-  '@modelcontextprotocol/sdk@1.25.3':
-    resolution: {integrity: sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ==}
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
@@ -3058,8 +3058,8 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
-  express-rate-limit@7.5.1:
-    resolution: {integrity: sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==}
+  express-rate-limit@8.4.1:
+    resolution: {integrity: sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==}
     engines: {node: '>= 16'}
     peerDependencies:
       express: '>= 4.11'
@@ -5990,7 +5990,7 @@ snapshots:
       '@types/react': 19.2.14
       react: 19.2.5
 
-  '@modelcontextprotocol/sdk@1.25.3(hono@4.12.5)(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.11(hono@4.12.5)
       ajv: 8.18.0
@@ -6001,7 +6001,8 @@ snapshots:
       eventsource: 3.0.7
       eventsource-parser: 3.0.6
       express: 5.2.1
-      express-rate-limit: 7.5.1(express@5.2.1)
+      express-rate-limit: 8.4.1(express@5.2.1)
+      hono: 4.12.5
       jose: 6.2.1
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -6009,7 +6010,6 @@ snapshots:
       zod: 3.25.76
       zod-to-json-schema: 3.25.1(zod@3.25.76)
     transitivePeerDependencies:
-      - hono
       - supports-color
 
   '@napi-rs/wasm-runtime@0.2.12':
@@ -8375,9 +8375,10 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  express-rate-limit@7.5.1(express@5.2.1):
+  express-rate-limit@8.4.1(express@5.2.1):
     dependencies:
       express: 5.2.1
+      ip-address: 10.1.0
 
   express@5.2.1:
     dependencies:

--- a/src/branch/__tests__/handlers.test.ts
+++ b/src/branch/__tests__/handlers.test.ts
@@ -2,91 +2,289 @@ import { describe, expect, it } from 'vitest';
 
 import { BranchHandlers } from '../handlers.js';
 
+const WORKSPACE_ID = '11111111-1111-1111-1111-111111111111';
+const OTHER_WORKSPACE_ID = '22222222-2222-2222-2222-222222222222';
+
+type Row = Record<string, unknown>;
+type Tables = Record<string, Row[]>;
+
 function createHandlerWithFakeClient(fakeClient: unknown): BranchHandlers {
   const handler = new BranchHandlers({
     supabaseUrl: 'http://127.0.0.1:54321',
     serviceRoleKey: 'service-role-key',
-    workspaceId: '11111111-1111-1111-1111-111111111111',
+    workspaceId: WORKSPACE_ID,
   });
 
   (handler as unknown as { client: unknown }).client = fakeClient;
   return handler;
 }
 
+function createWorkspaceAwareFakeClient(
+  initialTables: Tables,
+  options: { updateError?: string } = {},
+) {
+  const tables: Tables = Object.fromEntries(
+    Object.entries(initialTables).map(([name, rows]) => [
+      name,
+      rows.map((row) => ({ ...row })),
+    ]),
+  );
+
+  return {
+    tables,
+    from(table: string) {
+      if (!tables[table]) {
+        throw new Error(`Unexpected table: ${table}`);
+      }
+
+      const filters: Array<[string, unknown]> = [];
+      const nullFilters: Array<[string, unknown]> = [];
+      const inFilters: Array<[string, unknown[]]> = [];
+      let limitRows: number | null = null;
+      let updatePayload: Row | null = null;
+
+      const applyFilters = () => {
+        let rows = tables[table].filter((row) => {
+          return filters.every(([column, value]) => row[column] === value)
+            && nullFilters.every(([column, value]) => row[column] === value)
+            && inFilters.every(([column, values]) => values.includes(row[column]));
+        });
+
+        if (limitRows !== null) {
+          rows = rows.slice(0, limitRows);
+        }
+
+        return rows;
+      };
+
+      const builder = {
+        select() {
+          return this;
+        },
+        update(payload: Row) {
+          updatePayload = payload;
+          return this;
+        },
+        insert(payload: Row) {
+          tables[table].push({ ...payload });
+          return Promise.resolve({ error: null });
+        },
+        eq(column: string, value: unknown) {
+          filters.push([column, value]);
+          return this;
+        },
+        is(column: string, value: unknown) {
+          nullFilters.push([column, value]);
+          return this;
+        },
+        in(column: string, values: unknown[]) {
+          inFilters.push([column, values]);
+          return this;
+        },
+        order() {
+          return this;
+        },
+        limit(count: number) {
+          limitRows = count;
+          return this;
+        },
+        single() {
+          const row = applyFilters()[0] ?? null;
+          return Promise.resolve({
+            data: row,
+            error: row ? null : { message: 'not found' },
+          });
+        },
+        then(resolve: (value: { data?: Row[]; error: null | { message: string } }) => unknown) {
+          if (updatePayload) {
+            if (options.updateError) {
+              return Promise.resolve({ error: { message: options.updateError } }).then(resolve);
+            }
+
+            for (const row of applyFilters()) {
+              Object.assign(row, updatePayload);
+            }
+            return Promise.resolve({ error: null }).then(resolve);
+          }
+
+          return Promise.resolve({ data: applyFilters(), error: null }).then(resolve);
+        },
+      };
+
+      return builder;
+    },
+  };
+}
+
+describe('BranchHandlers workspace binding', () => {
+  it('denies spawn for a session in another workspace', async () => {
+    const fakeClient = createWorkspaceAwareFakeClient({
+      sessions: [{ id: 'session-1', workspace_id: OTHER_WORKSPACE_ID }],
+      thoughts: [
+        {
+          id: 'thought-1',
+          session_id: 'session-1',
+          workspace_id: OTHER_WORKSPACE_ID,
+          thought_number: 1,
+          branch_id: null,
+        },
+      ],
+      branches: [],
+    });
+    const handler = createHandlerWithFakeClient(fakeClient);
+
+    await expect(
+      handler.handleSpawn({
+        sessionId: 'session-1',
+        branchId: 'branch-a',
+        branchFromThought: 1,
+      }),
+    ).rejects.toThrow('Session session-1 not found');
+
+    expect(fakeClient.tables.branches).toHaveLength(0);
+  });
+
+  it('mints branch worker tokens only for the API-key workspace', async () => {
+    const fakeClient = createWorkspaceAwareFakeClient({
+      sessions: [{ id: 'session-1', workspace_id: WORKSPACE_ID }],
+      thoughts: [
+        {
+          id: 'thought-1',
+          session_id: 'session-1',
+          workspace_id: WORKSPACE_ID,
+          thought_number: 1,
+          branch_id: null,
+        },
+      ],
+      branches: [],
+    });
+    const handler = createHandlerWithFakeClient(fakeClient);
+
+    const result = await handler.handleSpawn({
+      sessionId: 'session-1',
+      branchId: 'branch-a',
+      branchFromThought: 1,
+    });
+    const token = new URL(result.workerUrl).searchParams.get('token');
+    const [encodedPayload] = token?.split('.') ?? [];
+    const tokenPayload = JSON.parse(
+      Buffer.from(encodedPayload, 'base64url').toString('utf8'),
+    ) as { workspace_id: string };
+
+    expect(fakeClient.tables.branches[0]).toMatchObject({
+      session_id: 'session-1',
+      workspace_id: WORKSPACE_ID,
+      branch_id: 'branch-a',
+    });
+    expect(tokenPayload.workspace_id).toBe(WORKSPACE_ID);
+  });
+
+  it('denies merge for a session in another workspace', async () => {
+    const fakeClient = createWorkspaceAwareFakeClient({
+      sessions: [{ id: 'session-1', workspace_id: OTHER_WORKSPACE_ID }],
+      thoughts: [],
+      branches: [
+        {
+          session_id: 'session-1',
+          workspace_id: OTHER_WORKSPACE_ID,
+          branch_id: 'branch-a',
+          status: 'completed',
+        },
+      ],
+    });
+    const handler = createHandlerWithFakeClient(fakeClient);
+
+    await expect(
+      handler.handleMerge({
+        sessionId: 'session-1',
+        synthesis: 'Synthesis thought',
+        selectedBranchId: 'branch-a',
+        resolution: 'selected',
+      }),
+    ).rejects.toThrow('Session session-1 not found');
+  });
+
+  it('returns no branches when list targets another workspace session', async () => {
+    const fakeClient = createWorkspaceAwareFakeClient({
+      sessions: [{ id: 'session-1', workspace_id: OTHER_WORKSPACE_ID }],
+      thoughts: [
+        {
+          session_id: 'session-1',
+          workspace_id: OTHER_WORKSPACE_ID,
+          branch_id: 'branch-a',
+        },
+      ],
+      branches: [
+        {
+          session_id: 'session-1',
+          workspace_id: OTHER_WORKSPACE_ID,
+          branch_id: 'branch-a',
+          description: null,
+          status: 'active',
+          branch_from_thought: 1,
+          spawned_at: '2026-04-25T00:00:00.000Z',
+          completed_at: null,
+        },
+      ],
+    });
+    const handler = createHandlerWithFakeClient(fakeClient);
+
+    await expect(handler.handleList({ sessionId: 'session-1' })).resolves.toEqual({
+      branches: [],
+    });
+  });
+
+  it('denies get for a branch in another workspace', async () => {
+    const fakeClient = createWorkspaceAwareFakeClient({
+      sessions: [{ id: 'session-1', workspace_id: OTHER_WORKSPACE_ID }],
+      thoughts: [
+        {
+          session_id: 'session-1',
+          workspace_id: OTHER_WORKSPACE_ID,
+          branch_id: 'branch-a',
+          thought_number: 1,
+        },
+      ],
+      branches: [
+        {
+          session_id: 'session-1',
+          workspace_id: OTHER_WORKSPACE_ID,
+          branch_id: 'branch-a',
+        },
+      ],
+    });
+    const handler = createHandlerWithFakeClient(fakeClient);
+
+    await expect(
+      handler.handleGet({ sessionId: 'session-1', branchId: 'branch-a' }),
+    ).rejects.toThrow('Branch branch-a not found in session session-1');
+  });
+});
+
 describe('BranchHandlers.handleMerge', () => {
   it('throws when a branch status update fails', async () => {
-    const fakeClient = {
-      from(table: string) {
-        if (table === 'branches') {
-          return {
-            select() {
-              return {
-                eq: async () => ({
-                  data: [{ branch_id: 'branch-a', status: 'completed' }],
-                  error: null,
-                }),
-              };
-            },
-            update() {
-              let eqCalls = 0;
-              return {
-                eq() {
-                  eqCalls += 1;
-                  if (eqCalls < 2) return this;
-                  return Promise.resolve({
-                    error: { message: 'write failed' },
-                  });
-                },
-              };
-            },
-          };
-        }
-
-        if (table === 'thoughts') {
-          return {
-            select() {
-              return {
-                eq() {
-                  return this;
-                },
-                is() {
-                  return this;
-                },
-                order() {
-                  return this;
-                },
-                limit() {
-                  return this;
-                },
-                single: async () => ({
-                  data: { thought_number: 1 },
-                }),
-              };
-            },
-            insert: async () => ({ error: null }),
-          };
-        }
-
-        if (table === 'sessions') {
-          return {
-            select() {
-              return {
-                eq() {
-                  return this;
-                },
-                single: async () => ({
-                  data: { id: 'session-1', workspace_id: '11111111-1111-1111-1111-111111111111' },
-                  error: null,
-                }),
-              };
-            },
-          };
-        }
-
-        throw new Error(`Unexpected table: ${table}`);
+    const fakeClient = createWorkspaceAwareFakeClient(
+      {
+        sessions: [{ id: 'session-1', workspace_id: WORKSPACE_ID }],
+        thoughts: [
+          {
+            session_id: 'session-1',
+            workspace_id: WORKSPACE_ID,
+            branch_id: null,
+            thought_number: 1,
+          },
+        ],
+        branches: [
+          {
+            session_id: 'session-1',
+            workspace_id: WORKSPACE_ID,
+            branch_id: 'branch-a',
+            status: 'completed',
+          },
+        ],
       },
-    };
-
+      { updateError: 'write failed' },
+    );
     const handler = createHandlerWithFakeClient(fakeClient);
 
     await expect(

--- a/src/branch/handlers.ts
+++ b/src/branch/handlers.ts
@@ -68,6 +68,7 @@ export class BranchHandlers {
       .from("sessions")
       .select("id, workspace_id")
       .eq("id", sessionId)
+      .eq("workspace_id", this.workspaceId)
       .single();
 
     if (sessErr || !session) {
@@ -78,6 +79,7 @@ export class BranchHandlers {
       .from("thoughts")
       .select("id")
       .eq("session_id", sessionId)
+      .eq("workspace_id", this.workspaceId)
       .eq("thought_number", branchFromThought)
       .is("branch_id", null)
       .single();
@@ -88,11 +90,9 @@ export class BranchHandlers {
       );
     }
 
-    const workspaceId = session.workspace_id ?? this.workspaceId;
-
     const { error: insErr } = await this.client.from("branches").insert({
       session_id: sessionId,
-      workspace_id: workspaceId,
+      workspace_id: this.workspaceId,
       branch_id: branchId,
       description: description ?? null,
       branch_from_thought: branchFromThought,
@@ -108,7 +108,7 @@ export class BranchHandlers {
       {
         session_id: sessionId,
         branch_id: branchId,
-        workspace_id: workspaceId,
+        workspace_id: this.workspaceId,
         branch_from_thought: branchFromThought,
         expires_at: new Date(Date.now() + BRANCH_WORKER_TOKEN_TTL_MS).toISOString(),
       },
@@ -137,6 +137,7 @@ export class BranchHandlers {
       .from("branches")
       .select("branch_id, status")
       .eq("session_id", sessionId)
+      .eq("workspace_id", this.workspaceId)
       .in("status", ["active", "completed"]);
 
     if (brErr || !branches?.length) {
@@ -169,6 +170,7 @@ export class BranchHandlers {
       .from("branches")
       .select("branch_id, description, status, branch_from_thought, spawned_at, completed_at")
       .eq("session_id", args.sessionId)
+      .eq("workspace_id", this.workspaceId)
       .order("spawned_at", { ascending: true });
 
     if (error) {
@@ -185,6 +187,7 @@ export class BranchHandlers {
         .from("thoughts")
         .select("branch_id")
         .eq("session_id", args.sessionId)
+        .eq("workspace_id", this.workspaceId)
         .in("branch_id", branchIds);
 
       if (thoughtError) {
@@ -222,6 +225,7 @@ export class BranchHandlers {
       .from("branches")
       .select("*")
       .eq("session_id", args.sessionId)
+      .eq("workspace_id", this.workspaceId)
       .eq("branch_id", args.branchId)
       .single();
 
@@ -235,6 +239,7 @@ export class BranchHandlers {
       .from("thoughts")
       .select("*")
       .eq("session_id", args.sessionId)
+      .eq("workspace_id", this.workspaceId)
       .eq("branch_id", args.branchId)
       .order("thought_number", { ascending: true });
 
@@ -259,6 +264,7 @@ export class BranchHandlers {
         .from("thoughts")
         .select("thought_number")
         .eq("session_id", sessionId)
+        .eq("workspace_id", this.workspaceId)
         .is("branch_id", null)
         .order("thought_number", { ascending: false })
         .limit(1)
@@ -324,6 +330,7 @@ export class BranchHandlers {
         .from("branches")
         .update(updatePayload)
         .eq("session_id", sessionId)
+        .eq("workspace_id", this.workspaceId)
         .eq("branch_id", bid);
 
       if (updateError) {
@@ -341,6 +348,7 @@ export class BranchHandlers {
       .from("sessions")
       .select("id, workspace_id")
       .eq("id", sessionId)
+      .eq("workspace_id", this.workspaceId)
       .single();
 
     if (error || !session?.workspace_id) {


### PR DESCRIPTION
## Summary

Two related security fixes for tenant isolation:

- **Identity-binding audit findings (CRITICAL/HIGH)** — fixes the cross-workspace branch spawn vulnerability in the MCP server (C6) and the password-reset cookie-contamination flow (C1+C2+C4 in the audit's class taxonomy).
- **MCP SDK CVE patch** — upgrades `@modelcontextprotocol/sdk` from 1.25.3 to 1.29.0 to close GHSA cross-client data leak via shared server/transport instance reuse.

The SDK CVE and the identity-binding audit address the same underlying property (multi-tenant data isolation) at different layers — application-layer in `BranchHandlers`, transport-layer in the SDK. Shipping one without the other leaves a hole.

## Changes

**`src/branch/handlers.ts` — workspace binding (C6 fix)**
- Every `sessions`, `thoughts`, and `branches` service-role operation now filters by `this.workspaceId` (the API-key-resolved workspace).
- Branch worker token issuance uses the API-key-resolved workspace, not a fetched session value.
- Coverage in `src/branch/__tests__/handlers.test.ts`: cross-workspace `spawn`, `merge`, `list`, `get` denial.

**Reset password flow — recovery proof (C1+C2+C4 fix)**
- `ResetPasswordForm.tsx`: disables `detectSessionInUrl`, calls `signOut({ scope: 'local' })` before installing the recovery session, validates the recovery token client-side, then submits `recoveryToken` and `recoveryUserId` as proof.
- `resetPasswordAction`: validates the recovery token via `getUser(recoveryToken)`, requires the verified recovery user to match the submitted `recoveryUserId`, requires the cookie-resolved session user to match the recovery user — refuses `updateUser` on any mismatch.
- Coverage in `apps/web/tests/app/auth/actions.test.ts`: missing proof, invalid proof, proof mismatch, cookie/recovery mismatch, success path.

**`@modelcontextprotocol/sdk` 1.25.3 → 1.29.0**
- Patches GHSA cross-client data leak (vulnerable `<=1.25.3`, patched `>=1.26.0`).

**Audit doc**
- `.specs/security/identity-binding-audit.md` updated with `FIXED 2026-04-25` markers for C6 and C1/C2/C4. Medium/low findings (latent C2 profile update, A1 OAuth callback redirect, A2 claim-page email rate limit) are explicitly labeled deferred.

## Sister audit results

After the original audit recommended a sister-audit pass over the rest of the MCP service-role surface, four files were checked:

- `src/knowledge/supabase-storage.ts` — clean (14/14 calls scope to `this.workspaceId`).
- `src/persistence/supabase-storage.ts` — clean (constructor-bound workspace).
- `src/observatory/channels/reasoning.ts` — N/A (in-memory only).
- `src/otel/otel-storage.ts` — 1 LOW finding (`checkHealth` cross-workspace event count) + 1 LATENT structural concern (storage class lacks constructor-bound workspace; protection lives in the upstream parser). Neither is CRITICAL or HIGH; both belong on the deferred follow-up list.

No new CRITICAL/HIGH findings.

## Test plan

- [x] `pnpm vitest run src/branch/__tests__/handlers.test.ts` — 6/6 pass
- [x] `pnpm vitest run` (web app) `tests/app/auth/actions.test.ts` — 15/15 pass
- [x] `pnpm tsc --noEmit` — clean both projects
- [x] `pnpm vitest run` (full suite) — 480 pass, 2 pre-existing failures (`architecture.test.ts`, `server-surface.test.ts`) that also fail on `origin/main` and are unrelated to this PR
- [x] `pnpm audit --audit-level=high --prod` after upgrade — MCP SDK CVE no longer reported

## Deferred (tracked, not blocking ship)

- C2-latent — `updateProfileAction` apply `verifiedSelfMutate` wrapper
- A1 — OAuth callback `next` param same-origin allow-list
- A2 — claim-page email rate limiting
- LOW — `OtelEventStorage.checkHealth` workspace filter
- LATENT — `OtelEventStorage` constructor-bound workspaceId
- Audit's canonical workspace-scoped table list should include `runs`
- Pre-existing test failures unrelated to security work

🤖 Generated with [Claude Code](https://claude.com/claude-code)