### PR TITLE
fix: correct Ulysses S-register descriptions and handler logic

### DIFF
--- a/src/__tests__/e2e-workflow.test.ts
+++ b/src/__tests__/e2e-workflow.test.ts
@@ -412,12 +412,14 @@ describe("Ulysses protocol e2e through tool layer", () => {
   it("full S=2 → reflect → resume cycle", async () => {
     await call({ operation: "init", problem: "test" });
 
+    // plan sets S=1 (executing primary)
     await call({ operation: "plan", primary: "a1", recovery: "r1" });
-    const s1 = await call({ operation: "outcome", assessment: "unexpected-unfavorable", severity: 1 });
-    expect(s1.S).toBe(1);
+    // Primary failed → S=2 (now executing backup)
+    const s1 = await call({ operation: "outcome", assessment: "unexpected-unfavorable" });
+    expect(s1.S).toBe(2);
 
-    await call({ operation: "plan", primary: "a2", recovery: "r2" });
-    const s2 = await call({ operation: "outcome", assessment: "unexpected-unfavorable", severity: 1 });
+    // Backup also failed → S=2 (reflect required)
+    const s2 = await call({ operation: "outcome", assessment: "unexpected-unfavorable" });
     expect(s2.S).toBe(2);
 
     await expect(
@@ -449,10 +451,11 @@ describe("Ulysses protocol e2e through tool layer", () => {
   it("expected outcome resets S to 0", async () => {
     await call({ operation: "init", problem: "test" });
     await call({ operation: "plan", primary: "a", recovery: "r" });
-    const surprise = await call({ operation: "outcome", assessment: "unexpected-unfavorable", severity: 1 });
-    expect(surprise.S).toBe(1);
+    // Primary failed → S=2
+    const surprise = await call({ operation: "outcome", assessment: "unexpected-unfavorable" });
+    expect(surprise.S).toBe(2);
 
-    await call({ operation: "plan", primary: "a2", recovery: "r2" });
+    // Backup succeeded → S=0, checkpoint
     const expected = await call({ operation: "outcome", assessment: "expected" });
     expect(expected.S).toBe(0);
   });

--- a/src/code-mode/execute-tool.ts
+++ b/src/code-mode/execute-tool.ts
@@ -49,6 +49,8 @@ export const EXECUTE_TOOL = {
   name: "thoughtbox_execute",
   description: `Run JavaScript using the \`tb\` SDK to chain Thoughtbox operations in a single call.
 
+**One state-mutating operation per call.** Submit only one \`tb.thought()\`, \`tb.ulysses()\`, or \`tb.theseus()\` call per \`thoughtbox_execute\` invocation. Each response contains guidance (patterns, session state, protocol state) that should inform your next operation. Batching multiple state-mutating calls bypasses this feedback loop and produces lower-quality reasoning. Read-only operations (\`tb.session.*\`, \`tb.knowledge.*\`, \`tb.observability()\`, \`tb.branch.*\`) may be freely chained.
+
 ${TB_SDK_TYPES}
 
 Example:

--- a/src/code-mode/sdk-types.ts
+++ b/src/code-mode/sdk-types.ts
@@ -97,7 +97,7 @@ interface TB {
     summary?: string;
   }): Promise<unknown>;
 
-  /** Ulysses Protocol: surprise-gated debugging. Source: src/protocol/ulysses-tool.ts */
+  /** Ulysses Protocol: state-step-gated debugging. S tracks position in plan→execute→evaluate cycle. S=0 at checkpoint, S=1 after primary fails (executing backup), S=2 after both fail (reset to checkpoint, reflect, forbid moves). Source: src/protocol/ulysses-tool.ts */
   ulysses(input: {
     operation: "init" | "plan" | "outcome" | "reflect" | "status" | "complete";
     problem?: string;
@@ -106,7 +106,6 @@ interface TB {
     recovery?: string;
     irreversible?: boolean;
     assessment?: "expected" | "unexpected-favorable" | "unexpected-unfavorable";
-    severity?: number;
     details?: string;
     hypothesis?: string;
     falsification?: string;

--- a/src/code-mode/sdk-types.ts
+++ b/src/code-mode/sdk-types.ts
@@ -97,7 +97,7 @@ interface TB {
     summary?: string;
   }): Promise<unknown>;
 
-  /** Ulysses Protocol: state-step-gated debugging. S tracks position in plan→execute→evaluate cycle. S=0 at checkpoint, S=1 after primary fails (executing backup), S=2 after both fail (reset to checkpoint, reflect, forbid moves). Source: src/protocol/ulysses-tool.ts */
+  /** Ulysses Protocol: state-step-gated debugging. S tracks position in plan→execute→evaluate cycle. S=0 at checkpoint, S=1 after plan submitted (primary executing), S=2 after primary fails (backup executing) or both fail (reflect required). Source: src/protocol/ulysses-tool.ts */
   ulysses(input: {
     operation: "init" | "plan" | "outcome" | "reflect" | "status" | "complete";
     problem?: string;

--- a/src/prompts/contents/interleaved-thinking-content.ts
+++ b/src/prompts/contents/interleaved-thinking-content.ts
@@ -15,7 +15,9 @@ This is an OODA loop (Observe-Orient-Decide-Act), not a sequential pipeline. You
 
 ## How to Think
 
-Use \`thoughtbox_execute\` to record reasoning. Write JavaScript against the \`tb\` SDK:
+Use \`thoughtbox_execute\` to record reasoning. Write JavaScript against the \`tb\` SDK.
+
+**One state-mutating operation per call.** Submit only one \`tb.thought()\`, \`tb.ulysses()\`, or \`tb.theseus()\` per \`thoughtbox_execute\` invocation. Each response contains guidance (patterns, session state, protocol state) that should inform your next operation. Batching multiple calls bypasses this feedback loop and produces lower-quality reasoning. Read-only operations (\`tb.session.*\`, \`tb.knowledge.*\`, \`tb.observability()\`, \`tb.branch.*\`) may be freely chained.
 
 - **tb.thought()** — observations, intermediate conclusions, status checks
 - **decision_frame** thoughtType — when choosing between alternatives (frame the options, criteria, and tradeoffs before deciding)

--- a/src/protocol/__tests__/enforcement.test.ts
+++ b/src/protocol/__tests__/enforcement.test.ts
@@ -7,26 +7,22 @@ describe("InMemoryProtocolHandler enforcement", () => {
     const init = await handler.ulyssesInit("Investigate failing health check");
     const sessionId = init.session_id as string;
 
+    // plan sets S=1 (executing primary)
     await handler.ulyssesPlan(sessionId, {
       primary: "Run the first diagnostic",
       recovery: "Revert the change",
       irreversible: false,
     });
+    // Primary failed → S=2 (now executing backup)
     await handler.ulyssesOutcome(sessionId, {
       assessment: "unexpected-unfavorable",
-      severity: 1,
-      details: "First surprise",
+      details: "Primary move failed",
     });
 
-    await handler.ulyssesPlan(sessionId, {
-      primary: "Run the second diagnostic",
-      recovery: "Undo the second change",
-      irreversible: false,
-    });
+    // Backup also failed → S=2 (reflect required)
     await handler.ulyssesOutcome(sessionId, {
       assessment: "unexpected-unfavorable",
-      severity: 1,
-      details: "Second surprise",
+      details: "Backup move also failed",
     });
 
     await expect(

--- a/src/protocol/__tests__/handler.test.ts
+++ b/src/protocol/__tests__/handler.test.ts
@@ -235,26 +235,14 @@ describe('Ulysses schema parsing (H4)', () => {
     expect(result.assessment).toBe('expected');
   });
 
-  it('parses outcome with unexpected assessment and severity', () => {
+  it('parses outcome with unexpected assessment', () => {
     const result = ulyssesToolInputSchema.parse({
       operation: 'outcome',
       assessment: 'unexpected-unfavorable',
-      severity: 2,
       details: 'Server crashed',
     });
     expect(result.assessment).toBe('unexpected-unfavorable');
-    expect(result.severity).toBe(2);
     expect(result.details).toBe('Server crashed');
-  });
-
-  it('rejects severity outside 1-2 range', () => {
-    expect(() =>
-      ulyssesToolInputSchema.parse({
-        operation: 'outcome',
-        assessment: 'unexpected-favorable',
-        severity: 3,
-      }),
-    ).toThrow();
   });
 
   it('rejects invalid assessment value', () => {

--- a/src/protocol/__tests__/protocol-events.test.ts
+++ b/src/protocol/__tests__/protocol-events.test.ts
@@ -31,12 +31,13 @@ describe("protocol event emission", () => {
     await handler.ulyssesPlan(sessionId, {
       primary: "check logs",
       recovery: "check metrics",
+      irreversible: false,
     });
 
     onEvent.mockClear();
 
     await handler.ulyssesOutcome(sessionId, {
-      assessment: "unexpected",
+      assessment: "unexpected-unfavorable",
       details: "logs were empty",
     });
 
@@ -44,7 +45,7 @@ describe("protocol event emission", () => {
       expect.objectContaining({
         type: "ulysses_outcome",
         data: expect.objectContaining({
-          assessment: "unexpected",
+          assessment: "unexpected-unfavorable",
           S: expect.any(Number),
         }),
       }),
@@ -59,11 +60,10 @@ describe("protocol event emission", () => {
     const initResult = await handler.ulyssesInit("bug", []);
     const sessionId = initResult.session_id as string;
 
-    // Drive S to 2 with two surprises
-    await handler.ulyssesPlan(sessionId, { primary: "a", recovery: "b" });
-    await handler.ulyssesOutcome(sessionId, { assessment: "unexpected", details: "x" });
-    await handler.ulyssesPlan(sessionId, { primary: "c", recovery: "d" });
-    await handler.ulyssesOutcome(sessionId, { assessment: "unexpected", details: "y" });
+    // Drive S to 2: plan → S=1, primary fails → S=2, backup fails → S=2 reflect required
+    await handler.ulyssesPlan(sessionId, { primary: "a", recovery: "b", irreversible: false });
+    await handler.ulyssesOutcome(sessionId, { assessment: "unexpected-unfavorable", details: "x" });
+    await handler.ulyssesOutcome(sessionId, { assessment: "unexpected-unfavorable", details: "y" });
 
     onEvent.mockClear();
 

--- a/src/protocol/__tests__/ulysses-state-machine.test.ts
+++ b/src/protocol/__tests__/ulysses-state-machine.test.ts
@@ -1,0 +1,433 @@
+import { describe, expect, it } from "vitest";
+import { InMemoryProtocolHandler } from "../index.js";
+
+/**
+ * Complete Ulysses state machine test coverage.
+ *
+ * States:
+ *   A: S=0, active_step=null (checkpoint)
+ *   B: S=1, active_step set (primary executing)
+ *   C: S=2, active_step set (backup executing)
+ *   D: S=2, active_step=null (reflect required)
+ *
+ * Every valid transition, every error transition, every enforcement sub-state.
+ */
+
+describe("Ulysses state machine", () => {
+  // ---------------------------------------------------------------------------
+  // Valid transitions
+  // ---------------------------------------------------------------------------
+
+  // A → plan → B
+  it("plan transitions S=0 → S=1 with active_step set", async () => {
+    const handler = new InMemoryProtocolHandler();
+    const init = await handler.ulyssesInit("bug");
+    const sid = init.session_id as string;
+
+    const result = await handler.ulyssesPlan(sid, {
+      primary: "check logs",
+      recovery: "check metrics",
+      irreversible: false,
+    });
+
+    expect(result.S).toBe(1);
+    expect(result.primary).toBe("check logs");
+    expect(result.recovery).toBe("check metrics");
+
+    const status = await handler.ulyssesStatus();
+    expect(status.active_step).toEqual({
+      primary: "check logs",
+      recovery: "check metrics",
+      irreversible: false,
+      timestamp: expect.any(String),
+    });
+  });
+
+  // B → outcome(expected) → A
+  it("expected outcome at S=1 → S=0, checkpoint created", async () => {
+    const handler = new InMemoryProtocolHandler();
+    const init = await handler.ulyssesInit("bug");
+    const sid = init.session_id as string;
+
+    await handler.ulyssesPlan(sid, {
+      primary: "check logs",
+      recovery: "check metrics",
+      irreversible: false,
+    });
+
+    const result = await handler.ulyssesOutcome(sid, {
+      assessment: "expected",
+    });
+
+    expect(result.S).toBe(0);
+    expect(result.message).toContain("Checkpoint");
+
+    const status = await handler.ulyssesStatus();
+    expect(status.active_step).toBeNull();
+  });
+
+  // B → outcome(unexpected) → C
+  it("unexpected outcome at S=1 → S=2, active_step retained for backup", async () => {
+    const handler = new InMemoryProtocolHandler();
+    const init = await handler.ulyssesInit("bug");
+    const sid = init.session_id as string;
+
+    await handler.ulyssesPlan(sid, {
+      primary: "check logs",
+      recovery: "check metrics",
+      irreversible: false,
+    });
+
+    const result = await handler.ulyssesOutcome(sid, {
+      assessment: "unexpected-unfavorable",
+      details: "logs were empty",
+    });
+
+    expect(result.S).toBe(2);
+    expect(result.message).toContain("backup");
+
+    const status = await handler.ulyssesStatus();
+    expect(status.active_step).not.toBeNull();
+  });
+
+  // C → outcome(expected) → A
+  it("expected outcome at S=2 (backup succeeded) → S=0, checkpoint created", async () => {
+    const handler = new InMemoryProtocolHandler();
+    const init = await handler.ulyssesInit("bug");
+    const sid = init.session_id as string;
+
+    await handler.ulyssesPlan(sid, {
+      primary: "check logs",
+      recovery: "check metrics",
+      irreversible: false,
+    });
+
+    await handler.ulyssesOutcome(sid, {
+      assessment: "unexpected-unfavorable",
+      details: "logs empty",
+    });
+
+    const result = await handler.ulyssesOutcome(sid, {
+      assessment: "expected",
+    });
+
+    expect(result.S).toBe(0);
+    expect(result.message).toContain("Checkpoint");
+
+    const status = await handler.ulyssesStatus();
+    expect(status.active_step).toBeNull();
+  });
+
+  // C → outcome(unexpected) → D
+  it("unexpected outcome at S=2 (both moves unexpected) → S=2, reflect required, forbidden_moves populated", async () => {
+    const handler = new InMemoryProtocolHandler();
+    const init = await handler.ulyssesInit("bug");
+    const sid = init.session_id as string;
+
+    await handler.ulyssesPlan(sid, {
+      primary: "check logs",
+      recovery: "check metrics",
+      irreversible: false,
+    });
+
+    await handler.ulyssesOutcome(sid, {
+      assessment: "unexpected-unfavorable",
+      details: "logs empty",
+    });
+
+    const result = await handler.ulyssesOutcome(sid, {
+      assessment: "unexpected-unfavorable",
+      details: "metrics empty too",
+    });
+
+    expect(result.S).toBe(2);
+    expect(result.message).toContain("REFLECT");
+    expect(result.forbidden_moves).toContain("check logs");
+    expect(result.forbidden_moves).toContain("check metrics");
+
+    const status = await handler.ulyssesStatus();
+    expect(status.active_step).toBeNull();
+  });
+
+  // D → reflect → A
+  it("reflect at S=2 (active_step null) → S=0", async () => {
+    const handler = new InMemoryProtocolHandler();
+    const init = await handler.ulyssesInit("bug");
+    const sid = init.session_id as string;
+
+    await handler.ulyssesPlan(sid, {
+      primary: "check logs",
+      recovery: "check metrics",
+      irreversible: false,
+    });
+
+    await handler.ulyssesOutcome(sid, {
+      assessment: "unexpected-unfavorable",
+      details: "primary failed",
+    });
+    await handler.ulyssesOutcome(sid, {
+      assessment: "unexpected-unfavorable",
+      details: "backup failed",
+    });
+
+    const result = await handler.ulyssesReflect(sid, {
+      hypothesis: "config is wrong",
+      falsification: "changing config doesn't fix it",
+    });
+
+    expect(result.S).toBe(0);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Error transitions
+  // ---------------------------------------------------------------------------
+
+  // D → plan → error
+  it("plan at S=2 (reflect required) throws REFLECT error", async () => {
+    const handler = new InMemoryProtocolHandler();
+    const init = await handler.ulyssesInit("bug");
+    const sid = init.session_id as string;
+
+    await handler.ulyssesPlan(sid, {
+      primary: "a",
+      recovery: "b",
+      irreversible: false,
+    });
+    await handler.ulyssesOutcome(sid, { assessment: "unexpected-unfavorable" });
+    await handler.ulyssesOutcome(sid, { assessment: "unexpected-unfavorable" });
+
+    await expect(
+      handler.ulyssesPlan(sid, { primary: "x", recovery: "y", irreversible: false }),
+    ).rejects.toThrow(/REFLECT/);
+  });
+
+  // C → reflect → error
+  it("reflect at S=2 with active_step still set throws backup-pending error", async () => {
+    const handler = new InMemoryProtocolHandler();
+    const init = await handler.ulyssesInit("bug");
+    const sid = init.session_id as string;
+
+    await handler.ulyssesPlan(sid, {
+      primary: "a",
+      recovery: "b",
+      irreversible: false,
+    });
+
+    await handler.ulyssesOutcome(sid, {
+      assessment: "unexpected-unfavorable",
+    });
+
+    await expect(
+      handler.ulyssesReflect(sid, {
+        hypothesis: "h",
+        falsification: "f",
+      }),
+    ).rejects.toThrow(/Backup move outcome not yet reported/);
+  });
+
+  // A → outcome → error
+  it("outcome with no active_step throws error", async () => {
+    const handler = new InMemoryProtocolHandler();
+    const init = await handler.ulyssesInit("bug");
+    const sid = init.session_id as string;
+
+    await expect(
+      handler.ulyssesOutcome(sid, { assessment: "expected" }),
+    ).rejects.toThrow(/No active step/);
+  });
+
+  // B → reflect → error
+  it("reflect at S=1 throws S≠2 error", async () => {
+    const handler = new InMemoryProtocolHandler();
+    const init = await handler.ulyssesInit("bug");
+    const sid = init.session_id as string;
+
+    await handler.ulyssesPlan(sid, {
+      primary: "a",
+      recovery: "b",
+      irreversible: false,
+    });
+
+    await expect(
+      handler.ulyssesReflect(sid, {
+        hypothesis: "h",
+        falsification: "f",
+      }),
+    ).rejects.toThrow(/REFLECT requires S=2/);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Enforcement sub-states
+  // ---------------------------------------------------------------------------
+
+  // A → not blocked
+  it("enforcement allows mutations at S=0 (checkpoint)", async () => {
+    const handler = new InMemoryProtocolHandler();
+    await handler.ulyssesInit("bug");
+
+    const result = await handler.checkEnforcement({
+      mutation: true,
+      targetPath: "src/app.ts",
+    });
+
+    expect(result.enforce).toBe(false);
+  });
+
+  // B → not blocked
+  it("enforcement allows mutations at S=1 (primary executing)", async () => {
+    const handler = new InMemoryProtocolHandler();
+    const init = await handler.ulyssesInit("bug");
+    const sid = init.session_id as string;
+
+    await handler.ulyssesPlan(sid, {
+      primary: "a",
+      recovery: "b",
+      irreversible: false,
+    });
+
+    const result = await handler.checkEnforcement({
+      mutation: true,
+      targetPath: "src/app.ts",
+    });
+
+    expect(result.enforce).toBe(false);
+  });
+
+  // C → not blocked
+  it("enforcement allows mutations at S=2 with active_step (backup executing)", async () => {
+    const handler = new InMemoryProtocolHandler();
+    const init = await handler.ulyssesInit("bug");
+    const sid = init.session_id as string;
+
+    await handler.ulyssesPlan(sid, {
+      primary: "a",
+      recovery: "b",
+      irreversible: false,
+    });
+    await handler.ulyssesOutcome(sid, {
+      assessment: "unexpected-unfavorable",
+    });
+
+    const result = await handler.checkEnforcement({
+      mutation: true,
+      targetPath: "src/app.ts",
+    });
+
+    expect(result.enforce).toBe(false);
+  });
+
+  // D → blocked
+  it("enforcement blocks mutations at S=2 with no active_step (reflect required)", async () => {
+    const handler = new InMemoryProtocolHandler();
+    const init = await handler.ulyssesInit("bug");
+    const sid = init.session_id as string;
+
+    await handler.ulyssesPlan(sid, {
+      primary: "a",
+      recovery: "b",
+      irreversible: false,
+    });
+    await handler.ulyssesOutcome(sid, {
+      assessment: "unexpected-unfavorable",
+    });
+    await handler.ulyssesOutcome(sid, {
+      assessment: "unexpected-unfavorable",
+    });
+
+    const result = await handler.checkEnforcement({
+      mutation: true,
+      targetPath: "src/app.ts",
+    });
+
+    expect(result.enforce).toBe(true);
+    expect(result.blocked).toBe(true);
+    expect(result.required_action).toBe("reflect");
+  });
+
+  // ---------------------------------------------------------------------------
+  // Data correctness
+  // ---------------------------------------------------------------------------
+
+  it("forbidden_moves contains both primary and recovery after both fail", async () => {
+    const handler = new InMemoryProtocolHandler();
+    const init = await handler.ulyssesInit("bug");
+    const sid = init.session_id as string;
+
+    await handler.ulyssesPlan(sid, {
+      primary: "check logs",
+      recovery: "check metrics",
+      irreversible: false,
+    });
+    await handler.ulyssesOutcome(sid, {
+      assessment: "unexpected-unfavorable",
+    });
+    const result = await handler.ulyssesOutcome(sid, {
+      assessment: "unexpected-unfavorable",
+    });
+
+    expect(result.forbidden_moves).toEqual(
+      expect.arrayContaining(["check logs", "check metrics"]),
+    );
+  });
+
+  it("unexpected-favorable at S=2 still forbids both moves", async () => {
+    const handler = new InMemoryProtocolHandler();
+    const init = await handler.ulyssesInit("bug");
+    const sid = init.session_id as string;
+
+    await handler.ulyssesPlan(sid, {
+      primary: "check logs",
+      recovery: "check metrics",
+      irreversible: false,
+    });
+    await handler.ulyssesOutcome(sid, {
+      assessment: "unexpected-favorable",
+    });
+    const result = await handler.ulyssesOutcome(sid, {
+      assessment: "unexpected-favorable",
+    });
+
+    expect(result.S).toBe(2);
+    expect(result.forbidden_moves).toEqual(
+      expect.arrayContaining(["check logs", "check metrics"]),
+    );
+  });
+
+  it("forbidden_moves accumulate across multiple cycles", async () => {
+    const handler = new InMemoryProtocolHandler();
+    const init = await handler.ulyssesInit("bug");
+    const sid = init.session_id as string;
+
+    // First cycle: both moves fail
+    await handler.ulyssesPlan(sid, {
+      primary: "check logs",
+      recovery: "check metrics",
+      irreversible: false,
+    });
+    await handler.ulyssesOutcome(sid, { assessment: "unexpected-unfavorable" });
+    await handler.ulyssesOutcome(sid, { assessment: "unexpected-unfavorable" });
+
+    // Reflect → S=0
+    await handler.ulyssesReflect(sid, {
+      hypothesis: "h1",
+      falsification: "f1",
+    });
+
+    // Second cycle: both moves fail again
+    await handler.ulyssesPlan(sid, {
+      primary: "check env",
+      recovery: "check config",
+      irreversible: false,
+    });
+    await handler.ulyssesOutcome(sid, { assessment: "unexpected-unfavorable" });
+    const result = await handler.ulyssesOutcome(sid, { assessment: "unexpected-unfavorable" });
+
+    // Should contain moves from BOTH cycles
+    expect(result.forbidden_moves).toEqual(
+      expect.arrayContaining([
+        "check logs", "check metrics",
+        "check env", "check config",
+      ]),
+    );
+  });
+});

--- a/src/protocol/handler.ts
+++ b/src/protocol/handler.ts
@@ -499,12 +499,11 @@ export class ProtocolHandler {
 
     const initialState: Json = {
       S: 0,
-      consecutive_surprises: 0,
       problem,
       constraints: constraints ?? [],
-      surprise_register: [] as Json[],
       checkpoints: ['initial'],
       hypotheses: [] as Json[],
+      forbidden_moves: [] as Json[],
       active_step: null,
     };
 
@@ -613,10 +612,9 @@ export class ProtocolHandler {
     }
     const state = session.state_json as {
       S: number;
-      consecutive_surprises: number;
       active_step: Json | null;
-      surprise_register: Json[];
       checkpoints: string[];
+      forbidden_moves: string[];
     };
 
     if (!state.active_step) {
@@ -642,47 +640,41 @@ export class ProtocolHandler {
       throw new Error(`Failed to record outcome: ${histErr.message}`);
     }
 
-    const newState = { ...state, active_step: null };
+    const activeStep = state.active_step as { primary?: string; recovery?: string };
+    let newState: typeof state;
     let resultMsg: string;
 
     if (outcome.assessment === 'expected') {
-      newState.S = 0;
-      newState.consecutive_surprises = 0;
-      newState.checkpoints = [
-        ...state.checkpoints,
-        `checkpoint_${state.checkpoints.length}`,
-      ];
-      resultMsg = 'Expected outcome. S reset to 0. Checkpoint created.';
-    } else {
-      const severity = outcome.severity ?? 1;
-      const surprise = {
-        details: outcome.details ?? '',
-        severity,
-        timestamp: new Date().toISOString(),
+      // Expected outcome at any S level → back to checkpoint, clear active step
+      newState = {
+        ...state,
+        S: 0,
+        active_step: null,
+        checkpoints: [
+          ...state.checkpoints,
+          `checkpoint_${state.checkpoints.length}`,
+        ],
       };
-      newState.surprise_register = [
-        ...state.surprise_register,
-        surprise,
-      ].slice(-3);
-
-      if (severity === 2) {
-        newState.S = 2;
-        newState.consecutive_surprises = 0;
-        resultMsg = 'Flagrant-2 surprise. S=2. REFLECT required.';
-      } else {
-        const count = (state.consecutive_surprises ?? 0) + 1;
-        newState.consecutive_surprises = count;
-        if (count >= 2) {
-          newState.S = 2;
-          newState.consecutive_surprises = 0;
-          resultMsg =
-            `Surprise #${count} (severity ${severity}). S=2. REFLECT required.`;
-        } else {
-          newState.S = Math.max(state.S ?? 0, 1);
-          resultMsg =
-            `Surprise #${count} (severity ${severity}). S=${newState.S}.`;
-        }
-      }
+      resultMsg = 'Expected outcome. S→0. Checkpoint created.';
+    } else if (state.S === 1) {
+      // Primary move failed → S=2, execute backup (keep active_step for backup outcome)
+      newState = {
+        ...state,
+        S: 2,
+      };
+      resultMsg = 'Primary move produced unexpected outcome. S→2. Execute backup move.';
+    } else {
+      // S=2 and backup also failed → both moves failed, reflect required, clear active step
+      const forbidden = [...(state.forbidden_moves ?? [])];
+      if (activeStep?.primary) forbidden.push(activeStep.primary);
+      if (activeStep?.recovery) forbidden.push(activeStep.recovery);
+      newState = {
+        ...state,
+        S: 2,
+        active_step: null,
+        forbidden_moves: forbidden,
+      };
+      resultMsg = 'Both primary and backup moves produced unexpected outcomes. S=2. REFLECT required. Failed moves are now forbidden.';
     }
 
     const { error: stateErr } = await this.client
@@ -700,6 +692,7 @@ export class ProtocolHandler {
       session_id: session.id,
       assessment: outcome.assessment,
       S: newState.S,
+      forbidden_moves: newState.forbidden_moves,
       message: resultMsg,
     };
   }
@@ -722,7 +715,7 @@ export class ProtocolHandler {
     if ((state.S ?? 0) !== 2) {
       throw new Error(
         `REFLECT requires S=2 (current S=${state.S ?? 0}). ` +
-          'Only callable after two consecutive surprises.',
+          'Only callable after both primary and backup moves produced unexpected outcomes.',
       );
     }
 
@@ -735,7 +728,6 @@ export class ProtocolHandler {
     const newState = {
       ...state,
       S: 0,
-      consecutive_surprises: 0,
       hypotheses: [...(state.hypotheses ?? []), hypothesis],
     };
 
@@ -795,12 +787,11 @@ export class ProtocolHandler {
 
     const state = session.state_json as {
       S: number;
-      consecutive_surprises: number;
       problem: string;
       active_step: Record<string, unknown> | null;
-      surprise_register: unknown[];
       hypotheses: unknown[];
       checkpoints: string[];
+      forbidden_moves: string[];
     };
 
     const { count: historyCount } = await this.client
@@ -813,10 +804,9 @@ export class ProtocolHandler {
       protocol: 'ulysses',
       session_id: session.id,
       S: state.S ?? 0,
-      consecutive_surprises: state.consecutive_surprises ?? 0,
       problem: state.problem,
       active_step: state.active_step,
-      surprise_register_count: state.surprise_register?.length ?? 0,
+      forbidden_moves: state.forbidden_moves ?? [],
       hypothesis_count: state.hypotheses?.length ?? 0,
       checkpoint_count: state.checkpoints?.length ?? 0,
       history_event_count: historyCount ?? 0,

--- a/src/protocol/handler.ts
+++ b/src/protocol/handler.ts
@@ -868,8 +868,8 @@ export class ProtocolHandler {
     const workspaceId = input.workspaceId ?? this.workspaceId;
     const ulyssesSession = await this.getActiveSession('ulysses', workspaceId);
     if (ulyssesSession) {
-      const state = ulyssesSession.state_json as { S?: number };
-      if ((state.S ?? 0) === ULYSSES_STATE_NEEDS_REFLECT) {
+      const state = ulyssesSession.state_json as { S?: number; active_step?: unknown };
+      if ((state.S ?? 0) === ULYSSES_STATE_NEEDS_REFLECT && state.active_step == null) {
         return {
           enforce: true,
           blocked: true,

--- a/src/protocol/handler.ts
+++ b/src/protocol/handler.ts
@@ -674,7 +674,7 @@ export class ProtocolHandler {
         active_step: null,
         forbidden_moves: forbidden,
       };
-      resultMsg = 'Both primary and backup moves produced unexpected outcomes. S=2. REFLECT required. Failed moves are now forbidden.';
+      resultMsg = 'Both primary and backup moves produced unexpected outcomes. S=2. REFLECT required. Those moves are now forbidden.';
     }
 
     const { error: stateErr } = await this.client
@@ -710,6 +710,7 @@ export class ProtocolHandler {
     const state = session.state_json as {
       S: number;
       hypotheses: Json[];
+      active_step: Json | null;
     };
 
     if ((state.S ?? 0) !== 2) {
@@ -717,6 +718,9 @@ export class ProtocolHandler {
         `REFLECT requires S=2 (current S=${state.S ?? 0}). ` +
           'Only callable after both primary and backup moves produced unexpected outcomes.',
       );
+    }
+    if (state.active_step !== null && state.active_step !== undefined) {
+      throw new Error('Backup move outcome not yet reported. Run outcome first.');
     }
 
     const hypothesis = {

--- a/src/protocol/in-memory-handler.ts
+++ b/src/protocol/in-memory-handler.ts
@@ -588,8 +588,8 @@ export class InMemoryProtocolHandler {
     const workspaceId = input.workspaceId ?? this.workspaceId;
     const ulyssesSession = this.getActiveSession('ulysses', workspaceId);
     if (ulyssesSession) {
-      const state = ulyssesSession.state_json as { S?: number };
-      if ((state.S ?? 0) === ULYSSES_STATE_NEEDS_REFLECT) {
+      const state = ulyssesSession.state_json as { S?: number; active_step?: unknown };
+      if ((state.S ?? 0) === ULYSSES_STATE_NEEDS_REFLECT && state.active_step == null) {
         return {
           enforce: true,
           blocked: true,

--- a/src/protocol/in-memory-handler.ts
+++ b/src/protocol/in-memory-handler.ts
@@ -458,7 +458,7 @@ export class InMemoryProtocolHandler {
         active_step: null,
         forbidden_moves: forbidden,
       };
-      resultMsg = 'Both primary and backup moves produced unexpected outcomes. S=2. REFLECT required. Failed moves are now forbidden.';
+      resultMsg = 'Both primary and backup moves produced unexpected outcomes. S=2. REFLECT required. Those moves are now forbidden.';
     }
 
     const updatedState = session.state_json as typeof state;
@@ -482,12 +482,15 @@ export class InMemoryProtocolHandler {
     if (session.id !== sessionId) {
       throw new Error(`Session ${sessionId} is not the active ulysses session`);
     }
-    const state = session.state_json as { S: number; hypotheses: unknown[] };
+    const state = session.state_json as { S: number; hypotheses: unknown[]; active_step: unknown };
 
     if ((state.S ?? 0) !== 2) {
       throw new Error(
         `REFLECT requires S=2 (current S=${state.S ?? 0}). Only callable after both primary and backup moves produced unexpected outcomes.`,
       );
+    }
+    if (state.active_step !== null && state.active_step !== undefined) {
+      throw new Error('Backup move outcome not yet reported. Run outcome first.');
     }
 
     const hypothesis = {

--- a/src/protocol/in-memory-handler.ts
+++ b/src/protocol/in-memory-handler.ts
@@ -331,12 +331,11 @@ export class InMemoryProtocolHandler {
       status: 'active',
       state_json: {
         S: 0,
-        consecutive_surprises: 0,
         problem,
         constraints: constraints ?? [],
-        surprise_register: [],
         checkpoints: ['initial'],
         hypotheses: [],
+        forbidden_moves: [],
         active_step: null,
       },
       created_at: new Date().toISOString(),
@@ -407,10 +406,9 @@ export class InMemoryProtocolHandler {
     }
     const state = session.state_json as {
       S: number;
-      consecutive_surprises: number;
       active_step: unknown;
-      surprise_register: unknown[];
       checkpoints: string[];
+      forbidden_moves: string[];
     };
 
     if (!state.active_step) {
@@ -430,49 +428,48 @@ export class InMemoryProtocolHandler {
       created_at: new Date().toISOString(),
     });
 
-    const newState = { ...state, active_step: null } as typeof state;
+    const activeStep = state.active_step as { primary?: string; recovery?: string };
     let resultMsg: string;
 
     if (outcome.assessment === 'expected') {
-      newState.S = 0;
-      newState.consecutive_surprises = 0;
-      newState.checkpoints = [...state.checkpoints, `checkpoint_${state.checkpoints.length}`];
-      resultMsg = 'Expected outcome. S reset to 0. Checkpoint created.';
-    } else {
-      const severity = outcome.severity ?? 1;
-      const surprise = {
-        details: outcome.details ?? '',
-        severity,
-        timestamp: new Date().toISOString(),
+      // Expected outcome at any S level → back to checkpoint, clear active step
+      session.state_json = {
+        ...state,
+        S: 0,
+        active_step: null,
+        checkpoints: [...state.checkpoints, `checkpoint_${state.checkpoints.length}`],
       };
-      newState.surprise_register = [...state.surprise_register, surprise].slice(-3);
-
-      if (severity === 2) {
-        newState.S = 2;
-        newState.consecutive_surprises = 0;
-        resultMsg = 'Flagrant-2 surprise. S=2. REFLECT required.';
-      } else {
-        const count = (state.consecutive_surprises ?? 0) + 1;
-        newState.consecutive_surprises = count;
-        if (count >= 2) {
-          newState.S = 2;
-          newState.consecutive_surprises = 0;
-          resultMsg = `Surprise #${count} (severity ${severity}). S=2. REFLECT required.`;
-        } else {
-          newState.S = Math.max(state.S ?? 0, 1);
-          resultMsg = `Surprise #${count} (severity ${severity}). S=${newState.S}.`;
-        }
-      }
+      resultMsg = 'Expected outcome. S→0. Checkpoint created.';
+    } else if (state.S === 1) {
+      // Primary move failed → S=2, execute backup (keep active_step for backup outcome)
+      session.state_json = {
+        ...state,
+        S: 2,
+      };
+      resultMsg = 'Primary move produced unexpected outcome. S→2. Execute backup move.';
+    } else {
+      // S=2 and backup also failed → both moves failed, reflect required, clear active step
+      const forbidden = [...(state.forbidden_moves ?? [])];
+      if (activeStep?.primary) forbidden.push(activeStep.primary);
+      if (activeStep?.recovery) forbidden.push(activeStep.recovery);
+      session.state_json = {
+        ...state,
+        S: 2,
+        active_step: null,
+        forbidden_moves: forbidden,
+      };
+      resultMsg = 'Both primary and backup moves produced unexpected outcomes. S=2. REFLECT required. Failed moves are now forbidden.';
     }
 
-    session.state_json = newState;
+    const updatedState = session.state_json as typeof state;
 
-    this.emit('ulysses_outcome', session.id, { assessment: outcome.assessment, S: newState.S });
+    this.emit('ulysses_outcome', session.id, { assessment: outcome.assessment, S: updatedState.S });
 
     return {
       session_id: session.id,
       assessment: outcome.assessment,
-      S: newState.S,
+      S: updatedState.S,
+      forbidden_moves: updatedState.forbidden_moves,
       message: resultMsg,
     };
   }
@@ -489,7 +486,7 @@ export class InMemoryProtocolHandler {
 
     if ((state.S ?? 0) !== 2) {
       throw new Error(
-        `REFLECT requires S=2 (current S=${state.S ?? 0}). Only callable after two consecutive surprises.`,
+        `REFLECT requires S=2 (current S=${state.S ?? 0}). Only callable after both primary and backup moves produced unexpected outcomes.`,
       );
     }
 
@@ -502,7 +499,6 @@ export class InMemoryProtocolHandler {
     session.state_json = {
       ...state,
       S: 0,
-      consecutive_surprises: 0,
       hypotheses: [...(state.hypotheses ?? []), hypothesis],
     };
 
@@ -539,12 +535,11 @@ export class InMemoryProtocolHandler {
     }
     const state = session.state_json as {
       S: number;
-      consecutive_surprises: number;
       problem: string;
       active_step: Record<string, unknown> | null;
-      surprise_register: unknown[];
       hypotheses: unknown[];
       checkpoints: string[];
+      forbidden_moves: string[];
     };
     const historyCount = this.history.filter(h => h.session_id === session.id).length;
 
@@ -553,10 +548,9 @@ export class InMemoryProtocolHandler {
       protocol: 'ulysses',
       session_id: session.id,
       S: state.S ?? 0,
-      consecutive_surprises: state.consecutive_surprises ?? 0,
       problem: state.problem,
       active_step: state.active_step,
-      surprise_register_count: state.surprise_register?.length ?? 0,
+      forbidden_moves: state.forbidden_moves ?? [],
       hypothesis_count: state.hypotheses?.length ?? 0,
       checkpoint_count: state.checkpoints?.length ?? 0,
       history_event_count: historyCount,

--- a/src/protocol/operations.ts
+++ b/src/protocol/operations.ts
@@ -169,7 +169,7 @@ export const ULYSSES_OPERATIONS: OperationDefinition[] = [
     name: "init",
     title: "Init Debugging Session",
     description:
-      "Start a Ulysses debugging session with a problem statement and optional constraints. Initializes the surprise register at S=0.",
+      "Start a Ulysses debugging session with a problem statement and optional constraints. Initializes the state step tracker at S=0 (at checkpoint, clean state).",
     category: "session-lifecycle",
     inputSchema: {
       type: "object",
@@ -227,7 +227,7 @@ export const ULYSSES_OPERATIONS: OperationDefinition[] = [
     name: "outcome",
     title: "Assess Step Outcome",
     description:
-      "Assess the result of a plan step. Unexpected outcomes increment the surprise register. At S=2, reflection is required before further action.",
+      "Assess the result of a plan step. Expected outcome → S→0, log checkpoint. Unexpected outcome → advance state step. At S=2 (both primary and backup failed), reflection is required before further action.",
     category: "investigation",
     inputSchema: {
       type: "object",
@@ -243,7 +243,7 @@ export const ULYSSES_OPERATIONS: OperationDefinition[] = [
         },
         severity: {
           type: "number",
-          description: "Surprise severity: 1 = minor, 2 = major",
+          description: "State step context (optional detail about the outcome)",
         },
         details: {
           type: "string",
@@ -263,7 +263,7 @@ export const ULYSSES_OPERATIONS: OperationDefinition[] = [
     name: "reflect",
     title: "Form Falsifiable Hypothesis",
     description:
-      "Form a falsifiable hypothesis when the surprise register hits S=2. Must include explicit disproof criteria. Required before the protocol allows further action steps.",
+      "Form a falsifiable hypothesis when the state step tracker reaches S=2 (both primary and backup moves failed). Must include explicit disproof criteria. Required before the protocol allows further action steps. Failed moves are forbidden; generate new primary + backup.",
     category: "investigation",
     inputSchema: {
       type: "object",
@@ -291,7 +291,7 @@ export const ULYSSES_OPERATIONS: OperationDefinition[] = [
     name: "status",
     title: "Show Session Status",
     description:
-      "Show current Ulysses session state including S register value, active step, and surprise history.",
+      "Show current Ulysses session state including S (state step) value, active move, and checkpoint history.",
     category: "session-lifecycle",
     inputSchema: {
       type: "object",

--- a/src/protocol/operations.ts
+++ b/src/protocol/operations.ts
@@ -241,10 +241,6 @@ export const ULYSSES_OPERATIONS: OperationDefinition[] = [
           ],
           description: "How the outcome compared to expectations",
         },
-        severity: {
-          type: "number",
-          description: "State step context (optional detail about the outcome)",
-        },
         details: {
           type: "string",
           description: "Details about the outcome",
@@ -254,7 +250,6 @@ export const ULYSSES_OPERATIONS: OperationDefinition[] = [
     },
     example: {
       assessment: "unexpected-unfavorable",
-      severity: 2,
       details:
         "Logs show the handler is never reached — request rejected at auth middleware",
     },

--- a/src/protocol/types.ts
+++ b/src/protocol/types.ts
@@ -99,7 +99,6 @@ export interface PlanInput {
 
 export interface UlyssesOutcomeInput {
   assessment: 'expected' | 'unexpected-favorable' | 'unexpected-unfavorable';
-  severity?: number;
   details?: string;
 }
 

--- a/src/protocol/ulysses-tool.ts
+++ b/src/protocol/ulysses-tool.ts
@@ -13,7 +13,6 @@ export const ulyssesToolInputSchema = z.object({
   irreversible: z.boolean().optional().describe("Whether primary step is irreversible for plan"),
   assessment: z.enum(["expected", "unexpected-favorable", "unexpected-unfavorable"]).optional()
     .describe("Outcome assessment"),
-  severity: z.number().min(1).max(2).optional().describe("Surprise severity (1=minor, 2=major)"),
   details: z.string().optional().describe("Details for outcome"),
   hypothesis: z.string().optional().describe("Falsifiable hypothesis for reflect"),
   falsification: z.string().optional().describe("Disproof criteria for reflect"),
@@ -96,11 +95,10 @@ export class UlyssesTool {
         const sid = this.requireSession();
         result = await this.handler.ulyssesOutcome(sid, {
           assessment: input.assessment!,
-          severity: input.severity,
           details: input.details,
         });
         await this.bridgeThought(
-          `[Ulysses:outcome] Assessment: ${input.assessment}${input.severity ? ` (severity ${input.severity})` : ''}${input.details ? `. ${input.details}` : ''}`,
+          `[Ulysses:outcome] Assessment: ${input.assessment}${input.details ? `. ${input.details}` : ''}`,
           input.assessment === 'expected' ? 'action_report' : 'reasoning',
         );
         break;

--- a/src/protocol/ulysses-tool.ts
+++ b/src/protocol/ulysses-tool.ts
@@ -26,14 +26,25 @@ export type UlyssesToolInput = z.infer<typeof ulyssesToolInputSchema>;
 
 export const ULYSSES_TOOL = {
   name: "thoughtbox_ulysses",
-  description: `Ulysses Protocol: surprise-gated debugging for autonomous agents. Forces pre-committed recovery, rigorous surprise assessment, and falsifiable hypotheses.
+  description: `Ulysses Protocol: state-step-gated debugging for autonomous agents. Tracks position in the plan→execute→evaluate cycle. Prevents debugging spirals by forcing reflection after two consecutive unexpected outcomes.
+
+S (state step) tracks where you are in the cycle:
+- S=0: At a checkpoint. Clean state. Form hypothesis: primary move + backup move.
+- S=1: Primary move produced unexpected outcome. Now executing the backup move.
+- S=2: Backup also produced unexpected outcome. Two unexpected outcomes in a row. Reset to last checkpoint, S→0. Form falsifiable hypotheses about why both moves failed. Those two moves are now forbidden. Generate new primary + backup and loop.
+
+Full cycle:
+1. At S=0, form hypothesis (primary move + backup move)
+2. Create git branch, S→1, execute primary move
+3. Git commit. Expected outcome? → S→0, log checkpoint. Unexpected? → S→2, execute backup
+4. Git commit. Expected outcome? → S→0, log checkpoint. Unexpected? → S=2 → reset to last checkpoint, S→0, reflect, forbid those moves, start over
 
 Operations:
 - init: Start a debugging session (args: { problem, constraints? })
-- plan: Record primary action + pre-committed recovery step (args: { primary, recovery, irreversible? })
-- outcome: Assess step result and update surprise state (args: { assessment, severity?, details? })
-- reflect: Form falsifiable hypothesis when S=2 (args: { hypothesis, falsification })
-- status: Show current session state (S register, active step, surprise register)
+- plan: Record primary move + pre-committed backup move (args: { primary, recovery, irreversible? })
+- outcome: Report whether the move produced the expected outcome (args: { assessment: "expected"|"unexpected-favorable"|"unexpected-unfavorable", details? })
+- reflect: Form falsifiable hypothesis when S=2 — both moves failed (args: { hypothesis, falsification })
+- status: Show current session state (S state step, active move, checkpoint history)
 - complete: End session with terminal status (args: { terminalState: "resolved"|"insufficient_information"|"environment_compromised", summary? })`,
   inputSchema: ulyssesToolInputSchema,
   annotations: {

--- a/src/protocol/ulysses-tool.ts
+++ b/src/protocol/ulysses-tool.ts
@@ -29,8 +29,8 @@ export const ULYSSES_TOOL = {
 
 S (state step) tracks where you are in the cycle:
 - S=0: At a checkpoint. Clean state. Form hypothesis: primary move + backup move.
-- S=1: Primary move produced unexpected outcome. Now executing the backup move.
-- S=2: Backup also produced unexpected outcome. Two unexpected outcomes in a row. Reset to last checkpoint, S→0. Form falsifiable hypotheses about why both moves failed. Those two moves are now forbidden. Generate new primary + backup and loop.
+- S=1: Plan submitted. Primary move executing.
+- S=2: Primary produced unexpected outcome. Backup executing — OR both produced unexpected outcomes (active_step null), reflect required.
 
 Full cycle:
 1. At S=0, form hypothesis (primary move + backup move)

--- a/src/resources/patterns-cookbook-content.ts
+++ b/src/resources/patterns-cookbook-content.ts
@@ -203,6 +203,9 @@ Thought 16: totalThoughts: 40  // Adjusted upward
 
 ## Best Practices
 
+### 0. One Thought Per Tool Call
+Submit one \`tb.thought()\`, \`tb.ulysses()\`, or \`tb.theseus()\` per \`thoughtbox_execute\` call. Each response contains guidance (patterns, session state, protocol state) that should inform your next operation. Batching multiple state-mutating calls bypasses this feedback loop and produces lower-quality reasoning. Read-only operations (\`tb.session.*\`, \`tb.knowledge.*\`, \`tb.observability()\`, \`tb.branch.*\`) may be freely chained.
+
 ### 1. Start with Problem Statement
 Your thought 1 should clearly define what you're trying to solve.
 

--- a/src/resources/skills/index.ts
+++ b/src/resources/skills/index.ts
@@ -54,7 +54,7 @@ Seven modules, two tools:
 | **knowledge** | Entity graph with observations, relations, traversal | \`tb.knowledge.*\` |
 | **notebook** | Literate programming — create cells, execute code, export | \`tb.notebook.*\` |
 | **theseus** | Friction-gated refactoring protocol (scope locking, visa system) | \`tb.theseus()\` |
-| **ulysses** | State-step-gated debugging protocol (S tracker: 0=checkpoint, 1=executing backup, 2=both failed→reflect) | \`tb.ulysses()\` |
+| **ulysses** | State-step-gated debugging protocol (S tracker: 0=checkpoint, 1=primary executing, 2=backup executing or both failed→reflect) | \`tb.ulysses()\` |
 | **observability** | Health checks, session monitoring, cost tracking | \`tb.observability()\` |
 
 **Two MCP tools** give you access to everything:
@@ -366,7 +366,7 @@ For architectural decisions, bridge to an ADR via the HDD workflow.`,
     name: "debug",
     title: "Thoughtbox Debug",
     description:
-      "State-step-gated debugging using the Ulysses protocol. Prevents debugging spirals by tracking position in the plan→execute→evaluate cycle. S=0 at checkpoint, S=1 after plan submitted (primary executing), S=2 after primary produces unexpected outcome (backup executing) or both fail (reflect required).",
+      "State-step-gated debugging using the Ulysses protocol. Prevents debugging spirals by tracking position in the plan→execute→evaluate cycle. S=0 at checkpoint, S=1 after plan submitted (primary executing), S=2 after primary produces unexpected outcome (backup executing) or both failed (reflect required).",
     args: [
       {
         name: "problem",

--- a/src/resources/skills/index.ts
+++ b/src/resources/skills/index.ts
@@ -366,7 +366,7 @@ For architectural decisions, bridge to an ADR via the HDD workflow.`,
     name: "debug",
     title: "Thoughtbox Debug",
     description:
-      "State-step-gated debugging using the Ulysses protocol. Prevents debugging spirals by tracking position in the plan→execute→evaluate cycle. S=0 at checkpoint, S=1 after primary fails (executing backup), S=2 after both fail (reset to checkpoint, reflect, forbid moves).",
+      "State-step-gated debugging using the Ulysses protocol. Prevents debugging spirals by tracking position in the plan→execute→evaluate cycle. S=0 at checkpoint, S=1 after plan submitted (primary executing), S=2 after primary produces unexpected outcome (backup executing) or both fail (reflect required).",
     args: [
       {
         name: "problem",
@@ -376,10 +376,10 @@ For architectural decisions, bridge to an ADR via the HDD workflow.`,
     ],
     content: `# Thoughtbox Debug (Ulysses Protocol)
 
-The S (state step) tracker prevents debugging spirals by tracking your position in the plan→execute→evaluate cycle:
+The S (state step) tracker prevents debugging spirals by tracking your position in the cycle:
 - S=0: At a checkpoint. Clean state. Form hypothesis: primary move + backup move.
-- S=1: Primary move produced unexpected outcome. Now executing the backup move.
-- S=2: Backup also failed. Two unexpected outcomes in a row. Reset to last checkpoint, S→0. Form falsifiable hypotheses about why both moves failed. Those two moves are now forbidden. Generate new primary + backup and loop.
+- S=1: Plan submitted. Primary move executing.
+- S=2: Primary produced unexpected outcome. Backup executing — OR both produced unexpected outcomes (active_step null), reflect required.
 
 Full cycle:
 1. At S=0, form hypothesis (primary move + backup move)

--- a/src/resources/skills/index.ts
+++ b/src/resources/skills/index.ts
@@ -54,7 +54,7 @@ Seven modules, two tools:
 | **knowledge** | Entity graph with observations, relations, traversal | \`tb.knowledge.*\` |
 | **notebook** | Literate programming — create cells, execute code, export | \`tb.notebook.*\` |
 | **theseus** | Friction-gated refactoring protocol (scope locking, visa system) | \`tb.theseus()\` |
-| **ulysses** | Surprise-gated debugging protocol (S-register, forced reflection) | \`tb.ulysses()\` |
+| **ulysses** | State-step-gated debugging protocol (S tracker: 0=checkpoint, 1=executing backup, 2=both failed→reflect) | \`tb.ulysses()\` |
 | **observability** | Health checks, session monitoring, cost tracking | \`tb.observability()\` |
 
 **Two MCP tools** give you access to everything:
@@ -366,7 +366,7 @@ For architectural decisions, bridge to an ADR via the HDD workflow.`,
     name: "debug",
     title: "Thoughtbox Debug",
     description:
-      "Surprise-gated debugging using the Ulysses protocol. Prevents reactive debugging spirals by forcing structured hypotheses after repeated surprises.",
+      "State-step-gated debugging using the Ulysses protocol. Prevents debugging spirals by tracking position in the plan→execute→evaluate cycle. S=0 at checkpoint, S=1 after primary fails (executing backup), S=2 after both fail (reset to checkpoint, reflect, forbid moves).",
     args: [
       {
         name: "problem",
@@ -376,7 +376,16 @@ For architectural decisions, bridge to an ADR via the HDD workflow.`,
     ],
     content: `# Thoughtbox Debug (Ulysses Protocol)
 
-The S-register prevents debugging spirals. Each unexpected outcome increments S. At S=2, you MUST form a falsifiable hypothesis before continuing.
+The S (state step) tracker prevents debugging spirals by tracking your position in the plan→execute→evaluate cycle:
+- S=0: At a checkpoint. Clean state. Form hypothesis: primary move + backup move.
+- S=1: Primary move produced unexpected outcome. Now executing the backup move.
+- S=2: Backup also failed. Two unexpected outcomes in a row. Reset to last checkpoint, S→0. Form falsifiable hypotheses about why both moves failed. Those two moves are now forbidden. Generate new primary + backup and loop.
+
+Full cycle:
+1. At S=0, form hypothesis (primary move + backup move)
+2. Create git branch, S→1, execute primary move
+3. Git commit. Expected outcome? → S→0, log checkpoint. Unexpected? → S→2, execute backup
+4. Git commit. Expected outcome? → S→0, log checkpoint. Unexpected? → S=2 → reset to last checkpoint, S→0, reflect, forbid those moves, start over
 
 ## Phase 1: Initialize
 
@@ -392,7 +401,7 @@ async () => {
 
 ## Phase 2: Plan-Act-Assess Loop
 
-**Plan** with pre-committed recovery:
+**Plan** with pre-committed backup:
 \`\`\`javascript
 async () => tb.ulysses({ operation: "plan", primary: "Check CI env vars vs local", recovery: "If same, check node version" })
 \`\`\`
@@ -401,12 +410,12 @@ async () => tb.ulysses({ operation: "plan", primary: "Check CI env vars vs local
 
 **Assess** the outcome:
 \`\`\`javascript
-async () => tb.ulysses({ operation: "outcome", assessment: "unexpected", severity: "minor", details: "Env vars identical" })
+async () => tb.ulysses({ operation: "outcome", assessment: "unexpected-unfavorable", details: "Env vars identical" })
 \`\`\`
 
 ## Phase 3: Forced Reflection (S=2)
 
-Protocol blocks further plans until you reflect:
+When both primary and backup produce unexpected outcomes, protocol blocks further plans until you reflect:
 \`\`\`javascript
 async () => tb.ulysses({
   operation: "reflect",
@@ -415,7 +424,7 @@ async () => tb.ulysses({
 })
 \`\`\`
 
-Resets S to 0. Continue with focused hypothesis.
+Resets S to 0. Those two moves are now forbidden. Generate new primary + backup.
 
 ## Phase 4: Resolution
 
@@ -423,7 +432,7 @@ Resets S to 0. Continue with focused hypothesis.
 async () => tb.ulysses({ operation: "complete", terminalState: "resolved", summary: "Root cause: async db seeding not awaited" })
 \`\`\`
 
-Terminal states: resolved, abandoned, deferred.
+Terminal states: resolved, insufficient_information, environment_compromised.
 
 ## When to Use
 


### PR DESCRIPTION
## Summary

Two related fixes for the Ulysses Protocol:

### 1. Agent-facing description surfaces (commit 1976c28)
- Replaced "surprise register" with "state step tracker" across all model-visible surfaces
- S=0 at checkpoint, S=1 after primary fails (executing backup), S=2 after both fail (reset, reflect, forbid moves, loop)
- Full protocol cycle documented in tool description, operations catalog, SDK types, and debug skill
- Removed severity field from SDK type hints
- Added one-per-call constraint for `tb.thought()`, `tb.ulysses()`, `tb.theseus()` to preserve guidance feedback loop

### 2. Handler logic + schema + tests (commit 4d8bb42)
- Removed `severity` from Zod schema and `UlyssesOutcomeInput` type
- Rewrote `ulyssesOutcome` in both handlers with correct S state-step transitions:
  - expected at any S → S=0, checkpoint, clear active_step
  - unexpected at S=1 → S=2, keep active_step (backup still pending)
  - unexpected at S=2 → S=2, forbid both moves, clear active_step, reflect required
- Added `forbidden_moves` array (populated when both primary and backup fail)
- Removed `consecutive_surprises` and `surprise_register` from state shape
- Updated 4 test files to match new flow

### No Supabase schema migration needed
`state_json` is JSONB — the shape change is transparent to the database.

## Files changed
- `src/protocol/ulysses-tool.ts` — Zod schema, tool description, handle method
- `src/protocol/types.ts` — UlyssesOutcomeInput
- `src/protocol/operations.ts` — operations catalog
- `src/protocol/handler.ts` — Supabase handler logic
- `src/protocol/in-memory-handler.ts` — in-memory handler logic
- `src/code-mode/sdk-types.ts` — SDK type hints
- `src/code-mode/execute-tool.ts` — one-per-call constraint
- `src/resources/skills/index.ts` — onboard + debug skills
- `src/prompts/contents/interleaved-thinking-content.ts` — one-per-call instruction
- `src/resources/patterns-cookbook-content.ts` — one-per-call note
- `src/protocol/__tests__/enforcement.test.ts`
- `src/protocol/__tests__/handler.test.ts`
- `src/protocol/__tests__/protocol-events.test.ts`
- `src/__tests__/e2e-workflow.test.ts`