### PR TITLE
fix(branch): surface tb.branch in Code Mode catalog and validate args

### DIFF
--- a/src/branch/__tests__/schemas.test.ts
+++ b/src/branch/__tests__/schemas.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import { validateBranchArgs } from "../schemas.js";
+
+describe("validateBranchArgs", () => {
+  it("rejects unknown operations", () => {
+    const r = validateBranchArgs("clone", { sessionId: "s" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain("Unknown branch operation");
+  });
+
+  describe("spawn", () => {
+    it("accepts a valid input", () => {
+      const r = validateBranchArgs("spawn", {
+        sessionId: "s",
+        branchId: "b",
+        branchFromThought: 2,
+      });
+      expect(r.ok).toBe(true);
+    });
+
+    it("rejects missing branchFromThought with a clear message", () => {
+      const r = validateBranchArgs("spawn", { sessionId: "s", branchId: "b" });
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error).toContain("branchFromThought");
+    });
+
+    it("rejects non-positive branchFromThought", () => {
+      const r = validateBranchArgs("spawn", {
+        sessionId: "s",
+        branchId: "b",
+        branchFromThought: 0,
+      });
+      expect(r.ok).toBe(false);
+    });
+  });
+
+  describe("merge", () => {
+    it("accepts a valid 'selected' merge", () => {
+      const r = validateBranchArgs("merge", {
+        sessionId: "s",
+        synthesis: "we picked A",
+        resolution: "selected",
+        selectedBranchId: "a",
+      });
+      expect(r.ok).toBe(true);
+    });
+
+    it("accepts 'synthesized' merge without selectedBranchId", () => {
+      const r = validateBranchArgs("merge", {
+        sessionId: "s",
+        synthesis: "blended A and B",
+        resolution: "synthesized",
+      });
+      expect(r.ok).toBe(true);
+    });
+
+    it("rejects 'selected' resolution with no selectedBranchId", () => {
+      const r = validateBranchArgs("merge", {
+        sessionId: "s",
+        synthesis: "x",
+        resolution: "selected",
+      });
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error).toContain("selectedBranchId is required");
+    });
+
+    it("rejects empty synthesis with the field name in the error", () => {
+      const r = validateBranchArgs("merge", {
+        sessionId: "s",
+        synthesis: "",
+        resolution: "synthesized",
+      });
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error).toContain("synthesis");
+    });
+
+    it("rejects an unknown resolution value", () => {
+      const r = validateBranchArgs("merge", {
+        sessionId: "s",
+        synthesis: "x",
+        resolution: "merged-but-not-really",
+      });
+      expect(r.ok).toBe(false);
+    });
+
+    it("translates the legacy mergeMessage/branchIds shape into a friendly error", () => {
+      // This is the wrong-shape call that previously surfaced as
+      // 'null value in column "thought" violates not-null constraint'
+      const r = validateBranchArgs("merge", {
+        sessionId: "s",
+        branchIds: ["a", "b"],
+        selectedBranchId: "a",
+        mergeMessage: "selected A",
+      });
+      expect(r.ok).toBe(false);
+      if (!r.ok) {
+        expect(r.error).toContain("synthesis");
+        expect(r.error).toContain("resolution");
+      }
+    });
+  });
+
+  describe("list", () => {
+    it("accepts a valid input", () => {
+      expect(validateBranchArgs("list", { sessionId: "s" }).ok).toBe(true);
+    });
+
+    it("rejects missing sessionId", () => {
+      const r = validateBranchArgs("list", {});
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error).toContain("sessionId");
+    });
+  });
+
+  describe("get", () => {
+    it("accepts a valid input", () => {
+      expect(
+        validateBranchArgs("get", { sessionId: "s", branchId: "b" }).ok,
+      ).toBe(true);
+    });
+
+    it("rejects missing branchId", () => {
+      const r = validateBranchArgs("get", { sessionId: "s" });
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error).toContain("branchId");
+    });
+  });
+});

--- a/src/branch/index.ts
+++ b/src/branch/index.ts
@@ -7,6 +7,7 @@
 
 import { BranchHandlers, type BranchHandlerDeps } from "./handlers.js";
 import { getOperation } from "./operations.js";
+import { validateBranchArgs } from "./schemas.js";
 
 export { BRANCH_TOOL } from "./operations.js";
 export { getOperationNames, getOperationsCatalog } from "./operations.js";
