### PR TITLE
feat(web): add GitHub link to public nav and footer

### DIFF
--- a/apps/web/src/components/nav/public-footer.tsx
+++ b/apps/web/src/components/nav/public-footer.tsx
@@ -32,6 +32,7 @@ export function PublicFooter() {
               <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Company</p>
               <ul className="mt-3 flex flex-col gap-2">
                 <li><Link href="/support" className="text-sm text-foreground hover:text-foreground hover:underline-thick transition-colors">Support</Link></li>
+                <li><a href="https://github.com/Kastalien-Research/thoughtbox" target="_blank" rel="noopener noreferrer" className="text-sm text-foreground hover:text-foreground hover:underline-thick transition-colors">GitHub</a></li>
                 <li><a href="https://discord.gg/8g4Ku3EXrv" target="_blank" rel="noopener noreferrer" className="text-sm text-foreground hover:text-foreground hover:underline-thick transition-colors">Discord</a></li>
               </ul>
             </div>

--- a/apps/web/src/components/nav/public-nav.tsx
+++ b/apps/web/src/components/nav/public-nav.tsx
@@ -45,6 +45,17 @@ export function PublicNav() {
         {/* Desktop CTA */}
         <div className="hidden items-center gap-3 md:flex">
           <a
+            href="https://github.com/Kastalien-Research/thoughtbox"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-foreground hover:text-foreground/70 transition-colors"
+            aria-label="GitHub"
+          >
+            <svg className="h-5 w-5" viewBox="0 0 24 24" fill="currentColor">
+              <path fillRule="evenodd" clipRule="evenodd" d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z" />
+            </svg>
+          </a>
+          <a
             href="https://discord.gg/8g4Ku3EXrv"
             target="_blank"
             rel="noopener noreferrer"
@@ -104,6 +115,18 @@ export function PublicNav() {
             ))}
           </ul>
           <div className="mt-4 flex flex-col gap-2 border-t border-foreground/10 pt-4">
+            <a
+              href="https://github.com/Kastalien-Research/thoughtbox"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-foreground hover:bg-foreground/5 transition-colors"
+              onClick={() => setMenuOpen(false)}
+            >
+              <svg className="h-4 w-4" viewBox="0 0 24 24" fill="currentColor">
+                <path fillRule="evenodd" clipRule="evenodd" d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z" />
+              </svg>
+              GitHub
+            </a>
             <a
               href="https://discord.gg/8g4Ku3EXrv"
               target="_blank"


### PR DESCRIPTION
## Summary
- Adds GitHub icon link next to the Discord icon in the public nav (desktop + mobile menu)
- Adds GitHub link in the public footer's Company column
- All point at `https://github.com/Kastalien-Research/thoughtbox`

## Test plan
- [ ] Vercel preview build succeeds
- [ ] Confirm GitHub icon appears in desktop nav next to Discord
- [ ] Confirm GitHub entry appears in mobile menu
- [ ] Confirm GitHub link appears in footer Company column
- [ ] Click each one and verify it opens the repo in a new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)