### PR TITLE
chore(auth): unwire THOUGHTBOX_API_KEY from production server

### DIFF
--- a/cloud-run-service.yaml
+++ b/cloud-run-service.yaml
@@ -25,11 +25,6 @@ spec:
           env:
             - name: NODE_ENV
               value: production
-            - name: THOUGHTBOX_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: thoughtbox-api-key
-                  key: latest
             - name: ANTHROPIC_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/src/index.ts
+++ b/src/index.ts
@@ -281,10 +281,7 @@ async function startHttpServer() {
       if (token.startsWith('tbx_')) {
         // API key via Bearer header
         try {
-          workspaceId = await resolveRequestAuth(req, {
-            staticKey: process.env.THOUGHTBOX_API_KEY,
-            localDevKey: process.env.THOUGHTBOX_API_KEY_LOCAL,
-          });
+          workspaceId = await resolveRequestAuth(req);
         } catch (err) {
           const message = err instanceof Error ? err.message : 'Authentication failed';
           res.status(401).json({
@@ -311,10 +308,7 @@ async function startHttpServer() {
     } else if (queryKey) {
       // API key via query param
       try {
-        workspaceId = await resolveRequestAuth(req, {
-          staticKey: process.env.THOUGHTBOX_API_KEY,
-          localDevKey: process.env.THOUGHTBOX_API_KEY_LOCAL,
-        });
+        workspaceId = await resolveRequestAuth(req);
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Authentication failed';
         res.status(401).json({
@@ -553,8 +547,6 @@ async function startHttpServer() {
     mountOtlpRoutes(app, {
       supabaseUrl: process.env.SUPABASE_URL!,
       serviceRoleKey: process.env.SUPABASE_SERVICE_ROLE_KEY!,
-      staticApiKey: process.env.THOUGHTBOX_API_KEY,
-      localDevApiKey: process.env.THOUGHTBOX_API_KEY_LOCAL,
     });
   }
 


### PR DESCRIPTION
## Summary

- **Drop production wiring of `THOUGHTBOX_API_KEY`**: stop passing the env var into `resolveRequestAuth` and `mountOtlpRoutes` config. The static-key short-circuit path is unreachable in production.
- **Drop the env var from `cloud-run-service.yaml`**: the secret block is removed; env var was already deleted from the running revision (`thoughtbox-mcp-00126-...` post-deploy).
- **Customer auth (`tbx_*` → `resolveApiKeyToWorkspace` → bcrypt) is unchanged.**

## Context

`THOUGHTBOX_API_KEY` was introduced in [ADR-AUTH-02 (2026-03-16)](.adr/accepted/ADR-AUTH-02-api-key-auth.md) as a 2-3-user demo shortcut, explicitly replacing the OAuth 2.1 flow from AUTH-01. When per-customer `tbx_*` keys shipped via Stripe-gated signup, the static-key path was supposed to be retired but never was.

This PR is the minimal-blast-radius cleanup: production server no longer reads the env var, even if someone re-adds it to Cloud Run env. Both code paths (`tbx_*` and OAuth JWT) are unaffected.

## Deliberately deferred

The `staticKey`/`localDevKey` parameters on `resolveRequestAuth` and the `staticApiKey`/`localDevApiKey` fields on `OtlpRoutesConfig` are **kept** because `src/otel/__tests__/routes.test.ts` uses them as a test fixture. A follow-up PR should:

1. Refactor `routes.test.ts` to use a real bcrypt-hashed `tbx_*` key fixture
2. Strip the `staticKey`/`localDevKey` parameters from `resolveRequestAuth`
3. Remove the auth-side use of `ensureStaticWorkspace` in `src/auth/resolve-request-auth.ts` (the local-mode uses in `src/index.ts:254,416` must stay)
4. Delete `scripts/sync-secrets.sh` and `scripts/push-secrets.sh` if they're no longer needed by anything else

## Side effects on tooling

`scripts/thoughtbox-mcp-proxy.sh` is already absent from main. `.gemini/settings.json` references `THOUGHTBOX_API_KEY` — that integration will stop working with this change; replace with a personal `tbx_*` key from the dashboard if you use Gemini against prod.

## Test plan

- [x] `pnpm check:types` clean
- [x] `pnpm check:lint` clean
- [x] `pnpm vitest run` — same 2 pre-existing failures as `main` (`server-surface.test.ts` Supabase-URL setup issue, unrelated)
- [x] `src/__tests__/api-key-auth.test.ts` passes
- [x] `src/otel/__tests__/routes.test.ts` passes (skipped on local Supabase unavailable, same as before)
- [x] Cyclic dependency check passes
- [ ] Manual: confirm production MCP still authenticates `tbx_*` keys after deploy
- [ ] Manual: monitor Cloud Logging for unexpected 401s post-deploy

## Out of scope

- LangSmith integration (separately disabled by removing `LANGSMITH_API_KEY` from prod env in the same session)
- Privacy policy / ToS updates flagged in the ship-readiness audit
- The `DISABLE_THOUGHT_LOGGING` env var (still pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)