@@ -44,6 +45,24 @@ export class BranchHandler {
     >;
     isError: boolean;
   }> {
+    const validation = validateBranchArgs(operation, args);
+    if (!validation.ok) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(
+              { success: false, error: validation.error },
+              null,
+              2,
+            ),
+          },
+        ],
+        isError: true,
+      };
+    }
+    const validated = validation.data;
+
     try {
       let result: unknown;
       const opDef = getOperation(`branch_${operation}`);
@@ -51,22 +70,22 @@ export class BranchHandler {
       switch (operation) {
         case "spawn":
           result = await this.handlers.handleSpawn(
-            args as Parameters<BranchHandlers["handleSpawn"]>[0]
+            validated as Parameters<BranchHandlers["handleSpawn"]>[0]
           );
           break;
         case "merge":
           result = await this.handlers.handleMerge(
-            args as Parameters<BranchHandlers["handleMerge"]>[0]
+            validated as Parameters<BranchHandlers["handleMerge"]>[0]
           );
           break;
         case "list":
           result = await this.handlers.handleList(
-            args as Parameters<BranchHandlers["handleList"]>[0]
+            validated as Parameters<BranchHandlers["handleList"]>[0]
           );
           break;
         case "get":
           result = await this.handlers.handleGet(
-            args as Parameters<BranchHandlers["handleGet"]>[0]
+            validated as Parameters<BranchHandlers["handleGet"]>[0]
           );
           break;
         default:

--- a/src/branch/schemas.ts
+++ b/src/branch/schemas.ts
@@ -1,0 +1,86 @@
+/**
+ * Zod schemas for branch tool argument validation.
+ *
+ * Validates inputs at the toolhost dispatch boundary so wrong-shape calls
+ * surface as friendly schema errors instead of leaking through to the
+ * database layer (e.g. raw Postgres NOT-NULL constraint violations).
+ */
+
+import { z } from "zod";
+
+export const branchSpawnSchema = z.object({
+  sessionId: z.string().min(1, "sessionId is required"),
+  branchId: z.string().min(1, "branchId is required"),
+  branchFromThought: z
+    .number()
+    .int()
+    .positive("branchFromThought must be a positive thought number"),
+  description: z.string().optional(),
+});
+
+export const branchMergeSchema = z
+  .object({
+    sessionId: z.string().min(1, "sessionId is required"),
+    synthesis: z
+      .string()
+      .min(1, "synthesis is required: a non-empty summary thought to record on the main track"),
+    resolution: z.enum(["selected", "synthesized", "abandoned"]),
+    selectedBranchId: z.string().min(1).optional(),
+  })
+  .refine(
+    (v) => v.resolution !== "selected" || !!v.selectedBranchId,
+    {
+      message: "selectedBranchId is required when resolution is 'selected'",
+      path: ["selectedBranchId"],
+    },
+  );
+
+export const branchListSchema = z.object({
+  sessionId: z.string().min(1, "sessionId is required"),
+});
+
+export const branchGetSchema = z.object({
+  sessionId: z.string().min(1, "sessionId is required"),
+  branchId: z.string().min(1, "branchId is required"),
+});
+
+const SCHEMAS = {
+  spawn: branchSpawnSchema,
+  merge: branchMergeSchema,
+  list: branchListSchema,
+  get: branchGetSchema,
+} as const;
+
+export type BranchOperation = keyof typeof SCHEMAS;
+
+export type BranchValidation =
+  | { ok: true; data: unknown }
+  | { ok: false; error: string };
+
+/**
+ * Validate args for a branch operation. Returns the parsed data on success,
+ * or a single human-readable error string on failure.
+ *
+ * Multiple validation errors are joined into one message so the caller can
+ * surface the full picture without parsing a Zod issue array.
+ */
+export function validateBranchArgs(
+  operation: string,
+  args: unknown,
+): BranchValidation {
+  const schema = SCHEMAS[operation as BranchOperation];
+  if (!schema) {
+    return { ok: false, error: `Unknown branch operation: ${operation}` };
+  }
+  const parsed = schema.safeParse(args);
+  if (parsed.success) {
+    return { ok: true, data: parsed.data };
+  }
+  const message = parsed.error.errors
+    .map((issue) => {
+      const path = issue.path.length > 0 ? `${issue.path.join(".")}: ` : "";
+      return `${path}${issue.message}`;
+    })
+    .join("; ");
+  return { ok: false, error: `Invalid arguments for branch.${operation}: ${message}` };
+}

--- a/src/code-mode/__tests__/search-tool.test.ts
+++ b/src/code-mode/__tests__/search-tool.test.ts
@@ -13,6 +13,7 @@ describe("thoughtbox_search", () => {
     const output = JSON.parse(result.content[0].text);
     expect(output.error).toBeUndefined();
     expect(output.result).toEqual([
+      "branch",
       "knowledge",
       "notebook",
       "observability",

--- a/src/code-mode/search-index.ts
+++ b/src/code-mode/search-index.ts
@@ -18,6 +18,7 @@ import {
 import {
   OBSERVABILITY_OPERATIONS,
 } from "../observability/operations.js";
+import { BRANCH_OPERATIONS } from "../branch/operations.js";
 
 export interface SearchCatalog {
   operations: Record<string, Record<string, {
@@ -83,6 +84,7 @@ export function buildSearchCatalog(): SearchCatalog {
       theseus: indexOperations(THESEUS_OPERATIONS),
       ulysses: indexOperations(ULYSSES_OPERATIONS),
       observability: indexOperations(OBSERVABILITY_OPERATIONS),
+      branch: indexOperations(BRANCH_OPERATIONS),
     },
 
     prompts: [


### PR DESCRIPTION
## Summary

Two related agent-UX fixes for the branch toolhost, both surfaced during a live probe of `tb.branch.spawn` / `merge` / `list` / `get` against the deployed MCP server.

1. **Surface branch operations in the Code Mode search catalog.** `buildSearchCatalog()` was missing `BRANCH_OPERATIONS`, so `thoughtbox_search` listed seven modules (session, notebook, knowledge, thought, theseus, ulysses, observability) but not branch — even though `tb.branch.*` is live on the SDK and dispatched by the execute tool. Agents probing for available capabilities couldn't discover branch.

2. **Validate branch tool args before dispatch.** `BranchHandler.processTool` cast incoming args directly to the handler parameter type with no validation. Wrong-shape calls leaked through to Postgres. Reproducer:

   ```ts
   await tb.branch.merge({
     sessionId,
     branchIds: ["a", "b"],          // not in schema
     selectedBranchId: "a",
     mergeMessage: "selected A"      // wrong field name; real field is 'synthesis'
   });
   ```

   Previously surfaced as: `null value in column "thought" of relation "thoughts" violates not-null constraint`. Now surfaces as: `Invalid arguments for branch.merge: synthesis: synthesis is required: a non-empty summary thought to record on the main track; resolution: Required`.

## What changed

- **New file** `src/branch/schemas.ts` — Zod schemas for spawn/merge/list/get plus a `validateBranchArgs(operation, args)` helper that returns `{ ok, data }` or `{ ok, error }` with a flattened, human-readable message.
- **`src/branch/index.ts`** — call `validateBranchArgs` at the start of `processTool`. On failure, return `{ isError: true, content: [{ type: 'text', text: { success: false, error } }] }`. On success, dispatch the validated payload (replaces the unchecked `args as Parameters<...>[0]` cast).
- **`src/code-mode/search-index.ts`** — import `BRANCH_OPERATIONS` and add `branch: indexOperations(BRANCH_OPERATIONS)` to `buildSearchCatalog().operations`.
- **`src/code-mode/__tests__/search-tool.test.ts`** — update the pinned module list to include `branch`.
- **New file** `src/branch/__tests__/schemas.test.ts` — 14 tests covering valid inputs, missing-field error messages, the conditional `selectedBranchId` requirement when `resolution: 'selected'`, and the legacy wrong-shape merge call that triggered this fix.

## Test plan

- [x] `pnpm check:types` clean
- [x] `pnpm check:lint` clean
- [x] `pnpm vitest run src/branch/` — 20 passed (14 new schema, 6 existing handler)
- [x] `pnpm vitest run src/code-mode/__tests__/search-tool.test.ts` — passes (was failing locally pre-fix)
- [x] `pnpm vitest run` full suite — same 2 pre-existing failures as `main` (`architecture.test.ts` and `server-surface.test.ts`, both rooted in `src/branch/handlers.ts` directly importing `SupabaseClient`; tracked separately, not introduced by this PR)
- [ ] Manual: post-deploy, repeat the live `tb.branch.merge` probe and confirm friendly error on wrong shape

## Backwards compatibility

Validation is additive — production callers already passing the documented argument shape are unaffected. The catalog addition is also additive — existing agents that iterate `Object.keys(catalog.operations)` will see one more module, which is the intended fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)