### PR TITLE
docs(specs): add cognitive harness improvements spec set

### DIFF
--- a/.specs/SPEC-CHX-001-cognitive-harness-improvements.md
+++ b/.specs/SPEC-CHX-001-cognitive-harness-improvements.md
@@ -1,0 +1,354 @@
+# SPEC-CHX-001: Cognitive Harness Usability Improvements
+
+> **Status**: Draft
+> **Priority**: High (#1, #2, #3 are quick wins; #4 unlocks new patterns)
+> **Phase**: Enhancement
+> **Estimated Effort**: 12-20 hours across 11 items, deliverable as separate PRs
+> **Source**: Thoughtbox session `0eb05082-4b22-42ab-ba9c-923c6d6dacb7` (146-thought sequential research run on orbital data center economics, 2026-04-26 → 2026-04-27). Recommendations derived from observed friction during the session.
+
+## Summary
+
+A long-form sequential reasoning run (146 thoughts, 9 branches, 3 subagent dispatches, 25+ Exa grounding rounds) surfaced concrete friction points in Thoughtbox-as-cognitive-harness. The MCP round-trip latency, branching, and seven-type thought taxonomy all worked well. The friction lives in: (a) per-call ergonomics that increase token cost without information value, (b) absence of mid-session recall primitives, (c) unidirectional subagent integration that forces manual fact re-recording, (d) operational-task-biased audit framework, and (e) hooks that compete with Thoughtbox's own progress tracking.
+
+This spec proposes 11 improvements ranked by impact-to-effort. Each is grounded in observed behavior and references the relevant source files.
+
+## Problem Statement
+
+The fundamental cost of an external reasoning harness is that **structured thought is more expensive to write than unstructured thought**. The agent trades native-context speed for persistent structure + cross-session recall + cryptographic audit. The trade is real and worth paying — the analysis at T100+ in the source session was substantively sharper than at T20.
+
+But some of that cost is removable without losing the structural benefits. Specifically:
+
+- The agent paid a token tax on every call for parameters that should be optional or defaulted (`thoughtNumber`, `totalThoughts`, `nextThoughtNeeded` in 90% of cases).
+- The agent had no mid-session recall: when it wanted to remember what it concluded at thought N, it had to hold the conclusion in working memory or skim the chat scrollback.
+- Subagent outputs landed as monolithic prose blocks in tool results; the agent then re-extracted facts and copied them into a fresh `context_snapshot` thought, paying the same token cost twice.
+- The session-end audit manifest flagged 12 "decision-without-action" gaps in a research session where the entire point was to defer action until synthesis. The audit framework assumes operational tasks.
+- The harness fired SessionStart task-tracking nudges 11 times during the run, each suggesting `TaskCreate` even though Thoughtbox itself was the structured tracker.
+
+## Scope
+
+### In Scope (this spec)
+
+11 distinct improvements organized into four buckets:
+
+- **Bucket A — Per-call ergonomics**: #1 auto-numbering surface, #2 terse default API, #6 cipher mode toggle.
+- **Bucket B — Mid-session recall**: #3 `getThought` / `recent` / `searchWithin`, #9 named checkpoints.
+- **Bucket C — Subagent integration**: #4 `subagent.attach`, #11 structured-return schemas.
+- **Bucket D — Audit + harness coordination**: #5 hook suppression during active sessions, #7 deliberation-without-commitment decision frames, #8 per-session-type audit, #10 knowledge-graph persistence shortcut.
+
+### Out of Scope
+
+- Changes to the seven thought types (taxonomy is right).
+- Changes to MCP transport / latency optimization (round-trip cost is acceptable).
+- New thought types beyond what already exists.
+- Web UI for live session viewing (orthogonal product surface).
+- Cipher vocabulary changes (`src/multi-agent/cipher-extension.ts` is fine as-is).
+
+## Recommendations
+
+### #1 — Surface auto-numbering in the SDK type description
+
+**Status today**: Server-side auto-assignment **already works** (`src/thought-handler.ts:364-377`, marked `// SIL-102`). When `thoughtNumber` is undefined the handler computes it from the main-chain max.
+
+**Why it still creates friction**:
+- The Code Mode SDK type at `src/code-mode/sdk-types.ts:23` shows `thoughtNumber?: number` — technically correct (optional) but co-listed with required `nextThoughtNeeded` and `thoughtType`. The agent reads "passed in every example, listed in the type, must be tracked."
+- Onboarding doc `.claude/skills/thoughtbox-onboard/SKILL.md` and the operation example at `src/thought/operations.ts:92-101` both pass `thoughtNumber: 1` in the canonical example.
+- The "Gotchas" section in onboarding states: "Thought numbers must be unique per session+branch — can't reuse a number." This nudges the agent toward defensive manual tracking.
+
+**Observed failure**: At T80 in the source session, the agent reused `thoughtNumber: 80` for a revision and got `duplicate key value violates unique constraint "thoughts_session_id_thought_number_branch_id_key"`. Lost ~30 seconds + a thought slot.
+
+**Proposed change**:
+1. Update `src/code-mode/sdk-types.ts` to comment-annotate the optional `thoughtNumber` with explicit "(server auto-assigns; only pass to revise/restart)".
+2. Remove `thoughtNumber: 1` from the canonical example in `src/thought/operations.ts:92-101`. Keep `sessionTitle` to demonstrate session creation.
+3. Update `thoughtbox-onboard` skill (located at `.claude/skills/thoughtbox-onboard/SKILL.md` per session reminder) Quick Start section to show calls without `thoughtNumber`.
+4. Keep the gotchas warning, but reframe: "Thought numbers are server-assigned and unique per session+branch. Pass an explicit number only to restart (1) or revise."
+
+**Effort**: 1 hour. Pure documentation/example surface.
+
+---
+
+### #2 — Terse default-case shorthand `tb.t(content)`
+
+**Status today**: All thought submission goes through `tb.thought({thought, thoughtType, nextThoughtNeeded, ...})` — see `src/code-mode/sdk-types.ts:18-44`. ~85% of thoughts in the source session were `thoughtType: "reasoning"` with `nextThoughtNeeded: true` and no other typed metadata. The full envelope adds ~120 tokens per call to a string that may itself be only 200-400 tokens of actual content.
+
+**Why it creates friction**: The agent writes the same boilerplate envelope hundreds of times per session. Token tax compounds: at 146 thoughts × ~120 boilerplate tokens = ~17,500 tokens of pure ceremony. That is roughly 5% of a 400k context window.
+
+**Proposed change**:
+Add a thin shorthand to the `tb` SDK in `src/code-mode/sdk-types.ts` and the Code Mode runtime:
+
+```ts
+interface TB {
+  /** Shorthand for plain reasoning thought. Equivalent to:
+   *  thought({thought: content, thoughtType: "reasoning", nextThoughtNeeded: true})
+   *  Server auto-assigns thoughtNumber.
+   */
+  t(content: string, opts?: { sessionTitle?: string; sessionTags?: string[]; nextThoughtNeeded?: boolean }): Promise<unknown>;
+
+  /** Shorthand for ending a reasoning chain. */
+  end(content: string): Promise<unknown>; // sets nextThoughtNeeded: false
+
+  /** Existing full-form thought() unchanged. */
+  thought(input: { ... }): Promise<unknown>;
+}
+```
+
+Implementation: ~20 lines added to `src/code-mode/execute-tool.ts` to expand `tb.t(...)` into the full handler call before delegating to the existing `ThoughtHandler`. No schema changes — purely a Code Mode SDK convenience.
+
+Reserve the full-form `tb.thought({...})` for typed thoughts (`decision_frame`, `belief_snapshot`, `assumption_update`, `context_snapshot`, `progress`, `action_report`) where the metadata is the point.
+
+**Effort**: 3-4 hours. Code Mode SDK only; no protocol or storage changes.
+
+---
+
+### #3 — Mid-session recall: `getThought(N)`, `recent(n)`, `searchWithin(query)`
+
+**Status today**: `src/sessions/operations.ts:43+` defines `session_list`, `session_get`, `session_search`, `session_resume`, `session_export`, `session_analyze`, `session_extract_learnings`. Per-thought retrieval requires `session_get(sessionId)` which returns the full session blob — wasteful when the agent wants thought N from the *current* session.
+
+**Storage layer already supports it**: `src/sessions/handlers.ts:184` uses `this.storage.getThoughts(args.sessionId)` to fetch thoughts from a session. A single-thought variant is a thin filter on top.
+
+**Why it creates friction**: At several points in the source session (notably T70, T85, T138) the agent paused to mentally inventory what it had already concluded. Without a cheap recall primitive, the agent either holds state in working memory (lossy) or skips the recall entirely (loses signal).
+
+**Proposed change**: Add three operations to `src/sessions/operations.ts` and corresponding handlers in `src/sessions/handlers.ts`:
+
+1. `session_get_thought` — fetch thought by `sessionId` + `thoughtNumber` (+ optional `branchId`). Returns single thought.
+2. `session_recent_thoughts` — fetch last N thoughts in the active session. Convenience over `session_get` filtering.
+3. `session_search_within` — full-text search over thoughts in a *single* session, distinct from `session_search` which searches across sessions by metadata.
+
+SDK exposure in `src/code-mode/sdk-types.ts`:
+
+```ts
+session: {
+  // ... existing
+  getThought(sessionId: string, thoughtNumber: number, branchId?: string): Promise<unknown>;
+  recent(sessionId: string, n?: number): Promise<unknown>;
+  searchWithin(sessionId: string, query: string, limit?: number): Promise<unknown>;
+};
+```
+
+For Code Mode convenience, also accept *no* sessionId and operate on the current execution-context session if one is active.
+
+**Effort**: 4-6 hours. Three handlers + storage filters + SDK type updates + tests.
+
+---
+
+### #4 — Subagent → parent session attachment
+
+**Status today**: When a subagent dispatch completes, its output lands as a tool result in the parent's chat. The parent agent must then manually copy salient facts into a fresh `context_snapshot` thought (see source session T21, T24, T30, T38-39, T67 — all manual re-recordings). Agent and subagent operate on completely disjoint Thoughtbox state.
+
+**Why it creates friction**: The parent pays the token cost twice — once to read the subagent's prose, once to re-extract structured facts. In the source session this consumed ~3,000 tokens of the parent's context for each of 3 subagent dispatches.
+
+**Proposed change**:
+
+1. **Pass parent session ID into subagent context**. When a parent calls the `Agent` tool with Thoughtbox context, propagate the active `sessionId` as an environment variable or initial system prompt addendum. The subagent can then optionally write to the parent's session as a special "subagent contribution" thought type or branch.
+
+2. **Add `tb.subagent.attach` to the Code Mode SDK**:
+
+   ```ts
+   subagent: {
+     /** Attach a completed subagent's structured output as a context_snapshot
+      *  thought in the parent session. Caller provides the agent's task ID
+      *  and a path/key into the structured return. */
+     attach(args: {
+       agentId: string;          // subagent task ID from Agent tool result
+       asThoughtType?: 'context_snapshot' | 'belief_snapshot' | 'reasoning';
+       summary?: string;         // optional condensed summary
+       extractedFacts?: object;  // structured facts the subagent returned
+     }): Promise<unknown>;
+   };
+   ```
+
+3. **Subagent return schema**: When dispatching a subagent for Thoughtbox-aware work, the dispatcher can pass an expected structured return schema (JSON Schema). The subagent's runtime validates the return; the parent's `tb.subagent.attach` receives the validated structure and stores it directly without re-parsing prose.
+
+This recommendation pairs with #11 (structured returns).
+
+**Effort**: 8-12 hours. Cross-cuts Code Mode SDK + multi-agent module + Agent tool runtime contract. Highest-impact item but largest effort.
+
+---
+
+### #5 — Suppress task-tracking hooks during active Thoughtbox sessions
+
+**Status today**: The harness fires SessionStart-style nudges suggesting `TaskCreate` use. In the source session this fired ~11 times across 146 thoughts, each suggesting that progress tracking might benefit from external task management.
+
+**Why it creates friction**: Thoughtbox itself provides progress tracking via the `progress` thought type (`src/thought/tool.ts:44-48` defines `ProgressDataSchema` with `task`, `status`, `note`). The TaskCreate nudge is redundant when Thoughtbox is the active structured tracker. Each nudge consumes ~100-150 tokens and breaks reasoning rhythm.
+
+**Proposed change**:
+- Hooks that fire SessionStart-class reminders should check for an active Thoughtbox session via the OTLP/observability layer (`src/observability/`). If a session is active and has had a thought submitted in the last N minutes (e.g., 15), suppress the nudge.
+- Specifically: `src/otel/` or hook configuration should expose `THOUGHTBOX_ACTIVE_SESSION_ID` as an environment hint that hooks can read.
+- This is a harness/plugin change, not a Thoughtbox-server change, but it should be specified here because it affects the agent's experience using Thoughtbox.
+
+**Effort**: 2-3 hours. Hook config + small observability hint API.
+
+---
+
+### #6 — Cipher mode as explicit toggle
+
+**Status today**: Cipher notation exists (`src/multi-agent/cipher-extension.ts`, exported via `session_export({format: "cipher"})` per `src/code-mode/sdk-types.ts:52`). The onboarding docs recommend switching to cipher around thought 20 for compression. **In practice, the source session never switched.** At T1 the agent planned to: "Switch to cipher notation around T30 to compress." The switch never happened across 146 thoughts.
+
+**Why it creates friction**: Mid-flow notation switching breaks reasoning rhythm. Choosing per-thought to write in cipher vs prose is itself a cognitive cost. Without an explicit mode toggle that wraps cipher-formatting around plain content, the agent defaults to prose.
+
+**Proposed change**: Add a `cipher: true` flag to thought submission OR a session-level `cipherMode: "auto" | "manual" | "off"` setting:
+
+- `auto`: server detects when to compress (e.g., session > 30 thoughts) and auto-formats stored thought.
+- `manual`: agent explicitly passes `cipher: true` per thought.
+- `off`: prose only (current default).
+
+Implementation in `src/thought/tool.ts` adds a `cipher` boolean. The `ThoughtHandler` either:
+1. Accepts cipher-formatted content directly (server stores as-is, marks metadata `cipher: true`).
+2. Auto-encodes prose into cipher if the agent passes a structured shorthand: `tb.cipher({type: "H", refs: [5, 6], content: "API latency ↑ bc db query regression"})` produces `S7|H|S5-S6|...`.
+
+**Effort**: 4-5 hours. Mostly schema + serialization; cipher format already defined.
+
+---
+
+### #7 — Deliberation without commitment
+
+**Status today**: `decision_frame` requires `options` with **exactly one** `selected: true` (validated in `src/thought/tool.ts:5-9` and in handler validation). The schema does not accept all-`selected: false`.
+
+**Why it creates friction**: At several points in the source session (notably T13, T20, T34) the agent wanted to record "considering these options, evidence is X, leaning toward Y but not yet committed." The current schema forces premature commitment OR recasts deliberation as plain `reasoning`, losing the structural benefit of the decision_frame type.
+
+**Proposed change**:
+
+Option A: Relax the constraint. Allow `options` with zero or one selected. Store metadata field `decisionState: "deliberating" | "committed"`.
+
+Option B: New thought type `deliberation` separate from `decision_frame`. Same `options[]` field, no selection requirement.
+
+Recommend **Option A** — cleaner extension of existing type. Add `decisionState` to `OptionSchema`-adjacent metadata; downstream audit (`src/audit/manifest-generator.ts`) treats `committed` decisions as today, ignores `deliberating` ones in the gap detector.
+
+**Effort**: 2-3 hours. Schema relaxation + audit update + tests.
+
+---
+
+### #8 — Per-session-type audit framework
+
+**Status today**: `src/audit/manifest-generator.ts:178-196` (`detectGaps`) hardcodes the rule: any `decision_frame` without a following `action_report` within 5 thoughts is a gap. In the source session — explicitly a research session where action is deferred to a synthesis phase ~100 thoughts later — this fired 12 false positives.
+
+**Why it creates friction**: The session-close manifest flags spurious gaps that an agent reading their own audit will either learn to ignore (losing signal) or chase down (wasting time).
+
+**Proposed change**:
+
+1. Add `sessionType` metadata at session creation: `"research" | "decision" | "implementation" | "debugging" | "exploration"`. Default to `"reasoning"` (current behavior).
+2. Make `detectGaps` in `src/audit/manifest-generator.ts` route on `sessionType`:
+   - `implementation` and `debugging`: keep current 5-thought decision-without-action rule.
+   - `research` and `exploration`: skip the rule. Replace with research-appropriate audits:
+     - Prior-revision rate (number of `assumption_update` thoughts / total).
+     - Branch-merge ratio (branches created vs merged back into main).
+     - Evidence citation density (`context_snapshot` thoughts with `dataSourcesAccessed` populated / total).
+     - Subagent-dispatch utilization.
+3. Manifest output structure adapts to session type.
+
+The audit framework is already pluggable enough to extend (`src/audit/index.ts`, `manifest-generator.ts`).
+
+**Effort**: 4-6 hours. Schema addition + handler routing + new gap detectors + tests + manifest format update.
+
+---
+
+### #9 — Named checkpoints
+
+**Status today**: No explicit checkpoint mechanism. The source session improvised checkpoints at T13, T20, T26, T46, T70, T85, T100, T138 — manual self-reflection thoughts that read "where am I in the analysis."
+
+**Why it would help**: A named checkpoint creates a navigable summary structure. Useful for: (a) the agent recalling its own progress mid-session, (b) export tooling rendering a session table-of-contents, (c) selective re-export of just the checkpoints as a high-signal summary.
+
+**Proposed change**: Add `tb.session.checkpoint(label, summary?)` to the SDK. Stored as a special `progress`-type thought with metadata `{checkpoint: true, label, summary}`. Existing `progress` schema already supports the `task` + `status` + `note` triad — minimal extension.
+
+Export tooling (`session_export`) gets a new format `"checkpoints-only"` that returns just the checkpoint summary chain.
+
+**Effort**: 2-3 hours. SDK convenience + export filter.
+
+---
+
+### #10 — Knowledge-graph persistence shortcut
+
+**Status today**: `tb.knowledge.createEntity`, `addObservation`, `createRelation` all exist (`src/code-mode/sdk-types.ts:58-65`). They are full operations requiring separate calls.
+
+**Why it creates friction**: At T143 of the source session, the agent enumerated entities and relations that would form a useful knowledge-graph encoding of the analysis. Persisting them required a separate sequence of `tb.knowledge.*` calls — never executed because the agent was about to close the session and didn't want to add boilerplate.
+
+**Proposed change**: Add `persistAs` field to `ThoughtData` for `belief_snapshot` and `assumption_update` types:
+
+```ts
+beliefs?: BeliefSchema;
+persistAs?: {
+  entity?: { name: string; type: KnowledgeEntityType; label: string };
+  observations?: string[];
+  relations?: Array<{ to_id: string; relation_type: KnowledgeRelationType }>;
+};
+```
+
+When `persistAs` is set, `ThoughtHandler` after persisting the thought also calls into `KnowledgeHandler` to create the entity / observations / relations. Atomic transaction: if knowledge persistence fails, thought still persists with a flag indicating the knowledge persist was skipped.
+
+**Effort**: 3-4 hours. Cross-module integration + transaction handling + tests.
+
+---
+
+### #11 — Structured-return schemas for subagent dispatch
+
+**Status today**: Subagents return prose. Parent agents extract structure manually. (See #4.)
+
+**Proposed change**: When dispatching a subagent intended to feed Thoughtbox, allow the dispatcher to pass an expected JSON Schema:
+
+```ts
+subagent.dispatch({
+  prompt: "Verify three claims about JWCC Next, Anduril valuation, Lonestar funding",
+  expectedReturn: {
+    type: "object",
+    properties: {
+      claim1: { type: "object", properties: { verdict: { enum: ["VERIFIED", "PARTIALLY_VERIFIED", "REFUTED"] }, evidence: { type: "array" }, citations: { type: "array" } } },
+      // ... claim2, claim3
+    }
+  }
+});
+```
+
+The subagent's runtime validates its return against the schema before completing. Parent's `tb.subagent.attach` (#4) ingests the validated structure as typed metadata in the resulting `context_snapshot`.
+
+**Effort**: 6-8 hours. Cross-cuts Agent runtime, multi-agent contract, Code Mode SDK. Pairs naturally with #4 and is partially covered there.
+
+---
+
+## Implementation Order (Suggested PRs)
+
+| PR | Items | Effort | Dependency |
+|----|-------|--------|------------|
+| 1 | #1 (auto-numbering surfacing) | 1h | None — pure docs |
+| 2 | #2 (`tb.t` shorthand) | 3-4h | None — Code Mode only |
+| 3 | #3 (mid-session recall) | 4-6h | None — additive ops |
+| 4 | #5 (hook suppression) | 2-3h | None — harness config |
+| 5 | #7 (deliberation) + #9 (checkpoints) | 4-6h | None — schema additions |
+| 6 | #6 (cipher mode) | 4-5h | None — cipher already exists |
+| 7 | #8 (per-session-type audit) | 4-6h | None — extends audit |
+| 8 | #10 (knowledge persistence shortcut) | 3-4h | None — cross-module |
+| 9 | #4 + #11 (subagent attach + structured returns) | 14-20h | Last; largest scope; depends on multi-agent contract review |
+
+PRs 1-5 are independent and can ship in parallel. PR 9 is the highest-impact item but largest effort and should land last.
+
+Total: 39-55 hours across 9 PRs.
+
+## Out of Scope for This Spec
+
+- **Latency optimization**. MCP round-trip cost (~400-700ms per call) was acceptable in the source session.
+- **New thought types**. The seven types are right.
+- **Branch merge semantics**. Branches today are documentation; a future spec could add explicit merge-back operations, but the source session did not surface friction here.
+- **Session resumption flow**. Worked seamlessly after subagent dispatches.
+- **Cipher vocabulary**. The notation in `src/multi-agent/cipher-extension.ts` is fine; problem is mode toggle (#6), not vocabulary.
+
+## Validation
+
+For each item, the validation criterion is observable in a follow-up sequential reasoning session of similar length and structure to `0eb05082-4b22-42ab-ba9c-923c6d6dacb7`:
+
+- #1: Agent submits 100+ thoughts without ever passing `thoughtNumber` and without dup-key errors.
+- #2: Agent submits 80%+ of plain reasoning thoughts via `tb.t(...)` shorthand. Token cost of boilerplate drops measurably.
+- #3: Agent calls `session.getThought` or `session.recent` at least 5 times in a 100+ thought session for self-recall.
+- #4: Agent dispatches a subagent and the subagent's structured output appears in the parent session as a `context_snapshot` thought without manual re-recording.
+- #5: SessionStart task-tracking hooks fire ≤1 time during a multi-hour Thoughtbox session.
+- #6: Agent submits 30+ thoughts in cipher mode without breaking flow.
+- #7: Agent submits at least one `decision_frame` with no committed selection and the audit doesn't flag it.
+- #8: Audit manifest for a research session contains research-appropriate metrics (revision rate, citation density) and zero spurious "decision-without-action" gaps.
+- #9: Session export includes a checkpoint-only format with named summary points.
+- #10: A `belief_snapshot` thought with `persistAs` populated produces a corresponding entity in the knowledge graph in the same transaction.
+- #11: A subagent dispatched with `expectedReturn` schema produces a validated structured response that ingests cleanly via `tb.subagent.attach`.
+
+## Provenance
+
+This spec was authored by the agent immediately after running session `0eb05082-4b22-42ab-ba9c-923c6d6dacb7` (146 thoughts, 9 branches, 3 subagent dispatches, 25+ Exa grounding rounds, ~6 hours of structured reasoning on orbital data center economics). Every recommendation is grounded in observed friction during that session, not theoretical concerns.
+
+The session export is at `/root/.thoughtbox/exports/0eb05082-4b22-42ab-ba9c-923c6d6dacb7-2026-04-27T02-50-02-994Z.json` for reference.
+
+Recommendations #1, #2, #3, #4 were the agent's verbal prioritization at session end before this spec was written. #5-#11 were elaborated during spec authoring with codebase grounding.

--- a/.specs/cognitive-harness-improvements/01-auto-numbering-surfacing.md
+++ b/.specs/cognitive-harness-improvements/01-auto-numbering-surfacing.md
@@ -1,0 +1,161 @@
+# Spec: Auto-Numbering Surfacing
+
+## Title
+Auto-Numbering Surfacing for Thought Numbers
+
+## Status
+Draft
+
+## Target State
+
+### Type Hierarchy Restructuring
+
+The key insight is that **client input types** and **server output types** have different constraints:
+
+- **Client Input (`ThoughtInput`)**: Fields the client MAY set when submitting
+- **Server Output (`Thought`)**: Fields the server ALWAYS provides after persisting
+
+```typescript
+/**
+ * Client-facing input type for thought submission.
+ * These fields are what the client is allowed to provide.
+ */
+interface ThoughtInput {
+  thought: string;
+  thoughtType: ThoughtType;
+  nextThoughtNeeded: boolean;
+
+  /**
+   * EXPLICITLY FORBIDDEN: Server-auto-assigned.
+   * Using `never` makes this field impossible to set at the type level.
+   */
+  thoughtNumber?: never;
+
+  /**
+   * EXPLICITLY FORBIDDEN: Server-auto-assigned.
+   */
+  timestamp?: never;
+
+  // ... other client-provided fields
+}
+
+/**
+ * Server-persisted thought type.
+ * All fields are guaranteed to be present after persistence.
+ */
+interface Thought extends ThoughtInput {
+  thoughtNumber: number;    // Now guaranteed present
+  timestamp: string;        // Now guaranteed present
+  contentHash?: string;     // Server-computed
+}
+```
+
+### SDK Type Definitions
+
+The `ThoughtInput` interface in the SDK types clearly documents that `thoughtNumber` and `timestamp` are **server-auto-assigned**:
+
+```typescript
+interface ThoughtInput {
+  thought: string;
+  thoughtType: ThoughtType;
+  nextThoughtNeeded: boolean;
+
+  /**
+   * Server-auto-assigned. Client should NOT set this field.
+   * The server assigns sequential thought numbers on write.
+   */
+  thoughtNumber?: never;
+
+  /**
+   * Server-auto-assigned. Client should NOT set this field.
+   * The server assigns ISO 8601 timestamps on write.
+   */
+  timestamp?: never;
+
+  // ... other fields
+}
+```
+
+### Documentation and Examples
+
+All SDK documentation, code examples, and tutorials show `thoughtNumber` omitted from thought submissions. When developers attempt to pass `thoughtNumber` in their code:
+
+1. TypeScript compilation fails with a type error ("thoughtNumber is declared as `never`")
+2. Runtime validation rejects the field with a clear error message
+
+### Gotchas Documentation
+
+The "Common Pitfalls" section in developer documentation is reframed to correctly characterize the behavior:
+
+**Before (incorrect framing):**
+> "Don't forget to manually increment thoughtNumber for each new thought"
+
+**After (correct framing):**
+> "The server automatically assigns sequential thought numbers. Do not attempt to set thoughtNumber manually."
+
+### Validation Behavior
+
+When a thought is returned from the server, `thoughtNumber` is always present and correctly sequential. The client can read it but never write it.
+
+---
+
+## Design Rationale
+
+### Making Illegal States Unrepresentable
+
+The `thoughtNumber` and `timestamp` fields represent canonical ordering metadata assigned by the server. Making them `never` in client input types creates a compile-time guarantee that clients cannot attempt to manipulate server-assigned values.
+
+### Type Hierarchy Separation
+
+The original `ThoughtInput extends ThoughtData` model was backwards:
+- `ThoughtData` described persisted thoughts (with required fields)
+- `ThoughtInput` inherited these required fields, contradicting the "optional client input" intent
+
+The correct model:
+- `ThoughtInput` describes what clients CAN send (server-assigned fields are `never`)
+- `Thought` describes what servers return (server-assigned fields are required)
+- `ThoughtInput` is NOT an extension of `Thought`
+
+### Semantic Correctness
+
+By declaring `thoughtNumber` and `timestamp` as `never` in the input type, we make the immutability contract explicit at compile time rather than relying on documentation alone. This is the essence of "making illegal states unrepresentable."
+
+---
+
+## Validation
+
+1. **Type Check**: TypeScript compilation fails when `thoughtNumber` is included in a `ThoughtInput` object
+2. **Type Check**: TypeScript compilation fails when `timestamp` is included in a `ThoughtInput` object
+3. **Runtime Rejection**: API returns 400 error if `thoughtNumber` is present in submitted thought payload
+4. **Runtime Rejection**: API returns 400 error if `timestamp` is present in submitted thought payload
+5. **Return Presence**: Every thought retrieved from the API includes a valid, sequential `thoughtNumber`
+6. **Return Presence**: Every thought retrieved from the API includes a valid ISO 8601 `timestamp`
+7. **Documentation Audit**: All examples in docs, tutorials, and SDK READMEs omit `thoughtNumber` and `timestamp`
+8. **Type Hierarchy**: `ThoughtInput` does NOT extend `Thought` (or `ThoughtData`)
+
+---
+
+## Implementation Notes
+
+### Zod Schema Alignment
+
+The Zod schema in `src/thought/tool.ts` should be updated:
+
+```typescript
+// BEFORE (current)
+export const thoughtToolInputSchema = z.object({
+  thoughtNumber: z.number().optional(), // Wrong - allows client to set
+  // ...
+});
+
+// AFTER (correct)
+export const thoughtToolInputSchema = z.object({
+  // Explicitly using never() would be redundant in Zod - omitting achieves same effect
+  // as the type system will prevent setting it
+  // ...
+}).strict(); // Enable strict mode to reject unexpected keys
+```
+
+### Persistence Layer
+
+The persistence layer (`src/persistence/types.ts`) should maintain `ThoughtData` with required fields, but it should NOT be the parent of `ThoughtInput`.

--- a/.specs/cognitive-harness-improvements/02-terse-shorthand.md
+++ b/.specs/cognitive-harness-improvements/02-terse-shorthand.md
@@ -1,0 +1,221 @@
+# Spec: Terse Shorthand: `tb.t()` and `tb.end()`
+
+## Title
+Terse Shorthand Methods for Common Thought Patterns
+
+## Status
+Draft
+
+## Target State
+
+### Core Shorthand Methods
+The `tb` (Thoughtbox) SDK exposes two convenience methods that cover the most common thought patterns. Both return `Promise<Thought>` — the canonical server-persisted thought type defined in Spec 01 (`ThoughtInput` / `Thought` hierarchy) and Spec 03.
+
+#### `tb.t(content: string): Promise<Thought>`
+Submits a plain reasoning thought with:
+- `thoughtType: "reasoning"`
+- `nextThoughtNeeded: true`
+
+Equivalent to:
+```typescript
+tb.thought({
+  thought: content,
+  thoughtType: "reasoning",
+  nextThoughtNeeded: true
+});
+```
+
+#### `tb.end(content: string): Promise<Thought>`
+Submits a final thought that ends the current thought chain with:
+- `thoughtType: "reasoning"`
+- `nextThoughtNeeded: false`
+
+Equivalent to:
+```typescript
+tb.thought({
+  thought: content,
+  thoughtType: "reasoning",
+  nextThoughtNeeded: false
+});
+```
+
+The `tb.t()` / `tb.end()` shorthands on the main `tb` instance and the same-named methods on `ThoughtChain` (see Chain API below) have **identical signatures, identical return types, and identical persistence semantics**. The chain-bound versions resolve `sessionId` from the chain's captured session; the `tb`-instance versions resolve it from the ambient execution context (or throw `NoActiveSessionError` if none).
+
+### Usage Examples
+```typescript
+// Chain of reasoning thoughts
+await tb.t("The data suggests three possible approaches.");
+await tb.t("Option A is fastest but riskiest.");
+await tb.end("I'll proceed with Option B as a balanced choice.");
+
+// Short deliberation
+await tb.t("Is this edge case worth handling now?");
+await tb.end("Deferring to reduce scope.");
+```
+
+### Method Availability
+These methods are available on:
+- The main `tb` instance: `tb.t()`, `tb.end()`
+- A `ThoughtChain` returned from `tb.think()` (or sibling factories `tb.decide()`, `tb.research()`, etc.): `chain.t()`, `chain.end()`, `chain.thought(...)`
+
+---
+
+## Chain API: `ThoughtChain` Type and Persistence Model
+
+### Factory Methods
+
+`tb.think()`, `tb.decide()`, and `tb.research()` are convenience wrappers over the underlying `tb.session.create()` primitive. They differ from each other only in their default `sessionType` (Spec 08); otherwise equivalent:
+
+```typescript
+// These two are equivalent:
+const chain1 = await tb.think({ sessionTitle: "Analysis" });
+const chain2 = await tb.session
+  .create({ sessionTitle: "Analysis", sessionType: "exploration" })
+  .then(session => tb.session.openChain(session.id));
+```
+
+Callers wanting a session type not covered by the named factories should use `tb.session.create({ sessionType: "..." })` directly (see Spec 08 for the full enum) and call `tb.session.openChain(sessionId)` to obtain a chain. The named factories exist purely as ergonomic shorthands for the most common cases.
+
+The factory signatures:
+
+```typescript
+interface TB {
+  /**
+   * Open a thought chain bound to a new (or specified) session.
+   * Default sessionType: "exploration".
+   */
+  think(opts?: ThinkOpts): Promise<ThoughtChain>;
+
+  /**
+   * Open a thought chain optimized for decision-making.
+   * Default sessionType: "decision".
+   */
+  decide(opts?: ThinkOpts): Promise<ThoughtChain>;
+
+  /**
+   * Open a thought chain optimized for research.
+   * Default sessionType: "research".
+   */
+  research(opts?: ThinkOpts): Promise<ThoughtChain>;
+}
+
+interface ThinkOpts {
+  /** Resume existing session by ID. If omitted, a new session is created. */
+  sessionId?: string;
+  /** Title for the new session. Ignored when sessionId is provided. */
+  sessionTitle?: string;
+  /** Tags for the new session. Ignored when sessionId is provided. */
+  sessionTags?: string[];
+  /** Override the factory's default session type (Spec 08). */
+  sessionType?: SessionType;
+  /** Cipher mode for the new session (Spec 06). */
+  cipherMode?: CipherMode;
+  /** Per-session activity timeout for hook suppression (Spec 05). */
+  activityTimeoutMs?: number;
+}
+```
+
+### `ThoughtChain` Interface
+
+```typescript
+interface ThoughtChain {
+  /** Identifier of the underlying session. Captured at chain creation. */
+  readonly sessionId: string;
+
+  /** True after end() has been called on this chain instance. */
+  readonly closed: boolean;
+
+  /** Submit a reasoning thought (thoughtType: "reasoning", nextThoughtNeeded: true).
+   *  Persists immediately via per-call server roundtrip.
+   *  Throws ChainClosedError if called after end(). */
+  t(content: string): Promise<Thought>;
+
+  /** Submit a final thought (thoughtType: "reasoning", nextThoughtNeeded: false)
+   *  and mark the chain closed. Subsequent t/end/thought calls throw.
+   *  Returns the persisted final thought. */
+  end(content: string): Promise<Thought>;
+
+  /** Submit an explicitly-typed thought. Persists immediately.
+   *  Throws ChainClosedError if called after end(). */
+  thought(input: ThoughtInput): Promise<Thought>;
+}
+
+/** Thrown when a chain method is called after end(). */
+class ChainClosedError extends Error {
+  readonly sessionId: string;
+  readonly attemptedOperation: "t" | "end" | "thought";
+}
+```
+
+### Persistence Model
+
+The `ThoughtChain` is a **stateless facade** over the underlying session:
+
+1. **Per-call server roundtrip.** Every `chain.t(...)`, `chain.end(...)`, and `chain.thought(...)` is its own server write. There is no client-side buffering, no batching, no flush semantics, no transactional commit boundary.
+
+2. **No client-side state beyond `sessionId` and `closed`.** The chain object is a thin handle. If the chain object is garbage-collected mid-session, no thoughts are lost — the session continues to exist server-side and can be resumed via `tb.think({ sessionId })`.
+
+3. **Connection drops are recoverable.** A failed `chain.t()` returns a network error. The agent can retry the same call, or call `tb.think({ sessionId: chain.sessionId })` to obtain a fresh chain bound to the same session. Previously-persisted thoughts are unaffected.
+
+4. **Concurrent chains on the same session are allowed but discouraged.** If two chains both write to the same session, server-side auto-numbering (Spec 01) serializes writes safely. Ordering between concurrent writers is server-receive-time, not client-issue-time. Most callers should hold a single chain per session.
+
+5. **`end()` is one-shot per chain instance.** First call submits the final thought with `nextThoughtNeeded: false` and sets `closed: true`. Second and subsequent calls throw `ChainClosedError`. Callers wanting "submit final or no-op" should check `chain.closed` before calling.
+
+6. **`closed: true` is per-chain-instance, not per-session.** Calling `end()` on one chain does not prevent another chain (held by another reference) from continuing to write to the same session. The session's `nextThoughtNeeded: false` flag does signal session completion server-side, but session re-opening is governed by the session API (`tb.session.resume()`), not the chain's `closed` state.
+
+### Why Stateless
+
+A stateless facade matches the rest of the SDK's per-call persistence model and avoids surprising failure modes:
+
+- A long-running reasoning session may span subagent dispatches (Spec 04), retries, and even client process restarts. Per-call persistence means none of those events lose work.
+- Buffering or transactional semantics would add complexity (when does a buffer flush? what if it overflows? how is ordering preserved across concurrent calls?) without clear benefit. Reasoning workloads are not latency-sensitive in the way that, say, real-time gaming is — a 400 ms server roundtrip per thought is acceptable.
+- Explicit transactional shapes ("all thoughts in this chain commit atomically or none") are a different feature and should be specified separately as `tb.transaction(...)` if needed. They are out of scope for this spec.
+
+### Usage Examples
+
+```typescript
+// Open a chain for an exploration session
+const chain = await tb.think({ sessionTitle: "Refactor strategy" });
+
+await chain.t("Three approaches: incremental, big-bang, or hybrid.");
+await chain.t("Incremental is safest but slowest.");
+await chain.t("Big-bang risks regressions but lands faster.");
+await chain.end("Going hybrid: incremental for the data layer, big-bang for the UI.");
+
+// Resume an existing session via a new chain
+const resumed = await tb.think({ sessionId: chain.sessionId });
+await resumed.t("Followup observation after sleeping on it.");
+
+// Sibling factory for a decision-typed session
+const decision = await tb.decide({ sessionTitle: "DB choice" });
+await decision.thought({
+  thought: "Comparing Postgres vs DynamoDB",
+  thoughtType: "decision_frame",
+  options: [{ label: "Postgres" }, { label: "DynamoDB" }],
+  decisionState: "deliberating",
+  nextThoughtNeeded: true,
+});
+```
+
+---
+
+## Design Rationale
+
+The vast majority of thoughts in typical sessions are plain reasoning steps: brief observations, analyses, or continuations of a chain. Requiring the full `thought()` call with explicit `thoughtType` and `nextThoughtNeeded` flags adds friction without providing value in these common cases. The `tb.t()` shorthand reduces keystrokes and cognitive overhead for the 80% case.
+
+The `tb.end()` method explicitly marks the end of a thought chain, providing a clean terminal action without requiring the user to construct a full thought object with `nextThoughtNeeded: false`.
+
+---
+
+## Validation
+
+1. **Signature Correctness**: `tb.t("x")` produces identical server payload as `tb.thought({ thought: "x", thoughtType: "reasoning", nextThoughtNeeded: true })`
+2. **Signature Correctness**: `tb.end("x")` produces identical server payload as `tb.thought({ thought: "x", thoughtType: "reasoning", nextThoughtNeeded: false })`
+3. **Chain Integration**: `chain.t()`, `chain.end()`, `chain.thought()` are available on the value returned from `tb.think()`, `tb.decide()`, `tb.research()`
+4. **Type Safety**: TypeScript infers return type as `Promise<Thought>` for `t()`, `end()`, and `thought()`
+5. **Per-Call Persistence**: Each chain method call results in exactly one server-side thought write before resolving
+6. **Stateless**: Garbage-collecting the `ThoughtChain` object does not affect the underlying session; thoughts already submitted remain persisted
+7. **Concurrent Safety**: Two chains bound to the same session can write concurrently; server-side auto-numbering serializes them without client coordination
+8. **Closed Chain Errors**: Calling `t()`, `end()`, or `thought()` after `end()` on the same chain instance throws `ChainClosedError` with `attemptedOperation` populated
+9. **Session Resume**: `tb.think({ sessionId: chain.sessionId })` returns a fresh chain bound to the same session, even if the prior chain was closed
+10. **Factory Defaults**: `tb.think()` defaults to `sessionType: "exploration"`, `tb.decide()` to `"decision"`, `tb.research()` to `"research"`

--- a/.specs/cognitive-harness-improvements/03-mid-session-recall-primitives.md
+++ b/.specs/cognitive-harness-improvements/03-mid-session-recall-primitives.md
@@ -1,0 +1,273 @@
+# Spec: Mid-Session Recall Primitives
+
+## Title
+Session-Internal Thought Retrieval Operations
+
+## Status
+Draft
+
+## Target State
+
+### New SDK Operations
+
+The SDK exposes three new operations for retrieving thoughts within the current session:
+
+#### `tb.session.getThought(thoughtNumber: number): Promise<Thought | null>`
+
+Retrieves a specific thought by its ordinal number.
+- Returns `null` if `thoughtNumber` is out of bounds or session has no such thought
+- O(1) lookup by index
+- Return type explicitly includes `null` for the "not found" case
+
+#### `tb.session.recentThoughts(count?: number): Promise<readonly Thought[]>`
+
+Returns the most recent thoughts in the session.
+- Default: returns last 10 thoughts
+- Ordered from oldest to newest within the returned slice
+- `tb.session.recentThoughts(1)` returns the single most recent thought
+- Returns `readonly Thought[]` to prevent mutation of session data
+
+#### `tb.session.searchWithin(query: string, options?: SearchWithinOptions): Promise<readonly Thought[]>`
+
+Full-text search across thoughts in the current session.
+- Case-insensitive substring match on `thought.content`
+- Optional `limit` (default: 20, max: 100)
+- Optional `thoughtTypes` filter restricts search to specific thought types
+- Returns thoughts ordered from newest to oldest
+- Returns `readonly Thought[]` to prevent mutation
+
+### Supporting Types
+
+```typescript
+/**
+ * Options for session search.
+ */
+interface SearchWithinOptions {
+  /**
+   * Maximum number of results to return.
+   * @default 20
+   * @max 100
+   */
+  limit?: number;
+
+  /**
+   * Filter to only include thoughts of these types.
+   * If not provided, all thought types are searched.
+   */
+  thoughtTypes?: readonly ThoughtType[];
+}
+
+/**
+ * The server-persisted thought type.
+ * All server-assigned fields are guaranteed present.
+ */
+interface Thought {
+  thoughtNumber: number;     // Server-assigned, always present
+  thought: string;
+  thoughtType: ThoughtType;
+  nextThoughtNeeded: boolean;
+  timestamp: string;          // Server-assigned ISO 8601
+  // ... all other ThoughtData fields
+}
+
+/**
+ * Union of all valid thought types.
+ */
+type ThoughtType = 
+  | "reasoning"
+  | "decision_frame"
+  | "action_report"
+  | "belief_snapshot"
+  | "assumption_update"
+  | "context_snapshot"
+  | "progress"
+  | "action_receipt";
+```
+
+### Return Type Precision and Ordering
+
+All three operations return typed results. The two array-returning operations differ in their result ordering — this is **intentional, not a bug** — because the natural reading order differs between the use cases:
+
+| Operation | Return Type | Result Order | Why this order |
+|-----------|-------------|--------------|----------------|
+| `getThought(n)` | `Promise<Thought \| null>` | n/a (single result) | `null` for out-of-bounds |
+| `recentThoughts(n)` | `Promise<readonly Thought[]>` | **oldest-to-newest within the slice** | Callers almost always want to *read forward* through the recent past ("show me the last 10 thoughts as they unfolded"). Chronological order is the natural fit. |
+| `searchWithin(q, opts)` | `Promise<readonly Thought[]>` | **newest-to-oldest** | Search results are ranked by recency; when a caller asks "find thoughts about X," the most recent matches are usually the most relevant. |
+
+The asymmetry matters when chaining the two — a caller doing both `recentThoughts(20)` and `searchWithin("X", { limit: 20 })` receives results in opposite directions. To unify, the caller should explicitly sort or `.reverse()` one side.
+
+If a future caller needs a different ordering (e.g., search results in chronological order), an `order?: "asc" | "desc"` option can be added to `SearchWithinOptions`. v1 omits this option to keep the API surface small; add when a real use case appears.
+
+`readonly` on both array return types prevents mutation of session data.
+
+### Usage Examples
+
+```typescript
+// Check what I just concluded
+const last = await tb.session.getThought(session.thoughtCount);
+// or equivalently:
+const last = await tb.session.recentThoughts(1).then(r => r[0] ?? null);
+
+// Review my recent reasoning chain
+const recent = await tb.session.recentThoughts(5);
+
+// Find all decision frames I made
+const decisions = await tb.session.searchWithin("", {
+  thoughtTypes: ["decision_frame"]
+});
+
+// Find thoughts about a specific topic
+const relevant = await tb.session.searchWithin("authentication");
+
+// Get all recent belief snapshots (up to 50)
+const beliefs = await tb.session.searchWithin("", {
+  thoughtTypes: ["belief_snapshot"],
+  limit: 50
+});
+```
+
+### Operations Catalog Entry
+
+These operations appear in the Thoughtbox operations catalog under the `session` module:
+
+```typescript
+session: {
+  getThought: {
+    title: "Get Thought by Number",
+    description: "Retrieves a specific thought by its ordinal number. Returns null if not found."
+  };
+  recentThoughts: {
+    title: "Get Recent Thoughts",
+    description: "Returns the most recent N thoughts, ordered oldest-to-newest within the slice."
+  };
+  searchWithin: {
+    title: "Search Session Thoughts",
+    description: "Full-text search across thoughts in the current session."
+  };
+}
+```
+
+---
+
+## Design Rationale
+
+### Explicit Null Handling
+
+`getThought` returning `Thought | null` makes the "not found" case explicit. Callers must handle both possibilities, preventing null pointer exceptions from being surprise runtime errors.
+
+### Readonly Return Types
+
+Using `readonly Thought[]` for collection returns prevents callers from accidentally mutating session data. This follows the principle of **making illegal states unrepresentable** - if you can't mutate the returned data, you can't introduce inconsistencies.
+
+### Facilitating Useful States
+
+These primitives enable:
+- **Reflection**: "What did I just conclude?"
+- **Self-correction**: "Let me review my recent reasoning before continuing"
+- **Context-sensitive continuation**: "Find my thoughts about X to build on them"
+- **Type-specific retrieval**: "Show me only my decision frames"
+
+---
+
+## Validation
+
+1. **getThought Valid**: Returns correct `Thought` for valid `thoughtNumber`
+2. **getThought Null**: Returns `null` for out-of-bounds `thoughtNumber`
+3. **recentThoughts Count**: Returns exactly `count` thoughts (or default 10)
+4. **recentThoughts Order**: Ordered oldest-to-newest within slice
+5. **searchWithin Match**: Returns thoughts matching the query under the configured search mode (full-text by default; substring when `mode: "substring"`)
+6. **searchWithin Filters**: `thoughtTypes` filter correctly restricts results
+7. **searchWithin Limit**: Respects `limit` option (default 20, max 100)
+8. **Readonly Guarantee**: Returned arrays are `readonly` and mutations throw
+9. **Catalog Presence**: All three operations appear in the Thoughtbox catalog under `session`
+10. **Session-Scoped FTS**: `searchWithin` returns matches only from the specified session; never bleeds across sessions
+11. **Index Used**: `EXPLAIN ANALYZE` on the `searchWithin` query shows GIN index usage on `to_tsvector('english', thought)` for full-text mode
+
+---
+
+## Implementation Notes
+
+### Lookup Characteristics by Operation
+
+| Operation | Complexity | Backing Index |
+|-----------|-----------|---------------|
+| `getThought(N)` | O(1) | Existing unique index on `thoughts(session_id, thought_number)` — no new work needed |
+| `recentThoughts(n)` | O(n), n ≤ 100 | Same unique index, scanned `ORDER BY thought_number DESC LIMIT n` |
+| `searchWithin(query)` | O(log T + matches) where T = thoughts in session | New GIN index on `to_tsvector('english', thought)` |
+
+### Search Backing Index (Postgres FTS)
+
+```sql
+-- Migration: full-text search index on thought content
+CREATE INDEX idx_thoughts_content_fts
+  ON thoughts USING GIN (to_tsvector('english', thought));
+```
+
+```sql
+-- Query (full-text mode, default)
+SELECT thought_number, thought_type, thought, timestamp, metadata, ...
+FROM thoughts
+WHERE session_id = $1
+  AND to_tsvector('english', thought) @@ websearch_to_tsquery('english', $2)
+  AND ($3::text[] IS NULL OR thought_type = ANY($3))
+ORDER BY thought_number DESC
+LIMIT $4;
+
+-- Query (substring mode, optional)
+SELECT thought_number, thought_type, thought, timestamp, metadata, ...
+FROM thoughts
+WHERE session_id = $1
+  AND thought ILIKE '%' || $2 || '%'
+  AND ($3::text[] IS NULL OR thought_type = ANY($3))
+ORDER BY thought_number DESC
+LIMIT $4;
+```
+
+### `SearchWithinOptions.mode`
+
+To support both natural-language matching and exact-substring matching, extend the options:
+
+```typescript
+interface SearchWithinOptions {
+  limit?: number;              // default 20, max 100
+  thoughtTypes?: readonly ThoughtType[];
+
+  /**
+   * Search mode.
+   * - "fulltext" (default): tsvector match with stemming + stopwords; English locale
+   * - "substring": case-insensitive ILIKE match; no stemming; useful for exact phrase
+   */
+  mode?: "fulltext" | "substring";
+}
+```
+
+The default `"fulltext"` matches the agent's natural-language phrasing ("authentication" finds "authenticated", "auth", etc.). Use `"substring"` when an agent needs to find an exact identifier or phrase.
+
+### Performance Targets
+
+| Session size | `searchWithin` p99 (with GIN index) |
+|--------------|--------------------------------------|
+| ≤ 500 thoughts | < 20 ms |
+| ≤ 5,000 thoughts | < 50 ms |
+| ≤ 50,000 thoughts | < 200 ms |
+
+Substring mode without index assistance is acceptable up to ~1,000 thoughts; beyond that it should fall back to GIN trigram matching (`pg_trgm` extension, optional follow-up).
+
+### Why Postgres FTS, Not a Separate Search Service
+
+- `searchWithin` is always session-scoped. There is no need for a global cross-session search index.
+- A dedicated search service (Elasticsearch, MeiliSearch, Typesense) would add operational overhead — sync pipelines, schema drift, infra cost — with no benefit at the scale a Thoughtbox session reaches.
+- Postgres FTS ships in core, requires one migration, and meets the performance targets above for realistic session sizes.
+
+### Recommended Application-Layer Session Size Limits
+
+Sessions over a few thousand thoughts almost always indicate a missing session-end. Recommended posture:
+
+- **Soft warning at 1,000 thoughts**: surface a UI/log warning suggesting the session be closed.
+- **Hard cap at 10,000 thoughts**: refuse new submissions, force `nextThoughtNeeded: false`.
+
+These limits are policy, not infrastructure; the GIN index handles much larger sessions if a future use case demands it.
+
+### Session ID Resolution in the SDK
+
+The Code Mode SDK methods accept `sessionId` implicitly when called inside a `tb.think()` chain context (see Spec 02). When called directly on `tb.session.*` outside a chain, the active session is inferred from the execution context; if no active session exists, the call throws `NoActiveSessionError`.

--- a/.specs/cognitive-harness-improvements/04-subagent-session-attachment.md
+++ b/.specs/cognitive-harness-improvements/04-subagent-session-attachment.md
@@ -1,0 +1,228 @@
+# Spec: Subagent Session Attachment
+
+## Title
+Attaching Subagent Outputs to Parent Session
+
+## Status
+Draft
+
+## Related Specs
+
+- **Spec 11 (Structured Return Schemas)**: defines how `SubagentOutput.metadata` is produced and validated. The two specs are a coupled deliverable — Spec 04 describes how a subagent's output lands in the parent's reasoning chain; Spec 11 describes how that output is shaped and verified before attachment. Implementations should ship them together.
+- **Spec 02 (Terse Shorthand)**: the parent's `tb.subagent.attach()` and `tb.subagent.run()` are typically called from inside a chain context (`chain.t(...)` between dispatches), so chain semantics from Spec 02 apply.
+- **Spec 10 (Knowledge Graph Persistence)**: when `AttachOptions.entityName` is provided, an automatic knowledge-graph entity is created. Visibility and error semantics follow Spec 10's `KGPersistError` model.
+
+## Target State
+
+### `tb.subagent.attach()` Method
+
+The SDK provides a method to attach subagent outputs to the parent Thoughtbox session:
+
+```typescript
+interface SubagentOperations {
+  /**
+   * Attach a subagent output to the parent session.
+   *
+   * @param output - The subagent output to attach
+   * @param options - Optional configuration for the attachment
+   * @returns Promise<Thought> - The created thought
+   */
+  attach(output: SubagentOutput, options?: AttachOptions): Promise<Thought>;
+
+  /**
+   * Run a subagent and optionally attach its output.
+   */
+  run(input: SubagentDispatchInput): Promise<SubagentOutput>;
+}
+```
+
+### SubagentOutput Structure
+
+```typescript
+/**
+ * Output produced by a subagent execution.
+ * This is the result of tb.subagent.run().
+ */
+interface SubagentOutput {
+  /**
+   * Raw text output from the subagent.
+   */
+  content: string;
+
+  /**
+   * Optional one-line summary of the output.
+   * Useful for concise display in timelines.
+   */
+  summary?: string;
+
+  /**
+   * Optional structured metadata from the subagent.
+   * Structure depends on the subagent's expectedReturn schema.
+   */
+  metadata?: Readonly<Record<string, unknown>>;
+
+  /**
+   * When the subagent finished execution.
+   */
+  completedAt: string;  // ISO 8601
+
+  /**
+   * Duration of subagent execution in milliseconds.
+   */
+  durationMs?: number;
+
+  /**
+   * Model used by the subagent (if applicable).
+   */
+  model?: string;
+}
+```
+
+### AttachOptions
+
+```typescript
+/**
+ * Options for attaching a subagent output to the session.
+ */
+interface AttachOptions {
+  /**
+   * Thought type for the attachment.
+   * Default: "context_snapshot"
+   */
+  thoughtType?: ThoughtType;
+
+  /**
+   * Visibility for any knowledge graph entities created.
+   * Default: "agent-private"
+   */
+  visibility?: Visibility;
+
+  /**
+   * If provided, creates a knowledge graph entity with this name
+   * linking to the thought.
+   */
+  entityName?: string;
+}
+
+/**
+ * Visibility level for knowledge graph entities.
+ */
+type Visibility = "public" | "agent-private" | "user-private" | "team-private";
+
+/**
+ * All valid thought types for type checking.
+ */
+type ThoughtType =
+  | "reasoning"
+  | "decision_frame"
+  | "action_report"
+  | "belief_snapshot"
+  | "assumption_update"
+  | "context_snapshot"
+  | "progress"
+  | "action_receipt";
+```
+
+### Resulting Thought
+
+The attached thought has:
+- `thoughtType: "context_snapshot"` (or override)
+- `thought` field contains the subagent output content (or summary if provided)
+- `metadata.subagentOutput` contains the full original output and any structured metadata
+
+```typescript
+/**
+ * Metadata attached to a thought created from subagent output.
+ */
+interface SubagentOutputMetadata {
+  /**
+   * The original subagent output.
+   */
+  subagentOutput: SubagentOutput;
+
+  /**
+   * The thought type used for the attachment.
+   */
+  thoughtType: ThoughtType;
+
+  /**
+   * Visibility of any created KG entity (if applicable).
+   */
+  visibility?: Visibility;
+
+  /**
+   * ID of created KG entity (if entityName was provided).
+   */
+  entityId?: string;
+}
+```
+
+### Usage Example
+
+```typescript
+// Run a subagent and attach its output to the session
+const analysis = await tb.subagent.run({
+  prompt: "Analyze the authentication flow for vulnerabilities."
+});
+
+// Attach as context_snapshot with structured metadata
+const thought = await tb.subagent.attach(analysis, {
+  thoughtType: "context_snapshot",
+  entityName: "auth-vulnerability-analysis",
+  visibility: "team-private",
+  metadata: {
+    findingCount: analysis.metadata?.findingCount,
+    severity: analysis.metadata?.severity
+  }
+});
+
+// The thought.metadata.subagentOutput contains the original output
+console.log(thought.metadata.subagentOutput.content);
+```
+
+### Knowledge Graph Integration
+
+If `entityName` is provided, a knowledge graph entity is automatically created:
+
+- Entity type: `"Insight"`
+- Label: `entityName`
+- Observation: references the attached thought
+- Visibility: as specified in options (defaults to `"agent-private"`)
+
+---
+
+## Design Rationale
+
+### Explicit Type Definitions
+
+Rather than using `Record<string, unknown>` for all output structures, we define `SubagentOutput` with explicit fields:
+
+- `content`: Required - the raw text output
+- `summary`: Optional - for concise display
+- `metadata`: Optional but typed as `Readonly<Record<string, unknown>>` for flexibility
+- `completedAt`: Required - ISO timestamp for audit trail
+- `durationMs`: Optional - for performance tracking
+- `model`: Optional - for reproducibility
+
+### Readonly Metadata
+
+`metadata: Readonly<Record<string, unknown>>` prevents mutation of subagent-provided metadata after attachment. This maintains data integrity.
+
+### Type-Safe ThoughtType
+
+The `thoughtType` option is typed as `ThoughtType` union rather than generic `string`, enabling:
+- IDE autocomplete for valid options
+- Compile-time checking of invalid thought types
+- Self-documenting code
+
+---
+
+## Validation
+
+1. **Attachment Creation**: `tb.subagent.attach()` creates a thought in the parent session
+2. **Thought Type**: Default thought type is `context_snapshot` when not overridden
+3. **Metadata Preservation**: Original `SubagentOutput` appears in `thought.metadata.subagentOutput`
+4. **Entity Creation**: When `entityName` is provided, a knowledge graph entity exists with the given name
+5. **Visibility**: Entity respects the `visibility` option (defaults to `"agent-private"`)
+6. **Type Safety**: `thoughtType` option only accepts valid `ThoughtType` values
+7. **Readonly Metadata**: `metadata` field on `SubagentOutput` is `Readonly`

--- a/.specs/cognitive-harness-improvements/05-hook-suppression-during-sessions.md
+++ b/.specs/cognitive-harness-improvements/05-hook-suppression-during-sessions.md
@@ -1,0 +1,200 @@
+# Spec: Hook Suppression During Active Sessions
+
+## Title
+SessionStart Task-Tracking Hook Suppression
+
+## Status
+Draft
+
+## Target State
+
+### Hook Behavior
+
+When a SessionStart hook would normally fire a task-tracking nudge, it first checks for an active Thoughtbox session:
+
+```typescript
+// Pseudocode for SessionStart hook logic
+async function onSessionStart(sessionId: string): Promise<HookResult> {
+  // Check if there's an active Thoughtbox session
+  const hasActiveSession = await tb.session.isActive();
+
+  if (hasActiveSession) {
+    // Suppress the task-tracking nudge
+    logger.debug("Active Thoughtbox session detected; suppressing nudge");
+    return { suppressed: true, reason: "active_session" };
+  }
+
+  // Proceed with normal nudge logic
+  return { suppressed: false };
+}
+```
+
+### `tb.session.isActive()` Method
+
+```typescript
+interface SessionOperations {
+  /**
+   * Check if there is currently an active Thoughtbox session.
+   *
+   * @returns Promise<boolean> - true if an active session exists, false otherwise
+   *
+   * A session is considered "active" when:
+   * 1. A ThoughtboxSession has been created (via tb.session.create() or tb.think())
+   * 2. The configured activity timeout has not been exceeded since the last
+   *    thought submission (see "Activity Timeout Configuration" below)
+   * 3. The session has not been explicitly ended via tb.session.end()
+   */
+  isActive(): Promise<boolean>;
+}
+```
+
+### Active Session Detection
+
+A session is considered "active" when:
+1. A `ThoughtboxSession` has been created (via `tb.session.create()` or `tb.think()`)
+2. The configured activity timeout has not been exceeded since the last thought submission (see Activity Timeout Configuration below)
+3. The session has not been explicitly ended via `tb.session.end()`
+
+### Activity Timeout Configuration
+
+The "active" window is **configurable**, not hardcoded. The effective timeout for a given session is resolved in this order:
+
+1. **Per-session override** — `activityTimeoutMs` provided at session creation:
+
+   ```typescript
+   interface SessionCreateParams {
+     // ... existing fields
+     /**
+      * Inactivity threshold (milliseconds) beyond which the session is considered
+      * "inactive" for hook-suppression purposes. Affects only the
+      * `tb.session.isActive()` boolean response; does not actually close the session.
+      *
+      * Resolution order:
+      *   1. This per-session override (if provided)
+      *   2. THOUGHTBOX_ACTIVITY_TIMEOUT_MS environment variable
+      *   3. System default: 300_000 (5 minutes)
+      */
+     activityTimeoutMs?: number;
+   }
+   ```
+
+2. **Per-deployment default** — the `THOUGHTBOX_ACTIVITY_TIMEOUT_MS` environment variable, parsed as an integer number of milliseconds.
+
+3. **System default** — 300_000 ms (5 minutes), used when neither of the above is set.
+
+### Recommended Values
+
+| Use case | `activityTimeoutMs` | Rationale |
+|----------|---------------------|-----------|
+| Tight-focus reasoning, agent always active | `60_000` (1 min) | Short pause means the agent is gone; let nudges fire |
+| Default mixed-mode (recommended) | `300_000` (5 min) | Tolerates mid-thought tool calls without flapping |
+| Research session with subagent dispatch + waiting | `1_800_000` (30 min) | Subagent runs can legitimately take 60-90s; chain re-integration takes longer |
+| "Never auto-suppress" — always show nudges | `0` | Treats session as immediately inactive |
+| "Always suppress" while session lives | `Number.MAX_SAFE_INTEGER` | Effectively no timeout |
+
+### Reference Implementation
+
+```typescript
+async isActive(): Promise<boolean> {
+  const session = await getCurrentSession();
+  if (!session || session.endedAt) return false;
+
+  const lastThought = await getLastThoughtTimestamp(session.id);
+  if (!lastThought) return false;
+
+  const timeout =
+    session.activityTimeoutMs
+    ?? Number(process.env.THOUGHTBOX_ACTIVITY_TIMEOUT_MS)
+    ?? 300_000;
+
+  return Date.now() - lastThought.getTime() < timeout;
+}
+```
+
+### Return Type
+
+```typescript
+/**
+ * Result of checking hook suppression condition.
+ */
+interface HookResult {
+  /**
+   * Whether the hook/nudge was suppressed.
+   */
+  suppressed: boolean;
+
+  /**
+   * Reason for suppression (if suppressed).
+   */
+  reason?: "active_session" | "user_preference" | "rate_limited";
+
+  /**
+   * The session ID that caused suppression (if applicable).
+   */
+  sessionId?: string;
+}
+```
+
+### Nudge Types Suppressed
+
+When an active session is detected, the following nudge types are suppressed:
+- "You have N incomplete tasks"
+- "Consider updating your task list"
+- Session summary requests
+- Any hook-triggered notifications that would interrupt flow
+
+### User-Facing Behavior
+
+When nudges are suppressed:
+- No visible UI interruption
+- Hook fires silently in background (logged for observability)
+- User is never informed of suppression (the experience is seamless)
+
+### Observability
+
+The suppression events are logged with:
+
+```typescript
+interface SuppressionLogEntry {
+  hook: "SessionStart";
+  event: "nudge_suppressed";
+  reason: "active_session";
+  sessionId: string;
+  timestamp: string;  // ISO 8601
+}
+```
+
+---
+
+## Design Rationale
+
+### Explicit Return Type
+
+`isActive(): Promise<boolean>` makes the return type explicit:
+- `true` means an active session exists
+- `false` means no active session
+
+This clarity prevents confusion about what "active" means and enables simple boolean logic in callers.
+
+### Facilitating Useful States
+
+This feature enables:
+- **Uninterrupted flow**: Agents can think through problems without task-nudge interruptions
+- **Contextual hooks**: Hooks that know to be quiet when the user is in "thinking mode"
+- **Graceful degradation**: If session tracking fails, nudges still fire normally
+
+---
+
+## Validation
+
+1. **Return Type**: `tb.session.isActive()` returns `Promise<boolean>`
+2. **Suppression Trigger**: When `tb.session.isActive()` returns `true`, nudges are suppressed
+3. **No Suppression**: When `tb.session.isActive()` returns `false`, nudges fire normally
+4. **Default Timeout**: With no per-session override and no env var, sessions become inactive after 300_000 ms (5 min) of no thought submissions
+5. **Per-Session Override**: A session created with `activityTimeoutMs: 60_000` becomes inactive after 60 seconds, regardless of env var
+6. **Env Var Override**: With `THOUGHTBOX_ACTIVITY_TIMEOUT_MS=1800000` set and no per-session override, sessions become inactive after 30 minutes
+7. **Resolution Order**: Per-session override takes precedence over env var, which takes precedence over system default
+8. **Edge Value: Zero**: `activityTimeoutMs: 0` causes `isActive()` to return `false` immediately after each thought (treats session as instantly inactive for nudge purposes)
+9. **Edge Value: Max**: `activityTimeoutMs: Number.MAX_SAFE_INTEGER` causes `isActive()` to return `true` indefinitely while the session is open
+10. **Explicit End**: Calling `tb.session.end()` immediately restores nudge behavior regardless of timeout setting
+11. **Logging**: Suppression events appear in observability logs with correct metadata

--- a/.specs/cognitive-harness-improvements/06-cipher-mode-toggle.md
+++ b/.specs/cognitive-harness-improvements/06-cipher-mode-toggle.md
@@ -1,0 +1,168 @@
+# Spec: Cipher Mode Toggle
+
+## Title
+Session-Level and Per-Thought Cipher Mode Control
+
+## Status
+Draft
+
+## Target State
+
+### Session-Level Cipher Mode
+
+Sessions have a `cipherMode` setting that controls how cipher extension operates:
+
+```typescript
+type CipherMode = "auto" | "manual" | "off";
+```
+
+| Mode | Behavior |
+|------|----------|
+| `"auto"` | Cipher extension activates automatically based on content sensitivity signals |
+| `"manual"` | Cipher extension only activates when explicitly requested per-thought |
+| `"off"` | Cipher extension is disabled for the entire session |
+
+### Session Creation with Cipher Mode
+
+```typescript
+// Create session with explicit cipher mode
+const session = await tb.session.create({
+  title: "Security Review",
+  cipherMode: "manual"  // Explicit control
+});
+
+// Default cipher mode is "auto"
+const defaultSession = await tb.session.create({ title: "General Reasoning" });
+```
+
+### Per-Thought Cipher Flag (Conditional Override)
+
+The per-thought `cipher` flag is a **conditional override** that only applies when session `cipherMode` is `"manual"`:
+
+```typescript
+interface ThoughtInput {
+  thought: string;
+  thoughtType: ThoughtType;
+  nextThoughtNeeded: boolean;
+
+  /**
+   * Per-thought cipher override.
+   * ONLY effective when session.cipherMode === "manual".
+   * Ignored when session.cipherMode is "auto" or "off".
+   *
+   * - true: Request cipher processing (when session mode is "manual")
+   * - false: Explicit opt-out (when session mode is "manual")
+   * - undefined: Use session-level setting (when session mode is "manual")
+   */
+  cipher?: boolean;
+}
+```
+
+### Semantic Constraint: Making Illegal States Unrepresentable
+
+The combination of `cipherMode: "off"` + `cipher: true` is **semantically contradictory** and MUST be prevented:
+
+```typescript
+// This combination is INVALID and must be rejected:
+{
+  session: { cipherMode: "off" },
+  thought: { cipher: true }  // CANNOT override "off" - makes no sense
+}
+```
+
+**Rule**: Per-thought `cipher` flag is **silently ignored** when `cipherMode` is `"off"`. The `"off"` mode means "cipher is completely disabled for this session, no exceptions."
+
+```typescript
+// Behavior matrix:
+session.cipherMode = "auto":
+  - cipher flag is IGNORED (auto signals control behavior)
+  - Server determines cipher based on content sensitivity
+
+session.cipherMode = "manual":
+  - cipher: true  → process through cipher
+  - cipher: false → skip cipher
+  - cipher: undefined → skip cipher (defaults to off)
+
+session.cipherMode = "off":
+  - cipher flag is IGNORED (completely disabled)
+  - All thoughts skip cipher regardless of per-thought flag
+```
+
+### Session Cipher Mode Retrieval
+
+```typescript
+const session = await tb.session.getCurrent();
+console.log(session.cipherMode);  // "auto" | "manual" | "off"
+```
+
+### Type System Enforcement
+
+```typescript
+/**
+ * Represents the effective cipher decision for a thought.
+ * This is computed from session.cipherMode + thought.cipher flag.
+ */
+type EffectiveCipherDecision =
+  | { decision: "cipher"; reason: "auto_signal" | "manual_request" }
+  | { decision: "skip"; reason: "auto_signal_clear" | "manual_opt_out" | "mode_off" };
+
+/**
+ * Check the effective cipher decision for a thought.
+ * Used by the server to determine actual behavior.
+ */
+function getEffectiveCipherDecision(
+  sessionCipherMode: CipherMode,
+  thoughtCipherFlag?: boolean
+): EffectiveCipherDecision {
+  switch (sessionCipherMode) {
+    case "off":
+      return { decision: "skip", reason: "mode_off" };
+    case "auto":
+      // In a full implementation, this would consult auto-signals
+      return { decision: "skip", reason: "auto_signal_clear" };
+    case "manual":
+      if (thoughtCipherFlag === true) {
+        return { decision: "cipher", reason: "manual_request" };
+      }
+      return { decision: "skip", reason: "manual_opt_out" };
+  }
+}
+```
+
+---
+
+## Design Rationale
+
+### The Problem with the Original Design
+
+The original spec allowed `cipher: true` on a thought to override `cipherMode: "off"`. This creates a semantic contradiction:
+
+- `"off"` semantically means "cipher is disabled for this session"
+- But if a per-thought flag can override it, `"off"` doesn't actually mean "off"
+- This violates the principle of **making illegal states unrepresentable** — if a user sets `cipherMode: "off"`, they expect cipher to be off, period
+
+### The Correct Abstraction
+
+By making the per-thought `cipher` flag **conditionally effective only in `"manual"` mode**, we create a clean separation:
+
+| Session Mode | Intent | Per-thought Override |
+|--------------|--------|---------------------|
+| `"auto"` | Server decides based on content signals | Not applicable (ignored) |
+| `"manual"` | User explicitly controls each thought | YES - allows per-thought control |
+| `"off"` | Cipher completely disabled | NO - `"off"` is absolute |
+
+### Facilitating Useful States
+
+This design enables the **useful state** of having a "manual override session" where you can selectively enable cipher for specific sensitive thoughts while most thoughts go unencrypted. The `"auto"` mode handles the common case where the server should just figure it out. The `"off"` mode handles the "this session is entirely public" case.
+
+---
+
+## Validation
+
+1. **Mode "off" is Absolute**: `cipherMode: "off"` means all thoughts skip cipher, regardless of per-thought `cipher` flag
+2. **Mode "manual" Override**: `cipherMode: "manual"` with `cipher: true` processes through cipher
+3. **Mode "manual" Default**: `cipherMode: "manual"` with no `cipher` flag (or `false`) skips cipher
+4. **Mode "auto" Ignores Flag**: `cipherMode: "auto"` ignores per-thought `cipher` flag
+5. **Session Query**: `tb.session.getCurrent().cipherMode` returns the correct setting
+6. **Type Safety**: The `EffectiveCipherDecision` type accurately represents all valid states
+7. **No Contradiction**: `cipherMode: "off"` combined with `cipher: true` is handled gracefully (flag ignored, not an error)

--- a/.specs/cognitive-harness-improvements/07-deliberation-without-commitment.md
+++ b/.specs/cognitive-harness-improvements/07-deliberation-without-commitment.md
@@ -1,0 +1,300 @@
+# Spec: Deliberation Without Commitment
+
+## Title
+Decision Frames with Optional Selection and Deliberation State
+
+## Status
+Draft
+
+## Target State
+
+### The Problem with `selected: boolean` on Each Option
+
+A naive representation of decision options looks like:
+
+```typescript
+options: Array<{
+  label: string;
+  selected: boolean;  // PROBLEM: Multiple options can have selected: true
+}>
+```
+
+This allows **illegal states** like:
+```typescript
+{
+  options: [
+    { label: "PostgreSQL", selected: true },
+    { label: "MongoDB", selected: true },   // ILLEGAL: Multiple selections!
+    { label: "DynamoDB", selected: false }
+  ]
+}
+```
+
+### Type-Safe Option Representation
+
+We use a **discriminated union** pattern to make illegal states unrepresentable:
+
+```typescript
+/**
+ * Base option type with just a label (unselected state)
+ */
+interface UnselectedOption {
+  label: string;
+  selected?: false;  // Must be false or undefined
+}
+
+/**
+ * Selected option - distinguished by selected: true
+ */
+interface SelectedOption {
+  label: string;
+  selected: true;
+  reason?: string;   // Why this was selected
+}
+
+/**
+ * Option in a decision - either selected or unselected
+ */
+type DecisionOption = UnselectedOption | SelectedOption;
+
+/**
+ * Options array is a single-selected set.
+ * Type system guarantees: at most one option has selected: true
+ */
+type DecisionOptionSet = DecisionOption[];
+```
+
+### Extended Decision Frame Structure
+
+```typescript
+interface DecisionFrameInput extends ThoughtInput {
+  thoughtType: "decision_frame";
+
+  /**
+   * Options being considered.
+   * - Empty array: deliberation in progress, no options yet enumerated
+   * - Non-empty: options under consideration
+   *
+   * Type system guarantee: at most one option has selected: true
+   */
+  options: DecisionOptionSet;
+
+  /**
+   * Current state of the decision process.
+   * - "deliberating": Still weighing options, no commitment yet
+   * - "committed": A decision has been made (exactly one option MUST be selected)
+   */
+  decisionState: "deliberating" | "committed";
+}
+```
+
+### Valid States Matrix
+
+| State | Options | Selected Count | Valid |
+|-------|---------|----------------|-------|
+| `deliberating` | `[]` | 0 | ✅ |
+| `deliberating` | `[{label: "A"}, {label: "B"}]` | 0 | ✅ |
+| `deliberating` | `[{label: "A", selected: true}, {label: "B"}]` | 1 | ✅ (can preview selection) |
+| `committed` | `[{label: "A", selected: true}, {label: "B"}]` | 1 | ✅ |
+| `deliberating` | `[{label: "A", selected: true}, {label: "B", selected: true}]` | 2 | ❌ Type error! |
+| `committed` | `[{label: "A"}, {label: "B"}]` | 0 | ❌ Runtime validation error |
+| `committed` | `[]` | 0 | ❌ Runtime validation error |
+
+### Type System Enforcement (and its limits)
+
+The discriminated union makes per-element typing self-documenting and lets TypeScript narrow once a single option is inspected. **However, TypeScript cannot enforce array-wide invariants such as "at most one element has `selected: true`" through the structural type system alone** — each element of the array is independently typed, and the type checker has no mechanism to express "at most N elements satisfy predicate P".
+
+What the type system **does** catch:
+
+```typescript
+// ✅ Compile-time error - 'selected: "yes"' is not assignable to literal types:
+const bad1: DecisionOptionSet = [
+  { label: "PostgreSQL", selected: "yes" }
+];
+
+// ✅ Compile-time error - 'selected: true' without label is invalid in either branch:
+const bad2: DecisionOptionSet = [
+  { selected: true }
+];
+
+// ✅ Type narrowing works for individual elements:
+const opt: DecisionOption = options[0];
+if (opt.selected) {
+  // TypeScript knows opt is SelectedOption here; opt.reason is in scope
+  console.log(opt.reason);
+}
+```
+
+What the type system **does not** catch (must be enforced at runtime):
+
+```typescript
+// ❌ NOT a compile-time error - both elements are independently valid:
+const bad3: DecisionOptionSet = [
+  { label: "PostgreSQL", selected: true },
+  { label: "MongoDB", selected: true }   // Type-checks fine; runtime rejects
+];
+```
+
+The "at most one selected" invariant is **enforced at runtime** by the Zod `refine` step (see Implementation Notes), which is the appropriate layer for cross-element constraints. The type system's contribution is making each individual option self-documenting and enabling clean narrowing — not preventing the multi-selection case.
+
+### Additional Validation (Runtime)
+
+Even though the type system prevents multiple `selected: true`, runtime validation enforces business rules:
+
+```typescript
+function validateDecisionFrame(input: DecisionFrameInput): void {
+  const selectedCount = input.options.filter(o => o.selected).length;
+
+  if (input.decisionState === "committed" && selectedCount !== 1) {
+    throw new DecisionValidationError(
+      `Committed decision must have exactly one selected option, got ${selectedCount}`
+    );
+  }
+
+  // selectedCount > 1 is prevented by type system, but we validate for safety
+  if (selectedCount > 1) {
+    throw new DecisionValidationError(
+      "Multiple options selected - this should be prevented by the type system"
+    );
+  }
+}
+```
+
+### Usage Examples
+
+```typescript
+// Still gathering options, no decision yet
+await tb.thought({
+  thought: "We need to decide on a database approach",
+  thoughtType: "decision_frame",
+  options: [],  // No options enumerated yet
+  decisionState: "deliberating",
+  nextThoughtNeeded: true
+});
+
+// Options enumerated, still deliberating
+await tb.thought({
+  thought: "Comparing three database options",
+  thoughtType: "decision_frame",
+  options: [
+    { label: "PostgreSQL" },
+    { label: "MongoDB" },
+    { label: "DynamoDB" }
+  ],
+  decisionState: "deliberating",
+  nextThoughtNeeded: true
+});
+
+// Decision made - exactly one selected, committed state
+await tb.thought({
+  thought: "Decision: Using PostgreSQL for relational integrity",
+  thoughtType: "decision_frame",
+  options: [
+    { label: "PostgreSQL", selected: true, reason: "ACID compliance and relational modeling" },
+    { label: "MongoDB" },
+    { label: "DynamoDB" }
+  ],
+  decisionState: "committed",
+  nextThoughtNeeded: false
+});
+```
+
+### Backward Compatibility
+
+For existing decision_frame thoughts that don't include `decisionState`:
+- Treat as `decisionState: "committed"` if any option is selected
+- Treat as `decisionState: "deliberating"` if no options are selected
+
+---
+
+## Design Rationale
+
+### Making Illegal States Unrepresentable (Per-Element)
+
+The original `options: Array<{ label: string; selected: boolean }>` design allowed each element to carry an arbitrary boolean payload, with no type-level distinction between "selected with a reason" and "unselected." Replacing it with a discriminated union where `selected: true` is a distinct branch (with required `label` and optional `reason`) makes each option self-documenting at the type level and enables clean narrowing.
+
+The cross-element invariant — "at most one option in the array has `selected: true`" — is **not** expressible in TypeScript's structural type system without phantom-type encoding that we judge to be more complex than its benefit. That invariant is enforced at runtime by Zod's `refine` step (see Implementation Notes), which is the appropriate layer for cross-element constraints.
+
+See "Type System Enforcement (and its limits)" above for a precise account of what the type system catches versus what runtime validation catches.
+
+### Facilitating Useful States
+
+The discriminated union still allows:
+- **Preview selection** during deliberation: `{ label: "A", selected: true }` to show which way you're leaning
+- **Clean committed state**: Exactly one selected when `decisionState: "committed"`
+- **Empty deliberation**: `[]` options when you haven't enumerated choices yet
+
+### Why Runtime Validation Still Exists
+
+Type system enforcement applies to **per-element structure** (each option is either selected-with-optional-reason or unselected). Runtime validation enforces **cross-element and cross-field invariants** that TypeScript's structural type system cannot express:
+
+- "At most one option has `selected: true`" — array-wide invariant
+- "`decisionState: \"committed\"` requires exactly 1 selection" — cross-field invariant tying `options` to `decisionState`
+
+These are complementary: the type system catches per-element structural errors at compile time; Zod `refine` catches cross-element and cross-field business rules at request time.
+
+---
+
+## Validation
+
+1. **Per-Element Type Safety (compile time, scope = a single option)**: For any single `DecisionOption` value, TypeScript rejects: (a) values where `selected` is anything other than a literal `true` or absent/`false`; (b) values with `selected: true` lacking the required `label`; (c) extra unknown fields when strict mode is enabled. This validation is **per-element only** — it does not, and cannot, constrain combinations across the array.
+2. **Cross-Element Runtime Rejection (request time, scope = the options array)**: An array containing two or more elements with `selected: true` is rejected at runtime by the Zod `refine` step. The type system alone does not catch the cross-element case — see "Type System Enforcement (and its limits)" in Target State for the precise account of what compile-time vs runtime catches.
+3. **Empty Options**: `decision_frame` with empty `options` and `decisionState: "deliberating"` is valid
+4. **Deliberating State**: `decision_frame` with multiple unselected options and `decisionState: "deliberating"` is valid
+5. **Committed State**: `decision_frame` with exactly one `selected: true` and `decisionState: "committed"` is valid
+6. **Committed Without Selection — Runtime Rejection**: `decision_frame` with `decisionState: "committed"` and no selection is rejected at runtime
+7. **Backward Compatibility**: Existing decision_frame thoughts without `decisionState` are parsed correctly
+8. **Option Narrowing**: Inside an `if (option.selected)` block, TypeScript narrows the type to `SelectedOption` and `option.reason` is in scope
+
+---
+
+## Implementation Notes
+
+### Zod Schema
+
+```typescript
+const UnselectedOptionSchema = z.object({
+  label: z.string(),
+  selected: z.literal(false).optional(),
+});
+
+const SelectedOptionSchema = z.object({
+  label: z.string(),
+  selected: z.literal(true),
+  reason: z.string().optional(),
+});
+
+const DecisionOptionSchema: z.ZodType<DecisionOption> = z.union([
+  SelectedOptionSchema,
+  UnselectedOptionSchema,
+]);
+
+const DecisionFrameInputSchema = z.object({
+  // ... base thought fields
+  thoughtType: z.literal("decision_frame"),
+  options: z.array(DecisionOptionSchema),
+  decisionState: z.enum(["deliberating", "committed"]),
+})
+  // Cross-element invariant: at most one option may be selected.
+  // TypeScript's structural type system cannot express this; Zod enforces it.
+  .refine(
+    (data) => data.options.filter(o => o.selected === true).length <= 1,
+    {
+      message: "At most one option may have selected: true",
+      path: ["options"],
+    }
+  )
+  // Cross-field invariant: committed state requires exactly one selection.
+  .refine(
+    (data) => {
+      if (data.decisionState === "committed") {
+        return data.options.filter(o => o.selected === true).length === 1;
+      }
+      return true;
+    },
+    {
+      message: "Committed decision must have exactly one selected option",
+      path: ["decisionState"],
+    }
+  );
+```

--- a/.specs/cognitive-harness-improvements/08-per-session-type-audit.md
+++ b/.specs/cognitive-harness-improvements/08-per-session-type-audit.md
@@ -1,0 +1,239 @@
+# Spec: Per-Session Type Audit
+
+## Title
+SessionType Metadata Affecting Audit Gap Detection
+
+## Status
+Draft
+
+## Target State
+
+### SessionType Definition
+
+```typescript
+/**
+ * Enumerated session types for audit gap detection.
+ * Each type has different expected reasoning patterns.
+ */
+type SessionType = 
+  | "research" 
+  | "decision" 
+  | "implementation" 
+  | "debugging" 
+  | "exploration";
+
+/**
+ * Session creation parameters including type.
+ */
+interface SessionCreateParams {
+  title: string;
+  sessionType?: SessionType;
+  // ... other params
+}
+
+/**
+ * Session with type metadata.
+ */
+interface Session {
+  id: string;
+  title: string;
+  sessionType: SessionType;
+  // ... other fields
+}
+```
+
+### Session Creation with Type
+
+```typescript
+const session = await tb.session.create({
+  title: "Authentication Security Review",
+  sessionType: "debugging"  // Explicit session type
+});
+```
+
+### Default SessionType
+
+The Thoughtbox SDK exposes one underlying primitive for session creation, plus three convenience factory wrappers (defined in Spec 02). They all forward to the same underlying machinery; they differ only in their default `sessionType` when the caller does not provide one explicitly:
+
+| Entry Point | Default SessionType | Notes |
+|-------------|---------------------|-------|
+| `tb.session.create()` (primitive) | `"research"` | The general-purpose entry point. Used directly when callers want a non-factory session type. |
+| `tb.think()` (factory, Spec 02) | `"exploration"` | Convenience wrapper over `tb.session.create({ sessionType: "exploration" })` |
+| `tb.decide()` (factory, Spec 02) | `"decision"` | Convenience wrapper over `tb.session.create({ sessionType: "decision" })` |
+| `tb.research()` (factory, Spec 02) | `"research"` | Convenience wrapper over `tb.session.create({ sessionType: "research" })` — same default as the primitive, for symmetry with the other factories |
+
+If a caller provides `sessionType: "..."` explicitly to any of these (factory or primitive), the explicit value wins. The factory defaults apply only in the absence of an explicit value.
+
+For session types not covered by the named factories (`"implementation"`, `"debugging"`), use `tb.session.create({ sessionType: "implementation" })` or `tb.session.create({ sessionType: "debugging" })` directly. The factories exist purely as ergonomic shorthands for the most common cases; they are not the only entry point.
+
+### Audit Gap Detection by SessionType
+
+```typescript
+/**
+ * Expected patterns and gap detection rules per session type.
+ */
+const SESSION_TYPE_RULES: Record<SessionType, GapDetectionRule> = {
+  research: {
+    expectedThoughts: ["belief_snapshot"],
+    minCount: 2,
+    gapSeverity: "warning",
+    description: "Multiple belief snapshots expected; ends with synthesized insight"
+  },
+
+  decision: {
+    expectedThoughts: ["decision_frame"],
+    requiredState: "committed",
+    gapSeverity: "error",
+    description: "At least one committed decision_frame expected"
+  },
+
+  implementation: {
+    expectedThoughts: ["action_report"],
+    unexpectedThoughts: ["belief_snapshot"],
+    gapSeverity: "warning",
+    description: "action_report thoughts expected; belief snapshots unexpected"
+  },
+
+  debugging: {
+    expectedThoughts: ["action_report"],
+    requiredContent: "root cause",
+    gapSeverity: "error",
+    description: "action_report identifying root cause expected"
+  },
+
+  exploration: {
+    // No strict expectations
+    gapSeverity: null,  // No alerts for exploration
+    description: "Flexible; minimal constraints"
+  }
+};
+
+interface GapDetectionRule {
+  expectedThoughts?: ThoughtType[];
+  unexpectedThoughts?: ThoughtType[];
+  minCount?: number;
+  requiredState?: "committed";  // For decision frames
+  requiredContent?: string;     // Substring that must appear
+  gapSeverity: "warning" | "error" | null;
+  description: string;
+}
+```
+
+### Audit Gap Behavior
+
+When a gap is detected:
+
+1. Thought is flagged with `metadata.auditGap: AuditGap`
+2. Gap is recorded in session audit metadata
+3. Gap does NOT block thought submission (non-blocking)
+
+```typescript
+/**
+ * Audit gap metadata attached to thoughts that trigger gaps.
+ */
+interface AuditGap {
+  /**
+   * Type of gap detected.
+   */
+  type: AuditGapType;
+
+  /**
+   * Severity of the gap.
+   */
+  severity: "warning" | "error";
+
+  /**
+   * Human-readable description of the gap.
+   */
+  message: string;
+
+  /**
+   * The session type that triggered this check.
+   */
+  sessionType: SessionType;
+
+  /**
+   * Expected vs actual counts (if applicable).
+   */
+  details?: {
+    expected?: number;
+    actual?: number;
+    expectedTypes?: ThoughtType[];
+    actualTypes?: ThoughtType[];
+  };
+}
+
+/**
+ * Types of audit gaps that can be detected.
+ */
+type AuditGapType =
+  | "insufficient_belief_snapshots"   // research session
+  | "no_committed_decision"            // decision session
+  | "unexpected_belief_snapshots"       // implementation session
+  | "no_root_cause_identified";         // debugging session
+```
+
+### SessionType Change
+
+Session type can be changed mid-session if context shifts:
+
+```typescript
+interface SessionOperations {
+  /**
+   * Update session metadata.
+   * Can change sessionType if context shifts.
+   */
+  update(attrs: { sessionType?: SessionType }): Promise<Session>;
+}
+
+// Usage
+await tb.session.update({ sessionType: "debugging" });
+```
+
+### Usage Example
+
+```typescript
+// Start as exploration
+const session = await tb.session.create({ 
+  title: "Investigating auth failures", 
+  sessionType: "exploration" 
+});
+
+// Realize it's debugging, update type
+await tb.session.update({ sessionType: "debugging" });
+
+// Continue with debugging-appropriate audit expectations
+// Gap detection now expects: reasoning chain + action_report with root cause
+```
+
+---
+
+## Design Rationale
+
+### Facilitating Useful States
+
+The `SessionType` enables:
+
+- **Adaptive auditing**: Different session types have fundamentally different reasoning shapes
+- **Reduced noise**: Uniform audit policy causes false positives (warnings in exploration) or false negatives (missing decisions in decision sessions)
+- **Type-specific insights**: The audit system can provide targeted suggestions based on session type
+
+### Making Illegal States Unrepresentable
+
+`SessionType` as a closed union type (`"research" | "decision" | "implementation" | "debugging" | "exploration"`) prevents:
+- Typos: `"reseach"` is not a valid SessionType
+- Invalid combinations: `"research" | "decision"` doesn't make sense
+
+---
+
+## Validation
+
+1. **Type Assignment**: `tb.session.create()` accepts valid `SessionType` values
+2. **Default Inference**: `tb.think()` defaults to `"exploration"`, `tb.decide()` to `"decision"`
+3. **Gap Detection research**: Session with type `"research"` and fewer than 2 belief snapshots triggers audit gap
+4. **Gap Detection decision**: Session with type `"decision"` and no committed decision_frame triggers audit gap
+5. **Gap Detection implementation**: Session with type `"implementation"` and belief_snapshot present triggers audit gap
+6. **Gap Detection debugging**: Session with type `"debugging"` and no root cause action_report triggers audit gap
+7. **Non-Blocking**: Audit gaps do not prevent thought submission
+8. **Type Update**: `tb.session.update({ sessionType })` changes the session type
+9. **Type Safety**: Invalid session type strings cause TypeScript compilation errors

--- a/.specs/cognitive-harness-improvements/09-named-checkpoints.md
+++ b/.specs/cognitive-harness-improvements/09-named-checkpoints.md
@@ -1,0 +1,338 @@
+# Spec: Named Checkpoints
+
+## Title
+Labeled Session Progress Checkpoints
+
+## Status
+Draft
+
+## Target State
+
+### The Problem with Raw String Labels
+
+Using `string` for checkpoint labels allows **illegal states**:
+
+```typescript
+// These are all "valid" strings but problematic as checkpoint labels:
+const label1 = "";                    // Empty - useless
+const label2 = "has spaces";          // Unusual for programmatic use
+const label3 = "has/slashes";         // May cause path issues
+const label4 = "UPPERCASE";           // Inconsistent casing
+const label5 = "has    many   spaces"; // Unusual formatting
+```
+
+### Branded Type for Checkpoint Labels
+
+We use TypeScript's **branded type** pattern to enforce constraints at the type level:
+
+```typescript
+/**
+ * Branded type for URL-safe checkpoint labels.
+ * Format: lowercase, alphanumeric, hyphens, underscores only.
+ * Examples: "auth-analysis-complete", "data_model_finalized", "step-1-of-3"
+ */
+type CheckpointLabel = string & {
+  readonly __brand: "CheckpointLabel";
+  readonly __pattern: /^[a-z0-9][a-z0-9_-]*$/;
+};
+
+/**
+ * Validate and coerce a string to CheckpointLabel.
+ * Throws if the string doesn't match the pattern.
+ */
+function createCheckpointLabel(label: string): CheckpointLabel {
+  const pattern = /^[a-z0-9][a-z0-9_-]*$/;
+  if (!pattern.test(label)) {
+    throw new Error(
+      `Invalid checkpoint label "${label}". ` +
+      `Must match pattern /^[a-z0-9][a-z0-9_-]*$/: ` +
+      `lowercase alphanumeric, starting with letter or digit, ` +
+      `with hyphens and underscores allowed.`
+    );
+  }
+  return label as CheckpointLabel;
+}
+
+/**
+ * Check if a string is a valid checkpoint label (without throwing).
+ */
+function isValidCheckpointLabel(label: string): label is CheckpointLabel {
+  return /^[a-z0-9][a-z0-9_-]*$/.test(label);
+}
+```
+
+### SDK Method Signatures (Creation and Retrieval)
+
+```typescript
+interface SessionOperations {
+  // ----- Creation -----
+
+  /**
+   * Create a named progress checkpoint.
+   *
+   * @param label - URL-safe identifier (lowercase alphanumeric, hyphens, underscores)
+   * @param summary - Optional human-readable description
+   * @returns Promise<Thought> - The created checkpoint thought
+   * @throws Error if label doesn't match /^[a-z0-9][a-z0-9_-]*$/
+   */
+  checkpoint(label: string, summary?: string): Promise<Thought>;
+
+  /**
+   * Create a checkpoint with type-safe label.
+   * Use this when you have a pre-validated label.
+   */
+  checkpointWithLabel(label: CheckpointLabel, summary?: string): Promise<Thought>;
+
+  // ----- Retrieval (Spec 09 §Checkpoint Retrieval) -----
+
+  /**
+   * Get all checkpoints in the current session, ordered by thought_number ASC.
+   * Server-side filter on metadata.checkpoint — O(checkpoints) not O(thoughts).
+   */
+  checkpoints(): Promise<readonly CheckpointThought[]>;
+
+  /**
+   * Get a specific checkpoint by label. Returns the first match (oldest).
+   * For all matches under the same label, use checkpointsByLabel().
+   */
+  getCheckpoint(label: string): Promise<CheckpointThought | null>;
+
+  /**
+   * Get all checkpoints with the given label, oldest first.
+   * Multiple checkpoints with the same label are explicitly allowed (see
+   * "Label Constraints" below).
+   */
+  checkpointsByLabel(label: string): Promise<readonly CheckpointThought[]>;
+}
+```
+
+### `CheckpointThought` — The Type Returned by Creation and Retrieval
+
+`CheckpointThought` is the explicit type produced by `tb.session.checkpoint()` and returned by all checkpoint retrieval operations (`checkpoints()`, `getCheckpoint(label)`, `checkpointsByLabel(label)`). It is a refinement of the base `Thought` (Spec 03) where `thoughtType` is narrowed to the literal `"progress"` and `metadata.checkpoint` is guaranteed to be present and well-formed:
+
+```typescript
+/**
+ * The checkpoint metadata payload, always present on a CheckpointThought.
+ */
+interface CheckpointMetadata {
+  /** Type-safe, URL-safe label. See "Branded Type for Checkpoint Labels" above. */
+  label: CheckpointLabel;
+  /** Human-readable summary, if provided at creation time. */
+  summary?: string;
+  /** Server-assigned ISO 8601 timestamp at which the checkpoint was created. */
+  createdAt: string;
+}
+
+/**
+ * A Thought that is also a checkpoint.
+ *
+ * Refines the base Thought (Spec 03) by:
+ *   - narrowing `thoughtType` to the literal "progress"
+ *   - guaranteeing `metadata.checkpoint: CheckpointMetadata` is present (not optional)
+ *
+ * All other fields inherited from Thought (thoughtNumber, timestamp, etc.)
+ * retain their semantics from Spec 01 / Spec 03.
+ */
+interface CheckpointThought extends Thought {
+  thoughtType: "progress";
+  /** At creation time: `summary ?? \`Checkpoint: ${label}\``. */
+  thought: string;
+  metadata: Thought["metadata"] & {
+    checkpoint: CheckpointMetadata;
+  };
+}
+```
+
+A plain `Thought` may or may not be a checkpoint; a `CheckpointThought` is statically guaranteed to be one. Code paths that hold a `CheckpointThought` reference can access `t.metadata.checkpoint.label` without optional chaining.
+
+A type predicate is provided for narrowing from `Thought` to `CheckpointThought`:
+
+```typescript
+function isCheckpointThought(t: Thought): t is CheckpointThought {
+  return t.thoughtType === "progress"
+      && t.metadata?.checkpoint !== undefined
+      && isValidCheckpointLabel(t.metadata.checkpoint.label);
+}
+```
+
+### Usage Examples
+
+```typescript
+// ✅ Valid checkpoint labels
+await tb.session.checkpoint("auth-analysis-complete");
+await tb.session.checkpoint("data_model_finalized", "Entity relationships defined");
+await tb.session.checkpoint("step1", "Initial setup done");
+await tb.session.checkpoint("auth", "Authentication module complete");
+
+// ❌ INVALID - these throw at runtime (and would fail type coercion)
+await tb.session.checkpoint("");                        // Empty
+await tb.session.checkpoint("Has Spaces");               // Contains spaces
+await tb.session.checkpoint("has/slashes");              // Contains slash
+await tb.session.checkpoint("UPPERCASE");                // Not lowercase
+await tb.session.checkpoint("_starts-with-underscore");  // Starts with underscore
+```
+
+### Label Constraints (Runtime Enforcement)
+
+| Constraint | Rule |
+|------------|------|
+| Non-empty | Label must have at least 1 character |
+| Lowercase | All characters must be lowercase (a-z) |
+| Alphanumeric | Must start with letter or digit (0-9) |
+| Hyphens/Underscores | Allowed after first character |
+| No consecutive separators | `--` or `__` are allowed (no semantic restriction) |
+| No uniqueness | Multiple checkpoints with same label allowed |
+
+### Checkpoint Retrieval
+
+Use the dedicated retrieval primitives. They are backed by a JSONB GIN index (see Implementation Notes below) and scale to sessions of arbitrary size — `tb.session.checkpoints()` is O(checkpoints), not O(thoughts).
+
+```typescript
+// All checkpoints in current session, oldest first
+const all = await tb.session.checkpoints();
+
+// Get a checkpoint by label (returns first/oldest match)
+const dataModel = await tb.session.getCheckpoint("data-model-finalized");
+
+// Get all checkpoints sharing a label
+const allInits = await tb.session.checkpointsByLabel("init");
+```
+
+**Do not use `searchWithin("Checkpoint:")` for this purpose.** Substring search of thought content is fragile (depends on a content prefix that the spec does not guarantee), O(thoughts) rather than O(checkpoints), and unindexed at scale.
+
+#### Performance characteristics
+
+| Operation | Complexity | Backing Index |
+|-----------|-----------|---------------|
+| `checkpoints()` | O(checkpoints in session) | Partial JSONB GIN on `metadata->'checkpoint'` |
+| `getCheckpoint(label)` | O(log C) where C = checkpoints with this label in session | Same partial GIN, narrowed by `metadata->'checkpoint'->>'label'` equality |
+| `checkpointsByLabel(label)` | O(matches in session) | Same partial GIN |
+
+Even at 10,000-thought sessions with 100 checkpoints, retrieval is sub-millisecond — the partial index excludes non-checkpoint thoughts entirely from the lookup.
+
+### Integration with Hooks
+
+SessionStart hooks can be configured to fire when a session resumes after a specific checkpoint:
+
+```typescript
+// Hook configuration (external)
+{
+  trigger: "session_resume",
+  checkpoint: "auth-analysis-complete",  // Matches checkpoint label
+  action: "notify"
+}
+```
+
+---
+
+## Design Rationale
+
+### Making Illegal States Unrepresentable
+
+The branded `CheckpointLabel` type prevents illegal states from being represented:
+
+1. **Empty strings**: The regex requires at least 1 character
+2. **Mixed case**: Regex requires lowercase only
+3. **Spaces and special chars**: Only `a-z`, `0-9`, `-`, `_` allowed
+
+### Facilitating Useful States
+
+The branded type still allows all useful label patterns:
+
+- Semantic names: `auth-analysis-complete`, `database-schema-finalized`
+- Short identifiers: `step1`, `init`, `done`
+- Casing: `kebab-case` (recommended) and `snake_case` (allowed)
+
+### Why Runtime Validation Still Exists
+
+TypeScript's type system erases branded types at runtime. The `__brand` property exists only for type checking. Therefore:
+
+1. **Compile time**: TypeScript prevents assigning invalid strings to `CheckpointLabel`
+2. **Runtime**: `createCheckpointLabel()` validates and throws for invalid input
+
+This is a defense-in-depth approach: type system for developer ergonomics, runtime for safety.
+
+---
+
+## Validation
+
+1. **Type Safety**: `CheckpointLabel` only accepts strings matching `/^[a-z0-9][a-z0-9_-]*$/`
+2. **Thought Type**: Created thought has `thoughtType: "progress"`
+3. **Metadata Structure**: `metadata.checkpoint.label` is a valid `CheckpointLabel`
+4. **Metadata Structure**: `metadata.checkpoint.summary` exists only if summary was provided
+5. **Auto-Fields**: `thoughtNumber` is correctly auto-assigned, `createdAt` is server timestamp
+6. **Generic Retrieval**: Checkpoints appear in `tb.session.recentThoughts()` and `tb.session.searchWithin()` (general-purpose primitives)
+7. **Dedicated Retrieval — `checkpoints()`**: returns all checkpoints in the current session, ordered by `thought_number` ASC, sourced from the partial JSONB index, never returning non-checkpoint thoughts
+8. **Dedicated Retrieval — `getCheckpoint(label)`**: returns the oldest checkpoint with the matching label, or `null` if none
+9. **Dedicated Retrieval — `checkpointsByLabel(label)`**: returns all checkpoints with the matching label, oldest first
+10. **Index Used**: `EXPLAIN ANALYZE` on `checkpoints()` and `checkpointsByLabel()` queries shows GIN index usage on `(metadata -> 'checkpoint')` partial index
+11. **Multiple Checkpoints**: Multiple checkpoints with same label are allowed; all are retrievable via `checkpointsByLabel()`
+12. **Validation Error**: Invalid labels throw descriptive errors at creation time
+
+---
+
+## Implementation Notes
+
+### Backing Index (Postgres JSONB GIN, Partial)
+
+The dedicated retrieval primitives are backed by a partial GIN index on the checkpoint metadata. The `WHERE metadata ? 'checkpoint'` predicate makes the index size proportional to checkpoint count, not total thought count.
+
+```sql
+-- Migration: partial JSONB GIN index covering only checkpoint thoughts
+CREATE INDEX idx_thoughts_checkpoint
+  ON thoughts USING GIN ((metadata -> 'checkpoint'))
+  WHERE metadata ? 'checkpoint';
+```
+
+```sql
+-- Used by tb.session.checkpoints()
+SELECT thought_number, thought_type, thought, timestamp, metadata
+FROM thoughts
+WHERE session_id = $1
+  AND metadata ? 'checkpoint'
+ORDER BY thought_number ASC;
+
+-- Used by tb.session.getCheckpoint(label) and tb.session.checkpointsByLabel(label)
+SELECT thought_number, thought_type, thought, timestamp, metadata
+FROM thoughts
+WHERE session_id = $1
+  AND metadata -> 'checkpoint' ->> 'label' = $2
+ORDER BY thought_number ASC;
+```
+
+### Why JSONB Index, Not a Separate `session_checkpoints` Table
+
+A normalized `session_checkpoints` table with `(session_id, label, thought_number, summary, created_at)` would also work. We choose the JSONB approach for v1 because:
+
+- **Single source of truth** — the thought *is* the checkpoint, not a separate row referencing it. No dual-write consistency to maintain.
+- **No schema migration beyond the index** — adding the index is one DDL statement; a separate table requires migrations, foreign keys, and ON DELETE cascades to keep the two stores in sync.
+- **Adequate for in-session retrieval** — the partial GIN index meets the performance targets (sub-millisecond) for any realistic session size.
+
+If a future use case demands cross-session checkpoint search at scale (e.g., "find every `auth-complete` checkpoint across the corpus"), a separate `session_checkpoints` table or materialized view becomes the right answer at that point. Don't pre-build it.
+
+### Zod Schema
+
+```typescript
+const CheckpointLabelSchema = z
+  .string()
+  .regex(/^[a-z0-9][a-z0-9_-]*$/, {
+    message:
+      "Checkpoint label must match /^[a-z0-9][a-z0-9_-]*$/: " +
+      "lowercase alphanumeric, starting with letter or digit, " +
+      "with hyphens and underscores allowed",
+  })
+  .min(1, "Checkpoint label cannot be empty");
+```
+
+### TypeScript Utility Type
+
+```typescript
+/**
+ * Utility type to extract the branded CheckpointLabel from any string
+ * that has been validated at runtime.
+ */
+declare const __brand: unique symbol;
+type Brand<T, B> = T & { readonly [__brand]: B };
+
+type CheckpointLabel = Brand<string, "CheckpointLabel">;
+```

--- a/.specs/cognitive-harness-improvements/10-knowledge-graph-persistence.md
+++ b/.specs/cognitive-harness-improvements/10-knowledge-graph-persistence.md
@@ -1,0 +1,299 @@
+# Spec: Knowledge Graph Persistence Shortcut
+
+## Title
+Auto-Persistence of Beliefs and Assumptions via Thought Metadata
+
+## Status
+Draft
+
+## Target State
+
+### Where `persistAs` Lives in the Type Hierarchy
+
+`persistAs` is **not** a field on the canonical `ThoughtInput` defined in Spec 01. It is added only on the discriminated subtypes that semantically support automatic knowledge-graph persistence — `BeliefSnapshotInput` and `AssumptionUpdateInput`. The full hierarchy looks like:
+
+```typescript
+/**
+ * Spec 01's canonical client input type. `persistAs` is NOT defined here.
+ */
+interface ThoughtInput {
+  thought: string;
+  thoughtType: ThoughtType;
+  nextThoughtNeeded: boolean;
+  thoughtNumber?: never;   // server-assigned per Spec 01
+  timestamp?: never;       // server-assigned per Spec 01
+  // ... other base client-provided fields
+}
+
+/**
+ * Discriminated subtypes by `thoughtType`. `persistAs` appears only on
+ * BeliefSnapshotInput and AssumptionUpdateInput. Sending `persistAs` on
+ * any other thoughtType is rejected at request time with VALIDATION_ERROR.
+ */
+type TypedThoughtInput =
+  | ReasoningInput
+  | DecisionFrameInput            // see Spec 07
+  | ActionReportInput
+  | BeliefSnapshotInput            // ← carries persistAs
+  | AssumptionUpdateInput          // ← carries persistAs
+  | ContextSnapshotInput
+  | ProgressInput;
+```
+
+`persistAs` is **structurally scoped** to thought types where automatic KG persistence is semantically meaningful. Future specs that want to extend it to other types should add the field to those discriminated subtypes explicitly — do not promote it to the base `ThoughtInput`.
+
+### `persistAs` Field on the Supporting Thought Types
+
+```typescript
+interface BeliefSnapshotInput extends ThoughtInput {
+  thoughtType: "belief_snapshot";
+  beliefs: BeliefSchema;  // existing per Spec 01
+
+  /**
+   * If provided, automatically creates a knowledge graph entity
+   * representing this belief.
+   */
+  persistAs?: PersistAsConfig;
+}
+
+interface AssumptionUpdateInput extends ThoughtInput {
+  thoughtType: "assumption_update";
+  assumptionChange: AssumptionChangeSchema;  // existing per Spec 01
+
+  /**
+   * If provided, automatically creates/updates a knowledge graph entity
+   * representing this assumption. Entity type follows the selection
+   * criterion below (Concept vs Decision).
+   */
+  persistAs?: AssumptionPersistAsConfig;
+}
+
+/**
+ * Configuration for persisting a belief as a KG entity.
+ */
+interface PersistAsConfig {
+  name: string;              // Entity name in knowledge graph
+  visibility?: Visibility;   // Defaults to "agent-private"
+  relationTo?: string;      // Optional: existing entity ID to link via BUILDS_ON
+}
+
+/**
+ * Configuration for persisting an assumption as a KG entity.
+ * Extends PersistAsConfig with assumption-specific options.
+ */
+interface AssumptionPersistAsConfig extends PersistAsConfig {
+  /**
+   * The previous assumption status for change tracking.
+   */
+  previousStatus?: "believed" | "uncertain" | "refuted";
+}
+```
+
+### Visibility Type
+
+```typescript
+type Visibility = "public" | "agent-private" | "user-private" | "team-private";
+```
+
+### Automatic Entity Creation
+
+When `persistAs` is provided:
+
+1. A knowledge graph entity is created (or updated for `assumption_update`)
+2. Entity type follows the criterion below
+3. Entity label: from `persistAs.name`
+4. An observation is added referencing the thought
+5. If `relationTo` is provided, a `BUILDS_ON` relation is created to the referenced entity
+
+#### Entity Type Selection Criterion
+
+| Source thought type | `persistAs` context | Resulting KG entity type |
+|---------------------|---------------------|--------------------------|
+| `belief_snapshot` | always | `"Concept"` |
+| `assumption_update` with `assumptionChange.newStatus === "refuted"` | any | `"Decision"` |
+| `assumption_update` from a thought reachable from a committed `decision_frame` (i.e., `decisionState: "committed"` exists earlier in the same session, with the assumption logically downstream of that decision per `assumptionChange.downstream` references) | any | `"Decision"` |
+| `assumption_update` otherwise (status changes among `believed`/`uncertain`, no committed decision dependency) | any | `"Concept"` |
+
+Rationale: `Decision` denotes an entity that records a chosen-among-alternatives commitment. A refuted assumption is itself a decision (we have decided this is no longer believed). An assumption that lives downstream of a committed decision inherits decision-shape because it's part of the decision's surface. All other beliefs and assumptions are general concepts.
+
+The selection is computed server-side from the thought's content and prior session state; callers do not specify the entity type directly through `persistAs`.
+
+### Usage Examples
+
+```typescript
+// Belief with automatic KG persistence
+await tb.thought({
+  thought: "PostgreSQL provides ACID guarantees essential for financial data.",
+  thoughtType: "belief_snapshot",
+  nextThoughtNeeded: true,
+  persistAs: {
+    name: "PostgreSQL-ACID-suitability",
+    visibility: "team-private"
+  }
+});
+
+// Assumption update that builds on existing entity
+await tb.thought({
+  thought: "The user's role determines which data they can access.",
+  thoughtType: "assumption_update",
+  nextThoughtNeeded: false,
+  persistAs: {
+    name: "RBAC-assumption",
+    relationTo: "auth-module-entity-id"
+  }
+});
+```
+
+### Knowledge Graph Entity Structure
+
+```typescript
+// Created entity structure
+interface KGEntity {
+  id: string;
+  name: string;         // e.g., "PostgreSQL-ACID-suitability"
+  type: "Concept";      // or "Decision" for assumptions
+  label: string;
+  visibility: Visibility;
+  created_by: "agent";
+  observations: Array<{
+    id: string;
+    content: string;    // The thought content
+    source_session: string;
+    source_thought: number;  // Thought number
+    added_at: string;   // ISO timestamp
+  }>;
+}
+```
+
+### Error Handling: Making Illegal States Explicit
+
+When KG persistence fails, the thought is still submitted successfully, but the failure is captured explicitly:
+
+```typescript
+/**
+ * Error codes for KG persistence failures.
+ * These make the failure state explicit and queryable.
+ */
+type KGPersistErrorCode =
+  | "ENTITY_NAME_CONFLICT"    // Entity with this name already exists
+  | "RELATION_TARGET_NOT_FOUND" // relationTo references non-existent entity
+  | "VISIBILITY_DENIED"       // Insufficient permissions for requested visibility
+  | "STORAGE_ERROR"           // Underlying storage failure
+  | "UNKNOWN_ERROR";         // Unexpected failure
+
+/**
+ * Detailed error information captured when KG persistence fails.
+ * This is stored on the thought's metadata for debugging/auditing.
+ */
+interface KGPersistError {
+  code: KGPersistErrorCode;
+  message: string;           // Human-readable error description
+  details?: {
+    attemptedName?: string;   // The name we tried to create
+    attemptedRelationTo?: string; // The entity ID we tried to link
+    existingEntityId?: string; // If conflict, the existing entity
+  };
+  timestamp: string;         // When the error occurred (ISO 8601)
+}
+
+/**
+ * Thought metadata with explicit KG persistence status.
+ */
+interface ThoughtMetadata {
+  // ... other metadata fields
+  kgPersistError?: KGPersistError;  // Present ONLY if KG persistence failed
+  kgPersistSuccess?: {
+    entityId: string;        // ID of created/updated entity
+    entityName: string;      // Name of created/updated entity
+    timestamp: string;       // When persistence succeeded
+  };
+}
+```
+
+### Behavior on Failure
+
+```typescript
+async function processThoughtWithPersist(input: ThoughtInput): Promise<Thought> {
+  // First, save the thought (this always succeeds or throws)
+  const thought = await saveThought(input);
+
+  // Then attempt KG persistence (may fail)
+  if (input.persistAs) {
+    try {
+      const entity = await createKGEntity(input.persistAs, thought);
+      thought.metadata.kgPersistSuccess = {
+        entityId: entity.id,
+        entityName: entity.name,
+        timestamp: new Date().toISOString()
+      };
+    } catch (error) {
+      // Capture the error but don't fail the thought
+      thought.metadata.kgPersistError = {
+        code: categorizeError(error),
+        message: error.message,
+        details: extractDetails(error),
+        timestamp: new Date().toISOString()
+      };
+      logger.warn("KG persistence failed", thought.metadata.kgPersistError);
+    }
+  }
+
+  return thought;
+}
+```
+
+### Querying Persistence Status
+
+```typescript
+// Find all thoughts where KG persistence succeeded
+const successful = session.thoughts.filter(t => t.metadata.kgPersistSuccess);
+
+// Find all thoughts where KG persistence failed
+const failed = session.thoughts.filter(t => t.metadata.kgPersistError);
+
+// Get thoughts with specific error code
+const conflicts = session.thoughts.filter(
+  t => t.metadata.kgPersistError?.code === "ENTITY_NAME_CONFLICT"
+);
+```
+
+---
+
+## Design Rationale
+
+### Making Illegal States Explicit (Not Preventing Them)
+
+Unlike other specs where we make illegal states **unrepresentable**, KG persistence failures are **inherently possible** (network issues, name conflicts, permissions). Instead of preventing them, we:
+
+1. **Make them explicit** via `kgPersistError` metadata
+2. **Make them queryable** via structured error codes
+3. **Make them non-blocking** - thought submission succeeds regardless
+
+### Facilitating Useful States
+
+The `persistAs` shortcut enables:
+
+- **Effortless knowledge capture**: `persistAs: { name: "my-insight" }` instead of separate API calls
+- **Automatic linking**: `relationTo` creates `BUILDS_ON` relations automatically
+- **Visibility control**: Per-entity visibility without separate API calls
+
+### Error as Data
+
+By storing `kgPersistError` on the thought metadata, we treat the error as **data** rather than just an exception to catch. This enables:
+- Debugging: "Why didn't my entity get created?"
+- Auditing: "Which entities failed to create?"
+- Recovery: "I can retry creation for failed entities later"
+
+---
+
+## Validation
+
+1. **Entity Creation**: `belief_snapshot` with `persistAs` creates a knowledge graph entity
+2. **Entity Creation**: `assumption_update` with `persistAs` creates a knowledge graph entity
+3. **Observation Link**: Created entity includes observation referencing the source thought
+4. **Relation**: `relationTo` field creates a `BUILDS_ON` relation to specified entity
+5. **Visibility**: Entity respects `visibility` option (defaults to `"agent-private"`)
+6. **Thought Success**: Thought submission succeeds even if KG creation fails
+7. **Error Metadata**: Failed KG creation populates `metadata.kgPersistError` with structured error
+8. **Success Metadata**: Successful KG creation populates `metadata.kgPersistSuccess`
+9. **Error Queryability**: Error codes allow filtering/finding failed persist operations

--- a/.specs/cognitive-harness-improvements/11-structured-return-schemas.md
+++ b/.specs/cognitive-harness-improvements/11-structured-return-schemas.md
@@ -1,0 +1,309 @@
+# Spec: Structured Return Schemas
+
+## Title
+Schema-Validated Structured Output for Subagent Dispatch
+
+## Status
+Draft
+
+## Related Specs
+
+- **Spec 04 (Subagent Session Attachment)**: this spec is a coupled deliverable with Spec 04. Spec 11 describes how subagent output is *shaped and validated* against an `expectedReturn` schema; Spec 04 describes how the validated output *lands in the parent's reasoning session* via `tb.subagent.attach()`. Implementations should ship them together — Spec 11 without Spec 04 is a validator with nowhere to deliver, and Spec 04 without Spec 11 forces the parent to re-extract structured facts from prose (the friction this whole pair is designed to remove).
+- **Spec 10 (Knowledge Graph Persistence)**: when validated subagent output is attached with an `entityName`, the resulting KG entity follows Spec 10's persistence and error model.
+
+## Target State
+
+### Subagent Dispatch with Expected Return Schema
+
+The subagent dispatch operation accepts an `expectedReturn` JSON Schema:
+
+```typescript
+interface SubagentDispatchInput {
+  prompt: string;
+  expectedReturn?: {
+    schema: JSONSchema;
+    description?: string;
+  };
+}
+
+// Usage
+const result = await tb.subagent.run({
+  prompt: "Analyze this error and return structured findings.",
+  expectedReturn: {
+    schema: {
+      type: "object",
+      properties: {
+        rootCause: { type: "string" },
+        severity: { type: "string", enum: ["low", "medium", "high"] },
+        affectedComponents: { type: "array", items: { type: "string" } }
+      },
+      required: ["rootCause", "severity"]
+    },
+    description: "Bug analysis structured output"
+  }
+});
+```
+
+### Structured Output Validation
+
+Before attaching subagent output to the session:
+
+1. The subagent output is parsed as JSON (or extracted from structured delimiters if configured)
+2. The parsed output is validated against the `expectedReturn.schema`
+3. If validation fails, the output is rejected with a `StructuredOutputError`
+
+### Complete Error Type Definition
+
+```typescript
+/**
+ * Error thrown when subagent output fails schema validation.
+ * This is a discriminated union error type for type-safe error handling.
+ */
+interface StructuredOutputError {
+  readonly type: "structured_output_error";  // Discriminant for type narrowing
+
+  /**
+   * Human-readable error message.
+   */
+  readonly message: string;
+
+  /**
+   * The original subagent output that failed validation.
+   * Useful for debugging and retry logic.
+   */
+  readonly rawOutput: string;
+
+  /**
+   * Detailed validation errors for each field that failed.
+   */
+  readonly validationErrors: readonly ValidationError[];
+
+  /**
+   * The JSON Schema that the output was validated against.
+   */
+  readonly expectedSchema: JSONSchema;
+
+  /**
+   * Timestamp when validation failed.
+   */
+  readonly timestamp: string;  // ISO 8601
+
+  /**
+   * Optional parsing error details.
+   * Present when the output couldn't be parsed as JSON.
+   */
+  readonly parsingError?: ParsingError;
+}
+
+/**
+ * Detailed error for a single validation failure.
+ */
+interface ValidationError {
+  /**
+   * JSON path to the invalid field.
+   * Format: "$.rootCause" or "$.items[0].name"
+   */
+  readonly path: string;
+
+  /**
+   * The expected type or format per the schema.
+   */
+  readonly expected: string;
+
+  /**
+   * The actual value that was received.
+   * Stored as unknown since it may not match expected type.
+   */
+  readonly received: unknown;
+
+  /**
+   * Optional reason for the failure.
+   * Examples: "must be string", "must match pattern /^[A-Z]$/"
+   */
+  readonly reason?: string;
+}
+
+/**
+ * Error details when JSON parsing failed.
+ */
+interface ParsingError {
+  /**
+   * Error message from the parser.
+   */
+  readonly message: string;
+
+  /**
+   * Character offset where parsing failed (if available).
+   */
+  readonly offset?: number;
+
+  /**
+   * Line and column where parsing failed (if available).
+   */
+  readonly line?: number;
+  readonly column?: number;
+}
+
+/**
+ * Success result type for validated structured output.
+ */
+interface ValidatedOutput<T> {
+  readonly success: true;
+  readonly data: T;  // Parsed and validated JSON, typed as T
+  readonly schema: JSONSchema;
+  readonly validatedAt: string;  // ISO 8601
+}
+```
+
+### Behavior on Validation Failure
+
+When structured output validation fails:
+
+```typescript
+try {
+  const result = await tb.subagent.run({
+    prompt: "Return a JSON object with fields x and y",
+    expectedReturn: {
+      schema: {
+        type: "object",
+        properties: {
+          x: { type: "string" },
+          y: { type: "number" }
+        },
+        required: ["x", "y"]
+      }
+    }
+  });
+  // result is ValidatedOutput<{x: string; y: number}>
+  await tb.subagent.attach(result.data);
+} catch (error) {
+  if (error.type === "structured_output_error") {
+    // Type-safe access to error details
+    console.error(`Validation failed: ${error.message}`);
+    console.error(`Raw output: ${error.rawOutput}`);
+
+    for (const ve of error.validationErrors) {
+      console.error(`  - ${ve.path}: expected ${ve.expected}, got ${JSON.stringify(ve.received)}`);
+    }
+
+    // Handle specific error codes if needed
+    if (error.parsingError) {
+      console.error(`Parse error at ${error.parsingError.line}:${error.parsingError.column}`);
+    }
+  }
+  throw error;
+}
+```
+
+### Success Path
+
+On successful validation:
+
+```typescript
+const result = await tb.subagent.run({
+  prompt: "Analyze the codebase and return metrics",
+  expectedReturn: {
+    schema: {
+      type: "object",
+      properties: {
+        fileCount: { type: "number" },
+        totalLines: { type: "number" },
+        languages: { type: "array", items: { type: "string" } }
+      },
+      required: ["fileCount", "totalLines"]
+    }
+  }
+});
+
+// result is ValidatedOutput<{fileCount: number; totalLines: number; languages?: string[]}>
+if (result.success) {
+  // TypeScript knows data is validated
+  const { fileCount, totalLines, languages } = result.data;
+
+  // Attach to session with validated data
+  await tb.subagent.attach({
+    content: JSON.stringify(result.data),
+    summary: `Codebase analysis: ${fileCount} files, ${totalLines} lines`,
+    metadata: result.data
+  });
+}
+```
+
+### Schema Validation Implementation
+
+- Uses JSON Schema draft-07 for validation
+- Supports all standard JSON Schema keywords
+- Custom keywords are NOT supported
+
+---
+
+## Design Rationale
+
+### Type-Safe Error Handling
+
+The `StructuredOutputError` interface is designed for **type-safe error handling**:
+
+1. **`type: "structured_output_error"` discriminant**: Enables type narrowing with `if (error.type === "structured_output_error")`
+2. **Readonly fields**: Errors should be immutable once thrown
+3. **Detailed `validationErrors`**: Each failure is captured with path, expected, received, and optional reason
+4. **Optional `parsingError`**: When JSON parsing fails, we capture parser details (offset, line, column)
+
+### Making Errors Explicit and Actionable
+
+The structured error allows agents to:
+
+- **Debug**: See exactly which field failed and what was expected
+- **Retry intelligently**: Know if the failure was parsing (bad JSON) vs validation (wrong structure)
+- **Report accurately**: Line/column info helps pinpoint where in the output the problem is
+
+### Facilitating Useful States
+
+The `ValidatedOutput<T>` success type:
+- Carries the **typed data** after validation (`data: T`)
+- Includes the **schema** for reference
+- Includes **validation timestamp** for debugging
+
+---
+
+## Validation
+
+1. **Schema Acceptance**: `expectedReturn.schema` accepts valid JSON Schema objects
+2. **Validation Success**: Valid output matching schema is returned as `ValidatedOutput<T>`
+3. **Validation Failure**: Output not matching schema throws `StructuredOutputError`
+4. **Error Detail**: `StructuredOutputError.validationErrors` contains path, expected, and received for each failure
+5. **No Attachment on Failure**: Output that fails validation is NOT attached to session
+6. **JSON Parsing**: Non-JSON output that cannot be parsed throws `StructuredOutputError` with `parsingError`
+7. **Success Attachment**: Validated output can be successfully attached via `tb.subagent.attach()`
+8. **Type Narrowing**: `error.type === "structured_output_error"` enables type-safe error handling
+
+---
+
+## Implementation Notes
+
+### Zod Schema for Error Types
+
+```typescript
+const ValidationErrorSchema = z.object({
+  path: z.string(),
+  expected: z.string(),
+  received: z.unknown(),
+  reason: z.string().optional(),
+});
+
+const ParsingErrorSchema = z.object({
+  message: z.string(),
+  offset: z.number().optional(),
+  line: z.number().optional(),
+  column: z.number().optional(),
+});
+
+const StructuredOutputErrorSchema = z.object({
+  type: z.literal("structured_output_error"),
+  message: z.string(),
+  rawOutput: z.string(),
+  validationErrors: z.array(ValidationErrorSchema),
+  expectedSchema: z.any(), // JSON Schema is complex, use z.any() for flexibility
+  timestamp: z.string(),
+  parsingError: ParsingErrorSchema.optional(),
+});
+```

--- a/.specs/cognitive-harness-improvements/TYPE-SYSTEM-PRINCIPLES.md
+++ b/.specs/cognitive-harness-improvements/TYPE-SYSTEM-PRINCIPLES.md
@@ -1,0 +1,254 @@
+# Type System Principles Applied to Cognitive Harness Specs
+
+This document summarizes the type system refinements applied across the cognitive-harness-improvements specs, organized by principle.
+
+---
+
+## Principle 1: Making Illegal States Unrepresentable
+
+### Definition
+Use the type system to prevent invalid states from being representable in code. If a state is illegal, the type system should make it impossible to construct.
+
+### Applications
+
+#### Spec 01: Auto-Numbering Surfacing
+**Problem**: `thoughtNumber` was typed as optional (`number | undefined`) allowing clients to attempt to set it.
+
+**Solution**: Use `never` type to forbid the field entirely in client input types:
+```typescript
+interface ThoughtInput {
+  thoughtNumber?: never;  // Cannot be set by client
+  timestamp?: never;      // Cannot be set by client
+}
+```
+TypeScript will now error if any code attempts to set `thoughtNumber`.
+
+#### Spec 07: Deliberation Without Commitment
+**Problem**: `options: Array<{ label: string; selected: boolean }>` allowed multiple options to have `selected: true`.
+
+**Solution**: Use discriminated union to make multiple selections impossible:
+```typescript
+type DecisionOption = 
+  | { label: string; selected?: false }
+  | { label: string; selected: true; reason?: string };
+```
+Now TypeScript prevents code like:
+```typescript
+// COMPILE ERROR - can't have two selected: true:
+const options: DecisionOption = [
+  { label: "A", selected: true },
+  { label: "B", selected: true }  // Error!
+];
+```
+
+#### Spec 06: Cipher Mode Toggle
+**Problem**: `cipherMode: "off"` could be overridden by per-thought `cipher: true`, making "off" not actually mean "off".
+
+**Solution**: Make per-thought `cipher` flag conditionally effective only in `"manual"` mode:
+```typescript
+type EffectiveCipherDecision =
+  | { decision: "cipher"; reason: "auto_signal" | "manual_request" }
+  | { decision: "skip"; reason: "auto_signal_clear" | "manual_opt_out" | "mode_off" };
+```
+When `cipherMode === "off"`, the per-thought flag is ignored. This makes the semantics consistent.
+
+#### Spec 09: Named Checkpoints
+**Problem**: Labels were plain `string`, allowing empty strings, spaces, uppercase, etc.
+
+**Solution**: Use branded type with validation:
+```typescript
+type CheckpointLabel = string & {
+  readonly __brand: "CheckpointLabel";
+  readonly __pattern: /^[a-z0-9][a-z0-9_-]*$/;
+};
+```
+Now only URL-safe lowercase labels are valid.
+
+---
+
+## Principle 2: Facilitating Representation of Useful States
+
+### Definition
+Ensure that valid, useful states ARE representable and ergonomically expressible. The type system should guide developers toward correct usage.
+
+### Applications
+
+#### Spec 02: Terse Shorthand (`tb.t()` and `tb.end()`)
+**Enhancement**: Added explicit return types:
+```typescript
+interface TB {
+  t(content: string): Promise<ThoughtResult>;
+  end(content: string): Promise<ThoughtResult>;
+}
+```
+Clear return types help developers understand what they get back.
+
+#### Spec 03: Mid-Session Recall Primitives
+**Enhancement**: Added `readonly` to return arrays:
+```typescript
+recentThoughts(count?: number): Promise<readonly Thought[]>;
+searchWithin(query: string, options?: SearchWithinOptions): Promise<readonly Thought[]>;
+```
+`readonly` arrays prevent accidental mutation of session data.
+
+#### Spec 04: Subagent Session Attachment
+**Enhancement**: Complete type definitions for `SubagentOutput`:
+```typescript
+interface SubagentOutput {
+  content: string;
+  summary?: string;
+  metadata?: Readonly<Record<string, unknown>>;
+  completedAt: string;
+  durationMs?: number;
+  model?: string;
+}
+```
+Explicit fields with `Readonly` metadata prevent mutation.
+
+#### Spec 08: Per-Session Type Audit
+**Enhancement**: Define `SessionType` as a closed union:
+```typescript
+type SessionType = 
+  | "research" 
+  | "decision" 
+  | "implementation" 
+  | "debugging" 
+  | "exploration";
+```
+Closed unions prevent typos and invalid combinations.
+
+#### Spec 11: Structured Return Schemas
+**Enhancement**: Complete `ValidatedOutput<T>` success type:
+```typescript
+interface ValidatedOutput<T> {
+  readonly success: true;
+  readonly data: T;
+  readonly schema: JSONSchema;
+  readonly validatedAt: string;
+}
+```
+Typed data makes working with validated output ergonomic.
+
+---
+
+## Principle 3: Explicit Error States
+
+### Definition
+When errors CAN occur, make them explicit and typed rather than implicit and unstructured.
+
+### Applications
+
+#### Spec 10: Knowledge Graph Persistence
+**Enhancement**: Structured `KGPersistError`:
+```typescript
+interface KGPersistError {
+  code: KGPersistErrorCode;
+  message: string;
+  details?: {
+    attemptedName?: string;
+    attemptedRelationTo?: string;
+    existingEntityId?: string;
+  };
+  timestamp: string;
+}
+
+type KGPersistErrorCode =
+  | "ENTITY_NAME_CONFLICT"
+  | "RELATION_TARGET_NOT_FOUND"
+  | "VISIBILITY_DENIED"
+  | "STORAGE_ERROR"
+  | "UNKNOWN_ERROR";
+```
+Error codes enable programmatic handling and querying.
+
+#### Spec 11: Structured Return Schemas
+**Enhancement**: Complete `StructuredOutputError`:
+```typescript
+interface StructuredOutputError {
+  readonly type: "structured_output_error";  // Discriminant
+  readonly message: string;
+  readonly rawOutput: string;
+  readonly validationErrors: readonly ValidationError[];
+  readonly expectedSchema: JSONSchema;
+  readonly timestamp: string;
+  readonly parsingError?: ParsingError;
+};
+```
+The `type` discriminant enables type-safe error handling.
+
+---
+
+## Principle 4: Type Hierarchy Separation
+
+### Definition
+Client input types and server output types have different constraints. They should NOT inherit from each other.
+
+### Application
+
+#### Spec 01: Auto-Numbering Surfacing
+**Problem**: `ThoughtInput extends ThoughtData` where `ThoughtData` has required `thoughtNumber` and `timestamp`.
+
+**Solution**: Separate the hierarchies:
+```typescript
+// Client input - server-assigned fields are forbidden
+interface ThoughtInput {
+  thoughtNumber?: never;  // Not allowed
+  timestamp?: never;     // Not allowed
+  // ... client-provided fields
+}
+
+// Server output - server-assigned fields are required
+interface Thought extends ThoughtInput {
+  thoughtNumber: number;   // Always present
+  timestamp: string;       // Always present
+}
+```
+`ThoughtInput` is NOT an extension of `Thought`.
+
+---
+
+## Principle 5: Explicit Return Types
+
+### Definition
+Methods should explicitly declare their return types rather than relying on inference. This documents intent and catches mismatches.
+
+### Application
+
+#### Spec 05: Hook Suppression
+```typescript
+interface SessionOperations {
+  isActive(): Promise<boolean>;  // Explicit!
+}
+```
+
+#### Spec 03: Recall Primitives
+```typescript
+getThought(n: number): Promise<Thought | null>;  // null is explicit
+recentThoughts(count?: number): Promise<readonly Thought[]>;  // readonly is explicit
+```
+
+---
+
+## Summary Table
+
+| Spec | Principle | Technique | Illegal State Prevented |
+|------|-----------|-----------|------------------------|
+| 01 | Unrepresentable | `?: never` | Client setting server fields |
+| 01 | Type Separation | Separate interfaces | `ThoughtInput extends ThoughtData` |
+| 06 | Unrepresentable | Conditional effectiveness | `"off"` + `cipher: true` contradiction |
+| 07 | Unrepresentable | Discriminated union | Multiple selected options |
+| 08 | Facilitating | Closed union | Invalid session types |
+| 09 | Unrepresentable | Branded type + regex | Invalid checkpoint labels |
+| 10 | Explicit Errors | Structured error codes | Untyped KG persistence failures |
+| 11 | Explicit Errors | Discriminated error type | Untyped validation failures |
+
+---
+
+## Implementation Priority
+
+1. **Spec 01** (Foundational): Separates input/output types - should be implemented first
+2. **Spec 07** (High Impact): Prevents invalid decision states at compile time
+3. **Spec 06** (Semantic Fix): Resolves contradictory cipher mode behavior
+4. **Spec 09** (Quality of Life): Enforces naming conventions via types
+5. **Spec 08** (Audit Enhancement): Closed union for session types
+6. **Spec 10/11** (Error Handling): Structured error types for better debugging

--- a/.specs/cognitive-harness-improvements/VALIDATORS.md
+++ b/.specs/cognitive-harness-improvements/VALIDATORS.md
@@ -1,0 +1,249 @@
+# Validator Design — Cognitive Harness Improvements
+
+> **Companion to**: SPEC-CHX-001 and the eleven per-feature specs in this directory.
+> **Purpose**: Translate each spec's plain-English `Validation` section into deterministic,
+> code-based checks that can be wired into CI. A spec is "done" iff every validator below
+> passes against the impacted code.
+> **Provenance**: Designed in Thoughtbox session
+> `5131bd58-5d09-45ca-b2fd-6dcfa7846bdc` (16 thoughts, 1 assumption flip).
+
+---
+
+## 1. What counts as a validator
+
+A validator in this catalog must be:
+
+1. **Deterministic** — same input, same code, same answer every run. No reliance on a
+   live LLM, no flaky network, no clock-of-the-wall comparisons. Time and randomness are
+   injected, not observed.
+2. **Mechanical** — a post-condition over an artifact (a file's AST, a Zod parse result,
+   a SQL plan, a DB row, a JSON snapshot). No "agent submits 80%+ of thoughts via tb.t" —
+   that's product validation, not engineering acceptance.
+3. **Self-contained** — runnable from `pnpm test` (or one extra `pnpm exec` step for
+   `tsd`) without manual setup beyond `docker compose up postgres`.
+4. **Fails loudly on regression** — when the impacted code drifts back, the validator
+   surfaces the drift with a pointer to the spec section that defined the invariant.
+
+**The master spec's `Validation` section in `SPEC-CHX-001-cognitive-harness-improvements.md`
+is intentionally behavioral** ("agent submits 100+ thoughts without dup-key errors").
+Those are end-of-pipeline observations from a future reasoning session. The validators
+here are the *engineering* counterparts — they prove the *mechanism* is in place that
+would *cause* the behavior.
+
+---
+
+## 2. Validator categories
+
+| Category | Tool | What it checks |
+|----------|------|----------------|
+| **TS-FIXTURE** | `tsd` for `// @ts-expect-error` blocks; `expect-type` for runtime-friendly type asserts | Compile-time invariants — `?: never`, branded types, discriminated-union narrowing |
+| **ZOD** | vitest + the existing Zod schemas | Schema-level accept/reject of representative payloads |
+| **HANDLER** | vitest against the in-process handler with a real Postgres test DB (`docker compose up postgres-test`) | Persisted shape, side effects, error metadata |
+| **DB-PLAN** | vitest + `EXPLAIN (FORMAT JSON)` against seeded data | The intended index appears in the query plan |
+| **CATALOG** | vitest snapshot over `thoughtbox_search` catalog and `TB_SDK_TYPES` string | The SDK surface and Code Mode catalog match the spec |
+| **DOC-AUDIT** | `rg` invoked from a vitest test | No stale examples / no use of discouraged patterns |
+| **PURE-FN** | vitest table tests | Reference functions like `getEffectiveCipherDecision` are total over their input space |
+
+The first time a tooling choice appears (e.g. `tsd` for type fixtures), use it for every
+TS-FIXTURE entry that follows. Don't relitigate per-spec.
+
+**Recommended layout**: validators live next to their target module under
+`__tests__/spec-<NN>-*.test.ts` (or `.test-d.ts` for type fixtures). Cross-cutting
+validators live in `src/__tests__/cross-cutting/`.
+
+---
+
+## 3. Per-spec validator catalog
+
+Each entry is shaped:
+
+> **`Vn.k`** — *CATEGORY* — **target**: `path` — **check**: one sentence — **pass**: observable post-condition.
+
+### Spec 01 — Auto-Numbering Surfacing
+
+- **`V1.1`** — TS-FIXTURE — target: `src/code-mode/__tests__/spec-01-types.test-d.ts` — check: a `ThoughtInput` literal containing `thoughtNumber: 5` has a `// @ts-expect-error` comment that `tsd` accepts — pass: `pnpm exec tsd` exits 0; the same fixture without the field type-checks clean.
+- **`V1.2`** — ZOD — target: `src/thought/tool.ts` `thoughtToolInputSchema` — check: schema is `.strict()` (or `thoughtNumber` is removed from the `z.object` shape entirely) — pass: `safeParse({...thoughtNumber:5}).success === false` with `code: 'unrecognized_keys'` (strict) or the field is absent from `schema.shape`.
+- **`V1.3`** — TS-FIXTURE / AST-grep — target: `src/code-mode/sdk-types.ts`, `src/persistence/types.ts` — check: no `interface ThoughtInput extends Thought` or `extends ThoughtData` declaration — pass: `ast-grep --pattern 'interface ThoughtInput extends $X' --lang ts` returns no matches in either file.
+- **`V1.4`** — DOC-AUDIT — target: `src/`, `docs/`, `.claude/skills/`, `apps/`, excluding `**/__tests__/**` and `**/spec-01*` — check: no doc or example sets `thoughtNumber: 1` (or any literal) on a thought submission — pass: `rg -n 'thoughtNumber\s*:\s*\d+'` returns zero matches outside the allowlist.
+- **`V1.5`** — HANDLER — target: `src/thought-handler.ts` — check: every persisted thought returned from `processThought` carries non-null `thoughtNumber: number` and `timestamp: string` regardless of input — pass: 100 randomized submissions all surface both fields populated; submissions that pass `thoughtNumber` explicitly are rejected with HTTP-400-equivalent error.
+
+### Spec 02 — Terse Shorthand & Chain API
+
+- **`V2.1`** — HANDLER — target: `src/code-mode/execute-tool.ts` — check: `tb.t('x')` and `tb.thought({thought:'x',thoughtType:'reasoning',nextThoughtNeeded:true})` produce byte-identical handler input — pass: spy on the handler resolves both calls with deep-equal payloads (modulo non-deterministic id/timestamp fields).
+- **`V2.2`** — HANDLER — target: chain object — check: each `chain.t()` / `chain.end()` / `chain.thought()` call results in exactly one `INSERT` into `thoughts` — pass: storage spy count == call count; no client-side buffering observable.
+- **`V2.3`** — HANDLER — target: chain GC behavior — check: a chain reference dropped after one `chain.t()` does not lose the persisted thought — pass: `tb.session.recent(sessionId, 1)` returns the dropped chain's thought.
+- **`V2.4`** — HANDLER — target: `ChainClosedError` — check: `chain.end()` then `chain.t()` throws — pass: error `instanceof ChainClosedError`, `error.attemptedOperation === 't'`, `error.sessionId` matches.
+- **`V2.5`** — HANDLER — target: server-side auto-numbering under concurrency — check: two chains writing 5 thoughts each in parallel produce 10 thoughts with strictly increasing `thought_number`, no duplicates — pass: `SELECT array_agg(thought_number ORDER BY thought_number)` returns `[1..10]` with no gaps.
+- **`V2.6`** — HANDLER — target: factory defaults — check: `tb.think()` / `tb.decide()` / `tb.research()` create sessions with `sessionType` `exploration` / `decision` / `research` respectively — pass: `SELECT session_type FROM sessions WHERE id=$1` matches expected for each factory.
+- **`V2.7`** — CATALOG — target: `catalog.operations.session` and `TB_SDK_TYPES` string — check: `t`, `end`, `openChain`, `think`, `decide`, `research` are advertised — pass: snapshot test of `Object.keys(catalog.operations.session)` and `TB_SDK_TYPES.includes('t(content: string)')`.
+
+### Spec 03 — Mid-Session Recall Primitives
+
+- **`V3.1`** — HANDLER — target: `session_get_thought` handler — check: in-bounds returns the thought; out-of-bounds returns `null`, **never throws** — pass: `getThought(sessionId, 5)` returns the thought, `getThought(sessionId, 99)` returns `null`.
+- **`V3.2`** — HANDLER — target: `session_recent_thoughts` — check: ordering is **oldest-to-newest within slice** — pass: write thoughts 1..20, `recentThoughts(5)` returns `thoughtNumber` array `[16,17,18,19,20]` in that order.
+- **`V3.3`** — HANDLER — target: `session_search_within` — check: ordering is **newest-to-oldest** (intentionally opposite of recentThoughts) — pass: seed thoughts 1..20 each containing word `foo` only at positions 5, 12, 18; `searchWithin('foo')` returns `[18, 12, 5]`.
+- **`V3.4`** — HANDLER — target: `searchWithin` filter — check: `thoughtTypes:['decision_frame']` only matches that type — pass: out of 20 mixed-type thoughts, only the decision_frame rows return.
+- **`V3.5`** — HANDLER — target: `searchWithin` limit clamp — check: `limit: 1000` is clamped to 100 server-side — pass: query returning 200 candidates returns 100 rows.
+- **`V3.6`** — TS-FIXTURE — target: `src/code-mode/__tests__/spec-03-types.test-d.ts` — check: returned arrays are `readonly Thought[]` — pass: `// @ts-expect-error` on `recent[0] = {...}` accepted by `tsd`.
+- **`V3.7`** — DB-PLAN — target: Postgres FTS — check: `EXPLAIN (FORMAT JSON)` on the `searchWithin` query against a session with 1k thoughts contains a node referencing `idx_thoughts_content_fts` — pass: walk the plan JSON, assert *some* node has `Index Name === 'idx_thoughts_content_fts'`. **Don't assert node-type** (Bitmap vs Index Scan) — Postgres rewrites those across versions.
+- **`V3.8`** — HANDLER — target: session-scope isolation — check: cross-session leakage is impossible — pass: insert "foo" thought into session A and B; `searchWithin` invoked with session A's id returns 1 row, not 2.
+- **`V3.9`** — CATALOG — target: catalog operations — check: `session.getThought`, `session.recentThoughts`, `session.searchWithin` are present with the documented titles — pass: snapshot match.
+
+### Spec 04 — Subagent Session Attachment
+
+- **`V4.1`** — HANDLER — target: `tb.subagent.attach` — check: default `thoughtType` is `context_snapshot` — pass: `SELECT thought_type FROM thoughts WHERE id = $created` returns `'context_snapshot'`.
+- **`V4.2`** — HANDLER — target: metadata roundtrip — check: passed `SubagentOutput` appears verbatim under `metadata.subagentOutput` JSONB — pass: `metadata->'subagentOutput'->>'content'` equals input `content`; `completedAt`, `durationMs`, `model` survive the roundtrip.
+- **`V4.3`** — HANDLER — target: KG entity creation — check: when `entityName` is set, a `kg_entities` row exists with that name and an observation linking to the new thought — pass: `SELECT … FROM kg_entities WHERE name = $entityName` returns one row; an observation row exists with `source_thought = thought_number`. When `entityName` is omitted, no entity row exists.
+- **`V4.4`** — HANDLER — target: visibility default — check: missing `visibility` resolves to `agent-private` — pass: created entity row's `visibility` column equals `'agent-private'`.
+- **`V4.5`** — ZOD — target: `attach` input schema — check: invalid `thoughtType` rejected — pass: `safeParse({thoughtType:'not_a_real_type'}).success === false`.
+- **`V4.6`** — TS-FIXTURE — target: `SubagentOutput.metadata` — check: field is `Readonly<Record<string, unknown>>` — pass: `// @ts-expect-error` on assignment compiles.
+
+### Spec 05 — Hook Suppression During Active Sessions
+
+- **`V5.1`** — TS-FIXTURE — target: `tb.session.isActive` signature — check: returns `Promise<boolean>` — pass: `const x: boolean = await tb.session.isActive()` compiles.
+- **`V5.2`** — HANDLER — target: timeout resolution order — check: per-session > env > 300_000 default — pass: parametrized table covers all four cases with `last_thought_at` set to `effective − 1ms` and `effective + 1ms`; `isActive` returns `true` and `false` respectively.
+- **`V5.3`** — HANDLER — target: edge values — check: `0` always inactive; `Number.MAX_SAFE_INTEGER` always active — pass: with mocked clock advanced 1 hour, both expectations hold.
+- **`V5.4`** — HANDLER — target: explicit end — check: `tb.session.end()` makes `isActive()` return `false` regardless of timeout — pass: timestamp-immediate-after-end test.
+- **`V5.5`** — HANDLER (plugin) — target: plugin SessionStart hook in `plugins/thoughtbox-claude-code/` — check: with active session, hook output line is JSON `{suppressed:true, reason:'active_session', sessionId}`; without, the nudge string is emitted — pass: spawn the hook process with mocked stdin, assert stdout shape.
+- **`V5.6`** — HANDLER — target: suppression log — check: a `SuppressionLogEntry` with `hook='SessionStart'`, `event='nudge_suppressed'` is written iff suppressed — pass: log capture matches the shape exactly when and only when `isActive()` returns true.
+
+### Spec 06 — Cipher Mode Toggle
+
+- **`V6.1`** — PURE-FN — target: `getEffectiveCipherDecision` — check: full enumeration of `(cipherMode ∈ {auto,manual,off}) × (flag ∈ {undefined,false,true})` — pass: 9-row table-driven test, every row's `(decision, reason)` matches the spec table verbatim.
+- **`V6.2`** — HANDLER — target: server-side enforcement — check: `cipherMode='off'` + `cipher:true` payload persists with `metadata.cipherDecision = {decision:'skip', reason:'mode_off'}` — pass: SQL select on the resulting row.
+- **`V6.3`** — HANDLER — target: default mode — check: `tb.session.create()` with no `cipherMode` produces `cipher_mode='auto'` — pass: column value asserted.
+- **`V6.4`** — TS-FIXTURE — target: `CipherMode` union — check: invalid literal rejected — pass: `// @ts-expect-error` on `const m: CipherMode = 'invalid'`.
+- **`V6.5`** — HANDLER — target: contradiction non-throw — check: spec explicitly says flag-vs-mode contradiction is **silently ignored, not an error** — pass: `cipherMode='off'` + `cipher:true` returns 200; structured log line at `debug` level recording the ignore; *not* an error response.
+
+### Spec 07 — Deliberation Without Commitment
+
+- **`V7.1`** — TS-FIXTURE — target: `DecisionOption` union — check: per-element structural typing — pass: `{label:'A',selected:'yes'}` and `{selected:true}` (no label) both fail `tsd`; `{label:'A',selected:true,reason:'r'}` compiles.
+- **`V7.2`** — ZOD — target: cross-element invariant — check: `options=[{label:'A',selected:true},{label:'B',selected:true}]` rejected at parse time by the `.refine` step — pass: `safeParse` returns `success:false` with message containing `'At most one option may have selected: true'`.
+- **`V7.3`** — ZOD — target: cross-field invariant — check: `decisionState='committed'` with zero selections rejected — pass: parse error message contains `'Committed decision must have exactly one selected option'`.
+- **`V7.4`** — HANDLER — target: legitimate deliberation — check: `options=[]` + `decisionState='deliberating'` is valid — pass: thought persists; row exists with empty options jsonb array.
+- **`V7.5`** — TS-FIXTURE — target: narrowing — check: `if (option.selected) { option.reason; }` compiles — pass: `tsd` accepts; the same access without the `if` errors.
+- **`V7.6`** — HANDLER — target: backward compat — check: a thought row with no `decisionState` and `options[0].selected===true` is read back as `decisionState='committed'`; with no selections, `'deliberating'` — pass: insert raw row, fetch via `session.get`, assert derived field.
+- **`V7.7`** — HANDLER — target: audit ignores deliberating — check: `generateAuditData` produces no `decision_without_action` gap for a `deliberating` decision_frame — pass: feed the aggregator a fixture session with one `deliberating` decision frame and zero following action_reports; resulting `gaps.length === 0`. *Pre-spec this test would fail with one gap.*
+
+### Spec 08 — Per-Session-Type Audit
+
+- **`V8.1`** — TS-FIXTURE — target: closed `SessionType` union — check: typo rejected — pass: `// @ts-expect-error` on `'reseach'`.
+- **`V8.2`** — HANDLER — target: research routing — check: `sessionType='research'` with 0 belief_snapshots emits `insufficient_belief_snapshots` warning — pass: aggregator output gap matches.
+- **`V8.3`** — HANDLER — target: decision routing — check: `sessionType='decision'` with no committed decision_frame emits `no_committed_decision` error — pass: gap matches.
+- **`V8.4`** — HANDLER — target: implementation routing — check: `sessionType='implementation'` containing belief_snapshot emits `unexpected_belief_snapshots` warning — pass: gap matches.
+- **`V8.5`** — HANDLER — target: debugging routing — check: `sessionType='debugging'` lacking `action_report` whose content matches `/root cause/i` emits `no_root_cause_identified` error — pass: gap matches; same session with one matching action_report passes clean.
+- **`V8.6`** — HANDLER — target: exploration silence — check: `sessionType='exploration'` always produces `gaps: []` regardless of contents — pass: even an empty session yields no gap.
+- **`V8.7`** — HANDLER — target: regression-prevention — check: the legacy 5-thought decision_without_action rule is suppressed for `research` and `exploration` — pass: pre-spec session fixture (research with decision_frame, no action) yielded 1 gap; post-spec yields 0. **Snapshot-test the gap-count delta** so a future refactor that re-introduces the rule fails loudly.
+- **`V8.8`** — HANDLER — target: type update — check: `tb.session.update({sessionType:'debugging'})` updates the column and changes the audit rules used on the next `generateAuditData` — pass: same session re-aggregated produces a different gaps shape.
+- **`V8.9`** — HANDLER — target: non-blocking — check: a session whose audit yields `severity:'error'` still allows `processThought` to return success — pass: gap is in the manifest, response status is 200.
+
+### Spec 09 — Named Checkpoints
+
+- **`V9.1`** — ZOD/PURE-FN — target: `createCheckpointLabel` — check: regex enforcement — pass: parametrized table; spec's negative cases (`''`, `'Has Spaces'`, `'has/slashes'`, `'UPPERCASE'`, `'_starts'`) all throw with message containing `/^[a-z0-9][a-z0-9_-]*$/`; positive cases resolve.
+- **`V9.2`** — TS-FIXTURE — target: branded `CheckpointLabel` — check: cannot assign raw string — pass: `// @ts-expect-error` on `const l: CheckpointLabel = 'foo'`; `createCheckpointLabel('foo')` compiles.
+- **`V9.3`** — HANDLER — target: persisted checkpoint shape — check: `tb.session.checkpoint('foo','bar')` produces a `progress` thought with `metadata.checkpoint = {label:'foo', summary:'bar', createdAt:<iso>}` — pass: SQL `metadata->'checkpoint'` deep-equal expected; `Date.parse(createdAt)` is finite.
+- **`V9.4`** — DB-PLAN — target: partial GIN — check: `EXPLAIN (FORMAT JSON)` on `WHERE session_id=$1 AND metadata ? 'checkpoint'` plan references `idx_thoughts_checkpoint`; same for label-equality query — pass: index name appears in the plan tree.
+- **`V9.5`** — HANDLER — target: `checkpointsByLabel` multiple matches — check: 3 checkpoints with label `'init'` returned oldest-first — pass: result `thought_number` array is monotonic ascending.
+- **`V9.6`** — HANDLER — target: `getCheckpoint` first-match — check: oldest match returned, `null` for missing — pass: returned row's `thought_number === MIN(thought_number)`; `getCheckpoint('does-not-exist')` is `null`.
+- **`V9.7`** — TS-FIXTURE — target: `isCheckpointThought` predicate — check: narrows `Thought` to `CheckpointThought` — pass: inside the `if` branch, `t.metadata.checkpoint.label` access compiles without optional chaining.
+- **`V9.8`** — DOC-AUDIT — target: any `*.test.ts` and `docs/` — check: discouragement of `searchWithin('Checkpoint:')` — pass: `rg -n "searchWithin\\(['\"]Checkpoint:" tests/ docs/` returns zero matches *after* the spec lands.
+
+### Spec 10 — Knowledge Graph Persistence Shortcut
+
+- **`V10.1`** — HANDLER — target: belief-snapshot path — check: `belief_snapshot` + `persistAs={name:'X', visibility:'team-private'}` creates `kg_entities` row with `type='Concept'` and `visibility='team-private'`, plus an observation linking back to `thought_number`, plus thought row's `metadata->'kgPersistSuccess'` populated — pass: all four assertions hold in one transaction.
+- **`V10.2`** — HANDLER — target: refuted → Decision typing — check: `assumption_update` with `assumptionChange.newStatus='refuted'` produces `type='Decision'` — pass: SQL select.
+- **`V10.3`** — HANDLER — target: non-refuted → Concept typing — check: `believed → uncertain` (no committed decision dependency) produces `type='Concept'` — pass: SQL select.
+- **`V10.4`** — HANDLER — target: downstream → Decision typing — check: prior committed `decision_frame` in same session, then `assumption_update` with `downstream:[<that thoughtNumber>]` produces `type='Decision'` — pass: SQL select.
+- **`V10.5`** — HANDLER — target: `relationTo` — check: `BUILDS_ON` relation row exists from new entity to specified target — pass: `SELECT * FROM kg_relations WHERE from_id=$new AND to_id=$existing AND relation_type='BUILDS_ON'` returns 1 row.
+- **`V10.6`** — HANDLER — target: failure atomicity — check: provoke `ENTITY_NAME_CONFLICT` (pre-insert clashing entity); thought still persists; `metadata.kgPersistError = {code:'ENTITY_NAME_CONFLICT', details:{existingEntityId,…}}`; **no** new entity row — pass: row counts pre and post differ by exactly 1 thought, 0 entities; metadata shape matches.
+- **`V10.7`** — ZOD — target: structural scoping — check: `persistAs` on a `reasoning` (or any non-belief/assumption) thought is rejected — pass: parse error mentions `persistAs` not allowed on this thoughtType.
+- **`V10.8`** — HANDLER — target: `RELATION_TARGET_NOT_FOUND` — check: `relationTo='non-existent-id'` produces that error code with `attemptedRelationTo` in details — pass: metadata shape match.
+- **`V10.9`** — HANDLER — target: visibility default — check: omitted `visibility` resolves to `agent-private` on the persisted entity — pass: SQL select.
+
+### Spec 11 — Structured Return Schemas
+
+- **`V11.1`** — HANDLER — target: schema-pass path — check: subagent dispatched with `expectedReturn.schema` and a return matching it produces `ValidatedOutput<T>` with `success:true` and typed `data` — pass: result deep-equals expected; type-fixture asserts `data` typed as the schema's TS shape.
+- **`V11.2`** — HANDLER — target: schema-fail path — check: invalid return throws `StructuredOutputError` with `type==='structured_output_error'` and `validationErrors[0]` populated with `path`, `expected`, `received` — pass: thrown error matches Zod parse of `StructuredOutputErrorSchema`.
+- **`V11.3`** — HANDLER — target: parse-fail path — check: subagent returns non-JSON; resulting error has `parsingError.offset >= 0` — pass: error matches; `validationErrors` is empty.
+- **`V11.4`** — HANDLER — target: no-attach on fail — check: validation failure means no thought row inserted in parent session — pass: `SELECT COUNT(*) FROM thoughts WHERE session_id=$parent` unchanged across the failed dispatch.
+- **`V11.5`** — TS-FIXTURE — target: discriminant narrowing — check: `if (e.type==='structured_output_error') { e.validationErrors.length }` compiles without `as` — pass: `tsd` accepts.
+- **`V11.6`** — TS-FIXTURE — target: `ValidatedOutput<T>` carries typed `data` — check: with schema `{x:string,y:number}` the result type is `{x:string,y:number}` — pass: `expectType<{x:string,y:number}>(result.data)`.
+
+---
+
+## 4. Cross-cutting validators
+
+These don't belong to any single spec; they catch failure modes across the suite.
+
+- **`CC.1`** — HANDLER — target: `src/code-mode/sdk-types.ts` ↔ Zod schemas — check: every operation declared in `TB_SDK_TYPES` has a matching exported Zod schema, and vice versa — pass: a vitest test imports both, computes the symmetric difference of operation names, asserts it is empty. Catches the failure mode where `tb.t` lands in the SDK string but the Code Mode runtime never wires it.
+- **`CC.2`** — CATALOG — target: `catalog.operations.session` returned by `thoughtbox_search` — check: includes `getThought`, `recentThoughts`, `searchWithin`, `checkpoint`, `checkpoints`, `getCheckpoint`, `checkpointsByLabel`, `isActive`, `update`, `openChain` — pass: snapshot of the keys array equals expected.
+- **`CC.3`** — TS-FIXTURE / AST-grep — target: `src/thought/tool.ts` `thoughtType` `z.enum` — check: the seven canonical types are unchanged: `reasoning | decision_frame | action_report | belief_snapshot | assumption_update | context_snapshot | progress` — pass: AST-grep confirms the literal union; if a future PR adds `'deliberation'` or similar, this fails. **Note**: `src/audit/manifest-generator.ts` contains an 8-element list including `'action_receipt'` — that is the audit aggregator's internal counter, not a thought-tool type. The Zod tool schema is the ground truth; CC.3 watches that one.
+- **`CC.4`** — DOC-AUDIT — target: `db/migrations/` (or `supabase/migrations/`) — check: each schema-touching spec has a corresponding migration file — pass: filename pattern check, e.g. `rg -l 'spec0(3|6|8|9|10)' db/migrations/` returns at least 5 paths. Fail message points at the missing spec number.
+
+---
+
+## 5. Caveats and tooling notes
+
+1. **TS-FIXTURE tooling.** Use `tsd` for `// @ts-expect-error` block validation and
+   `expect-type` for runtime-friendly type asserts inside vitest. Pick once; don't mix
+   both styles within one fixture file.
+2. **EXPLAIN-plan brittleness.** Postgres major versions can rearrange plan-node types
+   (Bitmap vs Index Scan vs Index-Only Scan). Assert *index-name presence* in the plan
+   tree, not node-type structure. Pin `enable_seqscan=off` only inside the test
+   transaction so production cost-based regressions still surface.
+3. **ThoughtType list discrepancy.** `src/thought/tool.ts` has 7 types; the audit
+   aggregator at `src/audit/manifest-generator.ts:64-73` enumerates 8 (includes
+   `'action_receipt'`). The specs uniformly say 7 — the audit aggregator's 8th is an
+   internal counter for a separate concept, not a submitted thought type. **Validators
+   anchor to `thoughtToolInputSchema` in `src/thought/tool.ts`**, not the audit list.
+   Flag the divergence in a separate cleanup task; do not silently widen the canonical
+   union to 8.
+4. **Deterministic vs behavioral.** Each spec's own `Validation` section retains
+   behavioral acceptance ("agent does X over a 100-thought session"). Those are useful
+   product checks, but they are **not** part of this catalog. If a behavioral check
+   regresses while the deterministic catalog passes, that is a bug in the catalog —
+   raise an issue and add a deterministic counterpart.
+5. **Session fixtures.** Handler tests need a small library of session fixtures
+   (research-no-beliefs, decision-with-deliberating-frame, debugging-with-root-cause,
+   etc.). House them under `src/__tests__/fixtures/sessions/` so multiple spec
+   validators reuse the same JSON without per-test setup drift.
+
+---
+
+## 6. How to run all of it
+
+Once implemented, the full catalog runs via:
+
+```bash
+docker compose up -d postgres-test
+pnpm test                          # Zod, HANDLER, DB-PLAN, CATALOG, PURE-FN
+pnpm exec tsd                      # TS-FIXTURE
+pnpm exec vitest run cross-cutting # CC.*
+```
+
+A single `pnpm validate:specs` script that wraps these three commands is the right
+target once the catalog stabilizes.
+
+---
+
+## 7. Validator count summary
+
+| Spec | # validators |
+|------|--------------|
+| 01 — Auto-numbering surfacing | 5 |
+| 02 — Terse shorthand & chain | 7 |
+| 03 — Mid-session recall | 9 |
+| 04 — Subagent attach | 6 |
+| 05 — Hook suppression | 6 |
+| 06 — Cipher mode toggle | 5 |
+| 07 — Deliberation without commitment | 7 |
+| 08 — Per-session-type audit | 9 |
+| 09 — Named checkpoints | 8 |
+| 10 — Knowledge-graph persistence | 9 |
+| 11 — Structured return schemas | 6 |
+| Cross-cutting | 4 |
+| **Total** | **81** |
+
+Implementation sequencing: TS-FIXTURE and Zod first (cheap, ~25 validators), HANDLER and
+DB-PLAN second (require test Postgres, ~45 validators), CATALOG / DOC-AUDIT / cross-cutting
+last (~10 validators, mostly drift detectors that benefit from running in CI on every PR).


### PR DESCRIPTION
## Summary

Brings the design artifacts from the cognitive-harness-improvements work forward to main:

- `.specs/SPEC-CHX-001-cognitive-harness-improvements.md` — master spec
- `.specs/cognitive-harness-improvements/01-…11-…md` — eleven per-feature specs
- `.specs/cognitive-harness-improvements/TYPE-SYSTEM-PRINCIPLES.md`
- `.specs/cognitive-harness-improvements/VALIDATORS.md` — 81-validator acceptance catalog

## Why docs-only

The prior implementation attempt on `feat/cognitive-harness-improvements` landed schema-layer changes only — it did not wire any of the eleven specs into the runtime call path (`ThoughtTool.handle()` bypasses the strict schema, the new fields are dropped at `thought-handler.ts:805`, and there is no chain runtime, recall handler, checkpoint storage, audit routing, subagent attach, or structured-return validation). Reviews from both Claude Code and Codex agreed the branch was scaffolding rather than implementation.

Rather than merge a half-built implementation, this PR preserves only the design deliverables — which both reviews considered genuinely complete and useful — and leaves the implementation work for a future, properly-scoped effort.

## What's in scope here

- Design docs only. No code changes.

## What's out of scope (deferred)

- All eleven runtime implementations (Specs 01–11)
- Migrations for schema-touching specs (03, 06, 08, 09, 10)
- The 81 validators themselves — to be authored against real implementations, not as scaffolding

The original implementation branch `feat/cognitive-harness-improvements` is preserved on origin for reference.

## Test plan

- [ ] No code changes — CI should pass on existing test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)