### PR TITLE
fix: update quickstart link to actual web app URL

### DIFF
--- a/apps/web/user-docs/quickstart.mdx
+++ b/apps/web/user-docs/quickstart.mdx
@@ -4,7 +4,7 @@ Get connected and record your first thought in under 5 minutes.
 
 ## 1. Get Your API Key
 
-Sign in to the [Thoughtbox web app](https://app.kastalienresearch.ai). Copy your API key from the dashboard. It starts with `tbx_`.
+Sign in to the [Thoughtbox web app](https://thoughtbox.kastalienresearch.ai). Copy your API key from the dashboard. It starts with `tbx_`.
 
 ## 2. Connect Claude Code
 


### PR DESCRIPTION
Replace hallucinated app.kastalienresearch.ai with actual production URL thoughtbox.kastalienresearch.ai