### PR TITLE
fix(privacy): align docs with product, disable thought logging

### DIFF
--- a/apps/web/src/app/(public)/privacy/page.tsx
+++ b/apps/web/src/app/(public)/privacy/page.tsx
@@ -18,7 +18,7 @@ export default function PrivacyPage() {
     <div className="px-6 py-16">
       <div className="mx-auto max-w-3xl">
         <h1 className="text-4xl font-extrabold tracking-tight text-foreground">Privacy Policy</h1>
-        <p className="mt-3 text-sm text-foreground">Last updated: March 2026</p>
+        <p className="mt-3 text-sm text-foreground">Last updated: April 2026</p>
 
         <div className="mt-10 space-y-8">
           <Section title="1. What we collect">
@@ -44,17 +44,20 @@ export default function PrivacyPage() {
 
           <Section title="3. Data storage and retention">
             <p>
-              Workspace data is stored in Supabase (Postgres) hosted on Google Cloud. Thought and
-              run data is retained according to your plan tier. Free plan: 30 days. Pro: 1 year.
-              Enterprise: configurable.
+              Workspace data — sessions, thoughts, knowledge graph entries, and run telemetry —
+              is stored in Supabase (Postgres). The MCP server that processes your requests
+              runs on Google Cloud Run. Data is retained for the life of your active
+              subscription. If you cancel or delete your account, personal data and workspace
+              contents are purged within 30 days. See Supabase&apos;s privacy notice for details
+              on their underlying infrastructure.
             </p>
           </Section>
 
           <Section title="4. Data security">
             <p>
-              We use TLS for data in transit and encryption at rest via GCP default storage
-              encryption. API keys are stored as bcrypt hashes — only you can see the plaintext
-              key at creation time.
+              We use TLS for data in transit and encryption at rest via the default storage
+              encryption provided by Supabase and Google Cloud. API keys are stored as bcrypt
+              hashes — only you can see the plaintext key at creation time.
             </p>
           </Section>
 
@@ -65,7 +68,10 @@ export default function PrivacyPage() {
                 <strong>Supabase</strong> — database and authentication
               </li>
               <li>
-                <strong>Google Cloud Platform</strong> — compute and storage
+                <strong>Google Cloud Platform</strong> — compute (Cloud Run) and observability
+              </li>
+              <li>
+                <strong>Vercel</strong> — web app hosting
               </li>
               <li>
                 <strong>Stripe</strong> — payment processing
@@ -84,8 +90,8 @@ export default function PrivacyPage() {
             <p>
               You may request access to, correction of, or deletion of your personal data at any
               time by emailing{' '}
-              <a href="mailto:privacy@thoughtbox.dev" className="text-foreground hover:underline-thick hover:underline">
-                privacy@thoughtbox.dev
+              <a href="mailto:thoughtboxsupport@kastalienresearch.ai" className="text-foreground hover:underline-thick hover:underline">
+                thoughtboxsupport@kastalienresearch.ai
               </a>
               . Account deletion removes all personally identifiable information within 30 days.
             </p>
@@ -108,8 +114,8 @@ export default function PrivacyPage() {
           <Section title="10. Contact">
             <p>
               Privacy questions:{' '}
-              <a href="mailto:privacy@thoughtbox.dev" className="text-foreground hover:underline-thick hover:underline">
-                privacy@thoughtbox.dev
+              <a href="mailto:thoughtboxsupport@kastalienresearch.ai" className="text-foreground hover:underline-thick hover:underline">
+                thoughtboxsupport@kastalienresearch.ai
               </a>
             </p>
           </Section>

--- a/apps/web/src/app/(public)/terms/page.tsx
+++ b/apps/web/src/app/(public)/terms/page.tsx
@@ -18,7 +18,7 @@ export default function TermsPage() {
     <div className="px-6 py-16">
       <div className="mx-auto max-w-3xl">
         <h1 className="text-4xl font-extrabold tracking-tight text-foreground">Terms of Service</h1>
-        <p className="mt-3 text-sm text-foreground">Last updated: March 2026</p>
+        <p className="mt-3 text-sm text-foreground">Last updated: April 2026</p>
 
         <div className="mt-10 space-y-8 text-foreground">
           <Section title="1. Acceptance of terms">
@@ -107,8 +107,8 @@ export default function TermsPage() {
           <Section title="12. Contact">
             <p>
               Questions about these Terms?{' '}
-              <a href="mailto:legal@thoughtbox.dev" className="text-foreground hover:underline-thick hover:underline">
-                legal@thoughtbox.dev
+              <a href="mailto:thoughtboxsupport@kastalienresearch.ai" className="text-foreground hover:underline-thick hover:underline">
+                thoughtboxsupport@kastalienresearch.ai
               </a>
             </p>
           </Section>

--- a/cloud-run-service.yaml
+++ b/cloud-run-service.yaml
@@ -42,6 +42,8 @@ spec:
                   key: latest
             - name: THOUGHTBOX_STORAGE
               value: supabase
+            - name: DISABLE_THOUGHT_LOGGING
+              value: "true"
           resources:
             limits:
               cpu: "1"


### PR DESCRIPTION
## Summary

Two coupled launch blockers from the ship-readiness audit. Live MCP server is already updated; this PR is the paper trail + the web doc fixes that deploy via Vercel on merge.

## 1. Privacy Policy + ToS — alignment with single-tier reality

| Where | Was | Now |
|-------|-----|-----|
| `privacy.tsx` § 3 | "Free plan: 30 days. Pro: 1 year. Enterprise: configurable." | Single-tier retention: data kept for the life of an active subscription, purged within 30 days after cancellation. |
| `privacy.tsx` § 3 | "stored in Supabase (Postgres) hosted on Google Cloud" | Removes the inaccurate claim about Supabase's underlying host; points users at Supabase's own privacy notice. Notes that the MCP server runs on Cloud Run (which it does). |
| `privacy.tsx` § 4 | "encryption at rest via GCP default storage encryption" | "encryption at rest via the default storage encryption provided by Supabase and Google Cloud" |
| `privacy.tsx` § 5 | Sub-processors: Supabase, GCP, Stripe | Adds Vercel (web app hosting). |
| `privacy.tsx` § 7 + § 10 | `privacy@thoughtbox.dev` (domain not owned) | `thoughtboxsupport@kastalienresearch.ai` (already in use on support page) |
| `terms.tsx` § 12 | `legal@thoughtbox.dev` | `thoughtboxsupport@kastalienresearch.ai` |
| both | Last updated: March 2026 | Last updated: April 2026 |

## 2. Customer thought content — out of Cloud Logging

`src/thought-handler.ts:1097` calls `console.error(formatThought(...))` unless `disableThoughtLogging` is `true`. The flag is wired through the config but the deployed `cloud-run-service.yaml` never set `DISABLE_THOUGHT_LOGGING`, so every customer's thought text was hitting the container's stderr and from there flowing into Cloud Logging at INFO level — visible to anyone with `roles/logging.viewer` on the project.

**Already done on live service** (no PR merge needed for the runtime fix):
```bash
gcloud run services update thoughtbox-mcp --region=us-central1 \
  --update-env-vars=DISABLE_THOUGHT_LOGGING=true
```
Live revision `thoughtbox-mcp-00130-nnw` is serving 100% traffic with logging suppressed. **No image rebuild** — the env var change alone flips the runtime check.

This PR adds the env block to `cloud-run-service.yaml` so the file matches deployed reality and a future `gcloud run services replace` from the YAML doesn't accidentally unset it.

## Test plan

- [x] `pnpm tsc --noEmit` (web) clean
- [x] `pnpm lint` (web) clean
- [x] `pnpm check:lint` (server) clean (pre-commit)
- [x] Live verification: revision `thoughtbox-mcp-00130-nnw` deployed, MCP `/health` returns 200, MCP `/mcp` correctly rejects unauthenticated requests with -32001
- [ ] Manual: after merge, confirm Vercel auto-deploy of the web app shows the new privacy + ToS text
- [ ] Manual: verify no new `💭 Thought` entries appear in Cloud Logging from `thoughtbox-mcp` revisions ≥ 00130

## Out of scope

The audit also flagged HIGH-severity items (Code Mode catalog had `branch` missing — fixed in PR #291; quickstart doc says "Settings → API Keys" but the nav has it as a top-level item; pricing page mentions "team features" while the UI has them disabled with a future-release tooltip; six high-severity prod-dependency vulnerabilities including `path-to-regexp` ReDoS). These are launch punch-list items, not blockers. They can ship in follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)