### PR TITLE
feat(peer-notebook): add claim extractor pilot

### DIFF
--- a/src/peer-notebook/__tests__/broker.test.ts
+++ b/src/peer-notebook/__tests__/broker.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it } from "vitest";
+import {
+  InMemoryPeerNotebookRepository,
+  MockPeerRuntimeProvider,
+  PeerNotebookError,
+  compilePeerManifestDraft,
+  createPeerBroker,
+  type PeerManifestRecord,
+  type PeerManifestStatus,
+  type PeerNotebookRecord,
+} from "../index.js";
+
+const workspaceId = "workspace_test";
+
+describe("claim-extractor peer pilot", () => {
+  it("rejects invalid args before runtime dispatch", async () => {
+    const { broker, provider } = await setupHarness();
+
+    await expect(
+      broker.peer.invoke({
+        peerId: "claim-extractor",
+        tool: "extract_claims",
+        args: {},
+      }),
+    ).rejects.toMatchObject({ code: "invalid_args" });
+    expect(provider.invocations).toHaveLength(0);
+  });
+
+  it("does not invoke draft or inactive manifests", async () => {
+    const draftHarness = await setupHarness({ manifestStatus: "draft" });
+    await expect(
+      draftHarness.broker.peer.invoke({
+        peerId: "claim-extractor",
+        tool: "extract_claims",
+        args: { textArtifactId: "input_text" },
+      }),
+    ).rejects.toMatchObject({ code: "manifest_not_active" });
+    expect(draftHarness.provider.invocations).toHaveLength(0);
+
+    const inactiveHarness = await setupHarness({ peerStatus: "disabled" });
+    await expect(
+      inactiveHarness.broker.peer.invoke({
+        peerId: "claim-extractor",
+        tool: "extract_claims",
+        args: { textArtifactId: "input_text" },
+      }),
+    ).rejects.toMatchObject({ code: "peer_not_active" });
+    expect(inactiveHarness.provider.invocations).toHaveLength(0);
+  });
+
+  it("passes the active manifest hash to the runtime provider", async () => {
+    const { broker, manifest, provider } = await setupHarness();
+
+    const result = await broker.peer.invoke({
+      peerId: "claim-extractor",
+      tool: "extract_claims",
+      args: { textArtifactId: "input_text" },
+    });
+
+    expect(result.manifestHash).toBe(manifest.manifestHash);
+    expect(provider.invocations[0].manifestHash).toBe(manifest.manifestHash);
+  });
+
+  it("allows artifact reads through the broker proxy", async () => {
+    const { broker, repository } = await setupHarness();
+
+    const result = await broker.peer.invoke({
+      peerId: "claim-extractor",
+      tool: "extract_claims",
+      args: { textArtifactId: "input_text" },
+    });
+    const events = await repository.listTraceEvents(workspaceId, result.invocationId);
+
+    expect(events.some(event => event.eventType === "outbound_call_allowed")).toBe(true);
+  });
+
+  it("does not forward denied outbound calls and records a trace event", async () => {
+    let forwardedDeniedTarget = false;
+    const { broker, repository } = await setupHarness({
+      proxyTargets: {
+        "thoughtbox.knowledge.queryGraph": async () => {
+          forwardedDeniedTarget = true;
+          return {};
+        },
+      },
+    });
+
+    const result = await broker.peer.invoke({
+      peerId: "claim-extractor",
+      tool: "extract_claims",
+      args: { textArtifactId: "input_text" },
+    });
+    const events = await repository.listTraceEvents(workspaceId, result.invocationId);
+
+    expect(forwardedDeniedTarget).toBe(false);
+    expect(events.some(event => event.eventType === "denied_outbound_call")).toBe(true);
+  });
+
+  it("returns claims.json as an artifact reference", async () => {
+    const { broker, repository } = await setupHarness();
+
+    const result = await broker.peer.invoke({
+      peerId: "claim-extractor",
+      tool: "extract_claims",
+      args: { textArtifactId: "input_text" },
+    });
+
+    expect(result.result).toMatchObject({
+      claimsArtifactId: `${result.invocationId}-claims`,
+      claimCount: 2,
+    });
+
+    const artifacts = await repository.listArtifacts(workspaceId, result.invocationId);
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0]).toMatchObject({
+      id: `${result.invocationId}-claims`,
+      name: "claims.json",
+      mimeType: "application/json",
+    });
+  });
+});
+
+async function setupHarness(options: {
+  manifestStatus?: PeerManifestStatus;
+  peerStatus?: PeerNotebookRecord["status"];
+  proxyTargets?: Parameters<typeof createPeerBroker>[0]["proxyTargets"];
+} = {}) {
+  const repository = new InMemoryPeerNotebookRepository();
+  const provider = new MockPeerRuntimeProvider();
+  const compiled = compilePeerManifestDraft([
+    {
+      name: "peer.manifest.json",
+      content: JSON.stringify(claimExtractorManifest()),
+    },
+  ]);
+
+  const now = "2026-04-30T00:00:00.000Z";
+  const peer: PeerNotebookRecord = {
+    id: "peer_record_claim_extractor",
+    workspaceId,
+    peerId: "claim-extractor",
+    displayName: "Claim extractor",
+    status: options.peerStatus ?? "active",
+    activeManifestId: "manifest_active",
+    createdAt: now,
+    updatedAt: now,
+  };
+  const manifest: PeerManifestRecord = {
+    id: "manifest_active",
+    workspaceId,
+    peerRecordId: peer.id,
+    peerId: peer.peerId,
+    version: 1,
+    schemaVersion: compiled.manifest.schemaVersion,
+    manifest: compiled.manifest,
+    manifestHash: compiled.manifestHash,
+    status: options.manifestStatus ?? "active",
+    compiledFrom: compiled.compiledFrom,
+    createdAt: now,
+  };
+
+  await repository.savePeer(peer);
+  await repository.saveManifest(manifest);
+  await repository.saveArtifactInput({
+    id: "input_text",
+    workspaceId,
+    invocationId: null,
+    peerRecordId: null,
+    peerId: null,
+    kind: "json",
+    name: "input.txt",
+    mimeType: "text/plain",
+    content: { text: "First claim. Second claim." },
+  });
+
+  return {
+    broker: createPeerBroker({
+      workspaceId,
+      repository,
+      runtimeProviders: { mock: provider },
+      proxyTargets: options.proxyTargets,
+    }),
+    repository,
+    provider,
+    manifest,
+  };
+}
+
+function claimExtractorManifest() {
+  return {
+    schemaVersion: "peer-notebook.v0",
+    peerId: "claim-extractor",
+    notebookId: "nb_claim_extractor",
+    runtime: {
+      provider: "mock",
+      timeoutMs: 120_000,
+    },
+    exposes: {
+      tools: [
+        {
+          name: "extract_claims",
+          description: "Extract atomic claims from a text artifact",
+          inputSchema: {
+            type: "object",
+            properties: {
+              textArtifactId: { type: "string" },
+            },
+            required: ["textArtifactId"],
+            additionalProperties: false,
+          },
+          outputSchema: {
+            type: "object",
+            properties: {
+              claimsArtifactId: { type: "string" },
+              claimCount: { type: "number" },
+            },
+            required: ["claimsArtifactId", "claimCount"],
+            additionalProperties: false,
+          },
+        },
+      ],
+      resources: [],
+      prompts: [],
+    },
+    mayCall: {
+      mcpTools: ["artifact.get"],
+    },
+    network: {
+      enabled: false,
+      allowHosts: [],
+    },
+    filesystem: {
+      mounts: [],
+    },
+    secrets: {
+      bindings: [],
+    },
+    persistence: {
+      snapshot: "manual",
+      exportNotebookOnInvoke: true,
+      retainArtifactsDays: 30,
+    },
+    budgets: {
+      maxDurationMs: 120_000,
+      maxToolCalls: 10,
+      maxArtifactBytes: 10_000_000,
+    },
+  };
+}

--- a/src/peer-notebook/__tests__/broker.test.ts
+++ b/src/peer-notebook/__tests__/broker.test.ts
@@ -1,13 +1,15 @@
 import { describe, expect, it } from "vitest";
 import {
+  BrokerProxy,
   InMemoryPeerNotebookRepository,
   MockPeerRuntimeProvider,
-  PeerNotebookError,
+  canonicalizeJson,
   compilePeerManifestDraft,
   createPeerBroker,
   type PeerManifestRecord,
   type PeerManifestStatus,
   type PeerNotebookRecord,
+  type RuntimeProvider,
 } from "../index.js";
 
 const workspaceId = "workspace_test";
@@ -118,11 +120,99 @@ describe("claim-extractor peer pilot", () => {
       mimeType: "application/json",
     });
   });
+
+  it("uses invocation_not_found for missing invocation updates", async () => {
+    const repository = new InMemoryPeerNotebookRepository();
+
+    await expect(
+      repository.updateInvocation({
+        id: "missing",
+        workspaceId,
+        peerRecordId: "peer",
+        peerId: "claim-extractor",
+        manifestId: "manifest",
+        manifestHash: "sha256:missing",
+        toolName: "extract_claims",
+        argsHash: "sha256:args",
+        resultHash: null,
+        status: "running",
+        runtimeProvider: "mock",
+        result: null,
+        error: null,
+        createdAt: "2026-04-30T00:00:00.000Z",
+        startedAt: null,
+        completedAt: null,
+      }),
+    ).rejects.toMatchObject({ code: "invocation_not_found" });
+  });
+
+  it("records auth-mismatch denies on trusted trace scope", async () => {
+    const { repository, manifest } = await setupHarness();
+    const proxy = new BrokerProxy({
+      repository,
+      manifest,
+      scopedToken: "trusted-token",
+      traceWorkspaceId: workspaceId,
+      traceInvocationId: "trusted_invocation",
+    });
+
+    await proxy.call({
+      invocationId: "attacker_invocation",
+      workspaceId: "attacker_workspace",
+      scopedToken: "wrong-token",
+      manifestHash: "sha256:wrong",
+      target: "artifact.get",
+      args: { artifactId: "input_text" },
+    });
+
+    const trustedEvents = await repository.listTraceEvents(workspaceId, "trusted_invocation");
+    const attackerEvents = await repository.listTraceEvents("attacker_workspace", "attacker_invocation");
+    expect(trustedEvents.some(event => event.eventType === "denied_outbound_call")).toBe(true);
+    expect(attackerEvents).toHaveLength(0);
+  });
+
+  it("marks invocations timeout when runtime exceeds maxDurationMs", async () => {
+    const provider: RuntimeProvider = {
+      describe: () => ({
+        provider: "mock",
+        isolation: "mock",
+        supportsCancel: false,
+        supportsSnapshots: false,
+      }),
+      invoke: () => new Promise(() => {}),
+      cancel: async () => {},
+      "snapshot/export": async () => null,
+      heartbeat: async () => {},
+    };
+    const { broker, repository } = await setupHarness({
+      provider,
+      budgets: { maxDurationMs: 1, maxToolCalls: 10, maxArtifactBytes: 10_000_000 },
+    });
+
+    await expect(
+      broker.peer.invoke({
+        peerId: "claim-extractor",
+        tool: "extract_claims",
+        args: { textArtifactId: "input_text" },
+      }),
+    ).rejects.toMatchObject({ code: "timeout" });
+
+    const invocations = await repository.listInvocations(workspaceId);
+    expect(invocations).toHaveLength(1);
+    expect(invocations[0].status).toBe("timeout");
+  });
+
+  it("omits undefined object properties during canonicalization", () => {
+    expect(canonicalizeJson({ b: 2, a: undefined })).toBe("{\"b\":2}");
+    expect(canonicalizeJson([undefined, "x"])).toBe("[null,\"x\"]");
+  });
 });
 
 async function setupHarness(options: {
   manifestStatus?: PeerManifestStatus;
   peerStatus?: PeerNotebookRecord["status"];
+  provider?: RuntimeProvider;
+  budgets?: ReturnType<typeof claimExtractorManifest>["budgets"];
   proxyTargets?: Parameters<typeof createPeerBroker>[0]["proxyTargets"];
 } = {}) {
   const repository = new InMemoryPeerNotebookRepository();
@@ -130,7 +220,7 @@ async function setupHarness(options: {
   const compiled = compilePeerManifestDraft([
     {
       name: "peer.manifest.json",
-      content: JSON.stringify(claimExtractorManifest()),
+      content: JSON.stringify(claimExtractorManifest(options.budgets)),
     },
   ]);
 
@@ -177,7 +267,7 @@ async function setupHarness(options: {
     broker: createPeerBroker({
       workspaceId,
       repository,
-      runtimeProviders: { mock: provider },
+      runtimeProviders: { mock: options.provider ?? provider },
       proxyTargets: options.proxyTargets,
     }),
     repository,
@@ -186,7 +276,11 @@ async function setupHarness(options: {
   };
 }
 
-function claimExtractorManifest() {
+function claimExtractorManifest(budgets = {
+  maxDurationMs: 120_000,
+  maxToolCalls: 10,
+  maxArtifactBytes: 10_000_000,
+}) {
   return {
     schemaVersion: "peer-notebook.v0",
     peerId: "claim-extractor",
@@ -240,10 +334,6 @@ function claimExtractorManifest() {
       exportNotebookOnInvoke: true,
       retainArtifactsDays: 30,
     },
-    budgets: {
-      maxDurationMs: 120_000,
-      maxToolCalls: 10,
-      maxArtifactBytes: 10_000_000,
-    },
+    budgets,
   };
 }

--- a/src/peer-notebook/broker-proxy.ts
+++ b/src/peer-notebook/broker-proxy.ts
@@ -21,37 +21,51 @@ export interface BrokerProxyOptions {
   repository: PeerNotebookRepository;
   manifest: PeerManifestRecord;
   scopedToken: string;
+  traceInvocationId: string;
+  traceWorkspaceId: string;
   targets?: Record<string, BrokerProxyTarget>;
+}
+
+interface TrustedTraceScope {
+  workspaceId: string;
+  invocationId: string;
 }
 
 export class BrokerProxy {
   constructor(private readonly options: BrokerProxyOptions) {}
 
   createClient(invocationId: string, workspaceId: string, manifestHash: string): BrokerProxyClient {
+    const traceScope = {
+      workspaceId,
+      invocationId,
+    };
     return {
       callTool: (target, args) =>
-        this.call({
-          invocationId,
-          workspaceId,
-          scopedToken: this.options.scopedToken,
-          manifestHash,
-          target,
-          args,
-        }),
+        this.call(
+          {
+            invocationId,
+            workspaceId,
+            scopedToken: this.options.scopedToken,
+            manifestHash,
+            target,
+            args,
+          },
+          traceScope,
+        ),
     };
   }
 
-  async call(request: BrokerProxyCall): Promise<BrokerProxyResult> {
+  async call(request: BrokerProxyCall, traceScope?: TrustedTraceScope): Promise<BrokerProxyResult> {
     if (
       request.scopedToken !== this.options.scopedToken ||
       request.workspaceId !== this.options.manifest.workspaceId ||
       request.manifestHash !== this.options.manifest.manifestHash
     ) {
-      return this.deny(request, "Broker proxy credentials do not match invocation scope");
+      return this.deny(request, "Broker proxy credentials do not match invocation scope", traceScope);
     }
 
     if (!this.options.manifest.manifest.mayCall.mcpTools.includes(request.target)) {
-      return this.deny(request, `Outbound call to ${request.target} is not allowed by active manifest`);
+      return this.deny(request, `Outbound call to ${request.target} is not allowed by active manifest`, traceScope);
     }
 
     const result = await this.forward(request);
@@ -96,10 +110,14 @@ export class BrokerProxy {
     return target(request.args);
   }
 
-  private async deny(request: BrokerProxyCall, message: string): Promise<BrokerProxyResult> {
+  private async deny(
+    request: BrokerProxyCall,
+    message: string,
+    traceScope?: TrustedTraceScope,
+  ): Promise<BrokerProxyResult> {
     await this.options.repository.appendTraceEvent({
-      workspaceId: request.workspaceId,
-      invocationId: request.invocationId,
+      workspaceId: traceScope?.workspaceId ?? this.options.traceWorkspaceId,
+      invocationId: traceScope?.invocationId ?? this.options.traceInvocationId,
       eventType: "denied_outbound_call",
       severity: "warn",
       body: message,

--- a/src/peer-notebook/broker-proxy.ts
+++ b/src/peer-notebook/broker-proxy.ts
@@ -1,0 +1,123 @@
+import type { JsonObject, JsonValue, PeerManifestRecord } from "./types.js";
+import { PeerNotebookError } from "./types.js";
+import type { PeerNotebookRepository } from "./repositories.js";
+
+export interface BrokerProxyCall {
+  invocationId: string;
+  workspaceId: string;
+  scopedToken: string;
+  manifestHash: string;
+  target: string;
+  args: JsonObject;
+}
+
+export type BrokerProxyResult =
+  | { ok: true; result: JsonValue }
+  | { ok: false; denied: true; error: { code: "outbound_denied"; message: string } };
+
+export type BrokerProxyTarget = (args: JsonObject) => Promise<JsonValue>;
+
+export interface BrokerProxyOptions {
+  repository: PeerNotebookRepository;
+  manifest: PeerManifestRecord;
+  scopedToken: string;
+  targets?: Record<string, BrokerProxyTarget>;
+}
+
+export class BrokerProxy {
+  constructor(private readonly options: BrokerProxyOptions) {}
+
+  createClient(invocationId: string, workspaceId: string, manifestHash: string): BrokerProxyClient {
+    return {
+      callTool: (target, args) =>
+        this.call({
+          invocationId,
+          workspaceId,
+          scopedToken: this.options.scopedToken,
+          manifestHash,
+          target,
+          args,
+        }),
+    };
+  }
+
+  async call(request: BrokerProxyCall): Promise<BrokerProxyResult> {
+    if (
+      request.scopedToken !== this.options.scopedToken ||
+      request.workspaceId !== this.options.manifest.workspaceId ||
+      request.manifestHash !== this.options.manifest.manifestHash
+    ) {
+      return this.deny(request, "Broker proxy credentials do not match invocation scope");
+    }
+
+    if (!this.options.manifest.manifest.mayCall.mcpTools.includes(request.target)) {
+      return this.deny(request, `Outbound call to ${request.target} is not allowed by active manifest`);
+    }
+
+    const result = await this.forward(request);
+    await this.options.repository.appendTraceEvent({
+      workspaceId: request.workspaceId,
+      invocationId: request.invocationId,
+      eventType: "outbound_call_allowed",
+      severity: "info",
+      attrs: {
+        target: request.target,
+      },
+    });
+    return { ok: true, result };
+  }
+
+  private async forward(request: BrokerProxyCall): Promise<JsonValue> {
+    if (request.target === "artifact.get") {
+      const artifactId = request.args.artifactId;
+      if (typeof artifactId !== "string") {
+        throw new PeerNotebookError("artifact_not_found", "artifact.get requires string artifactId");
+      }
+      const artifact = await this.options.repository.getArtifact(request.workspaceId, artifactId);
+      if (!artifact) {
+        throw new PeerNotebookError("artifact_not_found", `Artifact ${artifactId} does not exist`);
+      }
+      return {
+        artifact: {
+          id: artifact.id,
+          name: artifact.name,
+          mimeType: artifact.mimeType,
+          byteSize: artifact.byteSize,
+          sha256: artifact.sha256,
+          content: artifact.content,
+        },
+      };
+    }
+
+    const target = this.options.targets?.[request.target];
+    if (!target) {
+      throw new PeerNotebookError("tool_not_found", `No broker proxy target registered for ${request.target}`);
+    }
+    return target(request.args);
+  }
+
+  private async deny(request: BrokerProxyCall, message: string): Promise<BrokerProxyResult> {
+    await this.options.repository.appendTraceEvent({
+      workspaceId: request.workspaceId,
+      invocationId: request.invocationId,
+      eventType: "denied_outbound_call",
+      severity: "warn",
+      body: message,
+      attrs: {
+        target: request.target,
+      },
+    });
+    return {
+      ok: false,
+      denied: true,
+      error: {
+        code: "outbound_denied",
+        message,
+      },
+    };
+  }
+}
+
+export interface BrokerProxyClient {
+  callTool(target: string, args: JsonObject): Promise<BrokerProxyResult>;
+}

--- a/src/peer-notebook/broker.ts
+++ b/src/peer-notebook/broker.ts
@@ -100,22 +100,27 @@ export class PeerBroker {
       repository: this.options.repository,
       manifest,
       scopedToken,
+      traceInvocationId: invocation.id,
+      traceWorkspaceId: this.options.workspaceId,
       targets: this.options.proxyTargets,
     }).createClient(invocation.id, this.options.workspaceId, manifest.manifestHash);
 
     try {
-      const runtimeResult = await provider.invoke({
-        invocationId: invocation.id,
-        workspaceId: this.options.workspaceId,
-        peerId: input.peerId,
-        manifestHash: manifest.manifestHash,
-        tool: input.tool,
-        args: input.args,
-        brokerProxyUrl: "memory://broker-proxy",
-        scopedToken,
-        budgets: manifest.manifest.budgets,
-        brokerProxy: proxy,
-      });
+      const runtimeResult = await withTimeout(
+        provider.invoke({
+          invocationId: invocation.id,
+          workspaceId: this.options.workspaceId,
+          peerId: input.peerId,
+          manifestHash: manifest.manifestHash,
+          tool: input.tool,
+          args: input.args,
+          brokerProxyUrl: "memory://broker-proxy",
+          scopedToken,
+          budgets: manifest.manifest.budgets,
+          brokerProxy: proxy,
+        }),
+        resolveTimeoutMs(manifest.manifest.runtime.timeoutMs, manifest.manifest.budgets.maxDurationMs),
+      );
 
       const resultValidation = validateJsonSchemaSubset(runtimeResult.result, tool.outputSchema);
       if (!resultValidation.valid) {
@@ -170,7 +175,11 @@ export class PeerBroker {
         result: runtimeResult.result,
       };
     } catch (error) {
-      invocation.status = error instanceof PeerNotebookError && error.code === "outbound_denied" ? "denied" : "failed";
+      invocation.status = error instanceof PeerNotebookError && error.code === "outbound_denied"
+        ? "denied"
+        : error instanceof PeerNotebookError && error.code === "timeout"
+          ? "timeout"
+          : "failed";
       invocation.error = {
         message: error instanceof Error ? error.message : String(error),
       };
@@ -211,4 +220,23 @@ export class PeerBroker {
 
 export function createPeerBroker(options: PeerBrokerOptions): PeerBroker {
   return new PeerBroker(options);
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timeout: NodeJS.Timeout | null = null;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeout = setTimeout(() => {
+      reject(new PeerNotebookError("timeout", `Peer runtime exceeded maxDurationMs=${timeoutMs}`));
+    }, timeoutMs);
+  });
+
+  return Promise.race([promise, timeoutPromise]).finally(() => {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  });
+}
+
+function resolveTimeoutMs(runtimeTimeoutMs: number | undefined, budgetTimeoutMs: number): number {
+  return Math.min(runtimeTimeoutMs ?? budgetTimeoutMs, budgetTimeoutMs);
 }

--- a/src/peer-notebook/broker.ts
+++ b/src/peer-notebook/broker.ts
@@ -1,0 +1,214 @@
+import { randomUUID } from "node:crypto";
+import { BrokerProxy, type BrokerProxyTarget } from "./broker-proxy.js";
+import { hashJson } from "./manifest.js";
+import { validateJsonSchemaSubset } from "./json-schema.js";
+import type { PeerNotebookRepository } from "./repositories.js";
+import type { RuntimeProvider } from "./runtime-provider.js";
+import type { JsonObject, JsonValue, PeerInvocationRecord, RuntimeProviderName } from "./types.js";
+import { PeerNotebookError } from "./types.js";
+
+export interface PeerInvokeInput {
+  peerId: string;
+  tool: string;
+  args: JsonObject;
+}
+
+export interface PeerInvokeResult {
+  invocationId: string;
+  manifestHash: string;
+  result: JsonValue;
+}
+
+export interface PeerBrokerOptions {
+  workspaceId: string;
+  repository: PeerNotebookRepository;
+  runtimeProviders: Partial<Record<RuntimeProviderName, RuntimeProvider>>;
+  proxyTargets?: Record<string, BrokerProxyTarget>;
+}
+
+export class PeerBroker {
+  readonly peer = {
+    invoke: (input: PeerInvokeInput) => this.invoke(input),
+  };
+
+  constructor(private readonly options: PeerBrokerOptions) {}
+
+  async invoke(input: PeerInvokeInput): Promise<PeerInvokeResult> {
+    const peer = await this.options.repository.getPeerByPeerId(this.options.workspaceId, input.peerId);
+    if (!peer) {
+      throw new PeerNotebookError("peer_not_found", `Peer ${input.peerId} does not exist`);
+    }
+    if (peer.status !== "active") {
+      throw new PeerNotebookError("peer_not_active", `Peer ${input.peerId} is ${peer.status}`);
+    }
+    if (!peer.activeManifestId) {
+      throw new PeerNotebookError("manifest_not_active", `Peer ${input.peerId} has no active manifest`);
+    }
+
+    const manifest = await this.options.repository.getManifest(this.options.workspaceId, peer.activeManifestId);
+    if (!manifest || manifest.status !== "active") {
+      throw new PeerNotebookError("manifest_not_active", `Peer ${input.peerId} active manifest is not active`);
+    }
+
+    const tool = manifest.manifest.exposes.tools.find(candidate => candidate.name === input.tool);
+    if (!tool) {
+      throw new PeerNotebookError("tool_not_found", `Tool ${input.tool} is not exposed by ${input.peerId}`);
+    }
+
+    const argsValidation = validateJsonSchemaSubset(input.args, tool.inputSchema);
+    if (!argsValidation.valid) {
+      throw new PeerNotebookError("invalid_args", "Peer invocation args failed schema validation", {
+        errors: argsValidation.errors,
+      });
+    }
+
+    const provider = this.options.runtimeProviders[manifest.manifest.runtime.provider];
+    if (!provider) {
+      throw new PeerNotebookError(
+        "runtime_provider_not_found",
+        `Runtime provider ${manifest.manifest.runtime.provider} is not registered`,
+      );
+    }
+
+    const invocation = this.createInvocation(
+      peer.id,
+      input.peerId,
+      manifest.id,
+      manifest.manifestHash,
+      manifest.manifest.runtime.provider,
+      input,
+    );
+    await this.options.repository.saveInvocation(invocation);
+    await this.options.repository.appendTraceEvent({
+      workspaceId: this.options.workspaceId,
+      invocationId: invocation.id,
+      eventType: "peer_invocation_created",
+      severity: "info",
+      attrs: {
+        peerId: input.peerId,
+        tool: input.tool,
+        manifestHash: manifest.manifestHash,
+      },
+    });
+
+    invocation.status = "running";
+    invocation.startedAt = new Date().toISOString();
+    await this.options.repository.updateInvocation(invocation);
+
+    const scopedToken = `peer-token:${invocation.id}`;
+    const proxy = new BrokerProxy({
+      repository: this.options.repository,
+      manifest,
+      scopedToken,
+      targets: this.options.proxyTargets,
+    }).createClient(invocation.id, this.options.workspaceId, manifest.manifestHash);
+
+    try {
+      const runtimeResult = await provider.invoke({
+        invocationId: invocation.id,
+        workspaceId: this.options.workspaceId,
+        peerId: input.peerId,
+        manifestHash: manifest.manifestHash,
+        tool: input.tool,
+        args: input.args,
+        brokerProxyUrl: "memory://broker-proxy",
+        scopedToken,
+        budgets: manifest.manifest.budgets,
+        brokerProxy: proxy,
+      });
+
+      const resultValidation = validateJsonSchemaSubset(runtimeResult.result, tool.outputSchema);
+      if (!resultValidation.valid) {
+        throw new PeerNotebookError("invalid_result", "Peer runtime result failed schema validation", {
+          errors: resultValidation.errors,
+        });
+      }
+
+      for (const artifact of runtimeResult.artifacts) {
+        await this.options.repository.saveArtifactInput({
+          id: artifact.artifactId,
+          workspaceId: this.options.workspaceId,
+          invocationId: invocation.id,
+          peerRecordId: peer.id,
+          peerId: peer.peerId,
+          kind: artifact.kind,
+          name: artifact.name,
+          mimeType: artifact.mimeType,
+          content: artifact.content,
+          preview: artifact.preview,
+        });
+        await this.options.repository.appendTraceEvent({
+          workspaceId: this.options.workspaceId,
+          invocationId: invocation.id,
+          eventType: "peer_artifact_written",
+          severity: "info",
+          attrs: {
+            artifactId: artifact.artifactId,
+            name: artifact.name,
+          },
+        });
+      }
+
+      invocation.status = "completed";
+      invocation.result = runtimeResult.result;
+      invocation.resultHash = hashJson(runtimeResult.result);
+      invocation.completedAt = new Date().toISOString();
+      await this.options.repository.updateInvocation(invocation);
+      await this.options.repository.appendTraceEvent({
+        workspaceId: this.options.workspaceId,
+        invocationId: invocation.id,
+        eventType: "peer_invocation_completed",
+        severity: "info",
+        attrs: {
+          resultHash: invocation.resultHash,
+        },
+      });
+
+      return {
+        invocationId: invocation.id,
+        manifestHash: manifest.manifestHash,
+        result: runtimeResult.result,
+      };
+    } catch (error) {
+      invocation.status = error instanceof PeerNotebookError && error.code === "outbound_denied" ? "denied" : "failed";
+      invocation.error = {
+        message: error instanceof Error ? error.message : String(error),
+      };
+      invocation.completedAt = new Date().toISOString();
+      await this.options.repository.updateInvocation(invocation);
+      throw error;
+    }
+  }
+
+  private createInvocation(
+    peerRecordId: string,
+    peerId: string,
+    manifestId: string,
+    manifestHash: string,
+    runtimeProvider: RuntimeProviderName,
+    input: PeerInvokeInput,
+  ): PeerInvocationRecord {
+    return {
+      id: randomUUID(),
+      workspaceId: this.options.workspaceId,
+      peerRecordId,
+      peerId,
+      manifestId,
+      manifestHash,
+      toolName: input.tool,
+      argsHash: hashJson(input.args),
+      resultHash: null,
+      status: "queued",
+      runtimeProvider,
+      result: null,
+      error: null,
+      createdAt: new Date().toISOString(),
+      startedAt: null,
+      completedAt: null,
+    };
+  }
+}
+
+export function createPeerBroker(options: PeerBrokerOptions): PeerBroker {
+  return new PeerBroker(options);
+}

--- a/src/peer-notebook/index.ts
+++ b/src/peer-notebook/index.ts
@@ -1,0 +1,35 @@
+export { createPeerBroker, PeerBroker } from "./broker.js";
+export type { PeerBrokerOptions, PeerInvokeInput, PeerInvokeResult } from "./broker.js";
+export { BrokerProxy } from "./broker-proxy.js";
+export type { BrokerProxyCall, BrokerProxyClient, BrokerProxyResult, BrokerProxyTarget } from "./broker-proxy.js";
+export { compilePeerManifestDraft, canonicalizeJson, hashJson } from "./manifest.js";
+export { validateJsonSchemaSubset } from "./json-schema.js";
+export { MockPeerRuntimeProvider } from "./mock-runtime-provider.js";
+export { InMemoryPeerNotebookRepository } from "./repositories.js";
+export type { PeerNotebookRepository, SaveArtifactInput } from "./repositories.js";
+export type {
+  CompiledPeerManifest,
+  JsonObject,
+  JsonPrimitive,
+  JsonSchemaSubset,
+  JsonValue,
+  ManifestDraftSource,
+  PeerArtifactRecord,
+  PeerInvocationRecord,
+  PeerManifest,
+  PeerManifestRecord,
+  PeerManifestStatus,
+  PeerNotebookRecord,
+  PeerNotebookStatus,
+  PeerToolManifest,
+  PeerTraceEventRecord,
+  RuntimeProviderName,
+} from "./types.js";
+export { PeerNotebookError } from "./types.js";
+export type {
+  RuntimeArtifactOutput,
+  RuntimeInvocationInput,
+  RuntimeInvocationResult,
+  RuntimeProvider,
+  RuntimeProviderDescription,
+} from "./runtime-provider.js";

--- a/src/peer-notebook/json-schema.ts
+++ b/src/peer-notebook/json-schema.ts
@@ -1,0 +1,88 @@
+import type { JsonSchemaSubset, JsonValue } from "./types.js";
+
+export interface SchemaValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+export function validateJsonSchemaSubset(
+  value: unknown,
+  schema: JsonSchemaSubset,
+  path = "$",
+): SchemaValidationResult {
+  const errors: string[] = [];
+  validateValue(value, schema, path, errors);
+  return { valid: errors.length === 0, errors };
+}
+
+function validateValue(
+  value: unknown,
+  schema: JsonSchemaSubset,
+  path: string,
+  errors: string[],
+): void {
+  if (schema.type && !matchesType(value, schema.type)) {
+    errors.push(`${path} must be ${schema.type}`);
+    return;
+  }
+
+  if (schema.type === "object" || schema.properties || schema.required) {
+    if (!isRecord(value)) {
+      errors.push(`${path} must be object`);
+      return;
+    }
+
+    for (const requiredKey of schema.required ?? []) {
+      if (!(requiredKey in value)) {
+        errors.push(`${path}.${requiredKey} is required`);
+      }
+    }
+
+    for (const [key, propertySchema] of Object.entries(schema.properties ?? {})) {
+      if (key in value) {
+        validateValue(value[key], propertySchema, `${path}.${key}`, errors);
+      }
+    }
+
+    if (schema.additionalProperties === false) {
+      const allowed = new Set(Object.keys(schema.properties ?? {}));
+      for (const key of Object.keys(value)) {
+        if (!allowed.has(key)) {
+          errors.push(`${path}.${key} is not allowed`);
+        }
+      }
+    }
+  }
+
+  if (schema.type === "array" || schema.items) {
+    if (!Array.isArray(value)) {
+      errors.push(`${path} must be array`);
+      return;
+    }
+
+    if (schema.items) {
+      value.forEach((item, index) => validateValue(item, schema.items!, `${path}[${index}]`, errors));
+    }
+  }
+}
+
+function matchesType(value: unknown, type: NonNullable<JsonSchemaSubset["type"]>): boolean {
+  switch (type) {
+    case "object":
+      return isRecord(value);
+    case "array":
+      return Array.isArray(value);
+    case "string":
+      return typeof value === "string";
+    case "number":
+      return typeof value === "number" && Number.isFinite(value);
+    case "boolean":
+      return typeof value === "boolean";
+    case "null":
+      return value === null;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, JsonValue> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}

--- a/src/peer-notebook/manifest.ts
+++ b/src/peer-notebook/manifest.ts
@@ -124,23 +124,30 @@ export function compilePeerManifestDraft(sources: ManifestDraftSource[]): Compil
 }
 
 export function canonicalizeJson(value: unknown): string {
-  return JSON.stringify(sortJson(value));
+  const canonical = JSON.stringify(sortJson(value));
+  if (canonical === undefined) {
+    throw new TypeError("Cannot canonicalize top-level undefined or non-JSON value");
+  }
+  return canonical;
 }
 
 export function hashJson(value: unknown): string {
   return `sha256:${createHash("sha256").update(canonicalizeJson(value), "utf8").digest("hex")}`;
 }
 
-function sortJson(value: unknown): JsonValue {
+function sortJson(value: unknown, inArray = false): JsonValue | undefined {
   if (Array.isArray(value)) {
-    return value.map(item => sortJson(item));
+    return value.map(item => sortJson(item, true) ?? null);
   }
 
   if (value && typeof value === "object") {
     return Object.fromEntries(
       Object.entries(value as Record<string, unknown>)
         .sort(([left], [right]) => left.localeCompare(right))
-        .map(([key, nested]) => [key, sortJson(nested)]),
+        .flatMap(([key, nested]) => {
+          const sorted = sortJson(nested);
+          return sorted === undefined ? [] : [[key, sorted]];
+        }),
     );
   }
 
@@ -148,5 +155,5 @@ function sortJson(value: unknown): JsonValue {
     return value;
   }
 
-  return null;
+  return inArray ? null : undefined;
 }

--- a/src/peer-notebook/manifest.ts
+++ b/src/peer-notebook/manifest.ts
@@ -1,0 +1,152 @@
+import { createHash } from "node:crypto";
+import { z } from "zod";
+import type {
+  CompiledPeerManifest,
+  JsonSchemaSubset,
+  JsonValue,
+  ManifestDraftSource,
+  PeerManifest,
+} from "./types.js";
+import { PeerNotebookError } from "./types.js";
+
+const JsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number(),
+    z.boolean(),
+    z.null(),
+    z.array(JsonValueSchema),
+    z.record(JsonValueSchema),
+  ]),
+);
+
+const JsonSchemaSubsetSchema: z.ZodType<JsonSchemaSubset> = z.lazy(() =>
+  z.object({
+    type: z.enum(["object", "array", "string", "number", "boolean", "null"]).optional(),
+    properties: z.record(JsonSchemaSubsetSchema).optional(),
+    required: z.array(z.string()).optional(),
+    items: JsonSchemaSubsetSchema.optional(),
+    additionalProperties: z.boolean().optional(),
+  }) as z.ZodType<JsonSchemaSubset>,
+);
+
+const PeerManifestSchema: z.ZodType<PeerManifest> = z.object({
+  schemaVersion: z.literal("peer-notebook.v0"),
+  peerId: z.string().min(1),
+  notebookId: z.string().min(1),
+  runtime: z.object({
+    provider: z.enum(["mock", "local-process", "smolvm"]),
+    image: z.string().optional(),
+    cpus: z.number().positive().optional(),
+    memoryMiB: z.number().positive().optional(),
+    timeoutMs: z.number().positive().optional(),
+  }),
+  exposes: z.object({
+    tools: z.array(z.object({
+      name: z.string().min(1),
+      description: z.string(),
+      inputSchema: JsonSchemaSubsetSchema,
+      outputSchema: JsonSchemaSubsetSchema,
+    })),
+    resources: z.array(JsonValueSchema),
+    prompts: z.array(JsonValueSchema),
+  }),
+  mayCall: z.object({
+    mcpTools: z.array(z.string()),
+  }),
+  network: z.object({
+    enabled: z.boolean(),
+    allowHosts: z.array(z.string()),
+  }),
+  filesystem: z.object({
+    mounts: z.array(z.object({
+      name: z.string(),
+      mode: z.enum(["ro", "rw"]),
+      target: z.string(),
+    })),
+  }),
+  secrets: z.object({
+    bindings: z.array(JsonValueSchema),
+  }),
+  persistence: z.object({
+    snapshot: z.enum(["manual", "never", "onInvoke"]).optional(),
+    exportNotebookOnInvoke: z.boolean().optional(),
+    retainArtifactsDays: z.number().nonnegative().optional(),
+  }),
+  budgets: z.object({
+    maxDurationMs: z.number().positive(),
+    maxToolCalls: z.number().nonnegative(),
+    maxArtifactBytes: z.number().nonnegative(),
+  }),
+});
+
+export function compilePeerManifestDraft(sources: ManifestDraftSource[]): CompiledPeerManifest {
+  const manifestSources = sources.filter(source => source.name === "peer.manifest.json");
+  if (manifestSources.length !== 1) {
+    throw new PeerNotebookError(
+      "manifest_compile_error",
+      `Expected exactly one peer.manifest.json draft source, found ${manifestSources.length}`,
+    );
+  }
+
+  const [source] = manifestSources;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(source.content);
+  } catch (error) {
+    throw new PeerNotebookError(
+      "manifest_compile_error",
+      "peer.manifest.json is not valid JSON",
+      { message: error instanceof Error ? error.message : String(error) },
+    );
+  }
+
+  const result = PeerManifestSchema.safeParse(parsed);
+  if (!result.success) {
+    throw new PeerNotebookError(
+      "manifest_compile_error",
+      "peer.manifest.json failed manifest validation",
+      { issues: result.error.issues as unknown as JsonValue },
+    );
+  }
+
+  const canonicalJson = canonicalizeJson(result.data);
+  return {
+    manifest: result.data,
+    canonicalJson,
+    manifestHash: `sha256:${createHash("sha256").update(canonicalJson, "utf8").digest("hex")}`,
+    status: "draft",
+    compiledFrom: {
+      sourceName: source.name,
+      sourceType: source.sourceType ?? "file",
+    },
+  };
+}
+
+export function canonicalizeJson(value: unknown): string {
+  return JSON.stringify(sortJson(value));
+}
+
+export function hashJson(value: unknown): string {
+  return `sha256:${createHash("sha256").update(canonicalizeJson(value), "utf8").digest("hex")}`;
+}
+
+function sortJson(value: unknown): JsonValue {
+  if (Array.isArray(value)) {
+    return value.map(item => sortJson(item));
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, nested]) => [key, sortJson(nested)]),
+    );
+  }
+
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean" || value === null) {
+    return value;
+  }
+
+  return null;
+}

--- a/src/peer-notebook/mock-runtime-provider.ts
+++ b/src/peer-notebook/mock-runtime-provider.ts
@@ -1,0 +1,93 @@
+import type {
+  RuntimeInvocationInput,
+  RuntimeInvocationResult,
+  RuntimeProvider,
+  RuntimeProviderDescription,
+} from "./runtime-provider.js";
+import type { JsonObject } from "./types.js";
+import { PeerNotebookError } from "./types.js";
+
+export class MockPeerRuntimeProvider implements RuntimeProvider {
+  readonly invocations: RuntimeInvocationInput[] = [];
+
+  describe(): RuntimeProviderDescription {
+    return {
+      provider: "mock",
+      isolation: "mock",
+      supportsCancel: true,
+      supportsSnapshots: false,
+    };
+  }
+
+  async invoke(input: RuntimeInvocationInput): Promise<RuntimeInvocationResult> {
+    this.invocations.push(input);
+
+    if (input.tool !== "extract_claims") {
+      throw new PeerNotebookError("tool_not_found", `Mock provider only supports extract_claims, got ${input.tool}`);
+    }
+
+    const textArtifactId = input.args.textArtifactId;
+    if (typeof textArtifactId !== "string") {
+      throw new PeerNotebookError("invalid_args", "extract_claims requires textArtifactId");
+    }
+
+    const read = await input.brokerProxy.callTool("artifact.get", { artifactId: textArtifactId });
+    if (!read.ok) {
+      throw new PeerNotebookError("outbound_denied", read.error.message);
+    }
+
+    await input.brokerProxy.callTool("thoughtbox.knowledge.queryGraph", { query: "denied pilot probe" });
+
+    const artifactContent = read.result as { artifact?: { content?: unknown } };
+    const text = extractText(artifactContent.artifact?.content);
+    const claims = extractClaims(text);
+    const claimsArtifactId = `${input.invocationId}-claims`;
+    const claimsJson: JsonObject = { claims };
+
+    return {
+      result: {
+        claimsArtifactId,
+        claimCount: claims.length,
+      },
+      artifacts: [
+        {
+          artifactId: claimsArtifactId,
+          kind: "json",
+          name: "claims.json",
+          mimeType: "application/json",
+          content: claimsJson,
+          preview: claimsJson,
+        },
+      ],
+    };
+  }
+
+  async cancel(): Promise<void> {}
+
+  async "snapshot/export"(): Promise<null> {
+    return null;
+  }
+
+  async heartbeat(): Promise<void> {}
+}
+
+function extractText(content: unknown): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (content && typeof content === "object" && "text" in content && typeof content.text === "string") {
+    return content.text;
+  }
+  return "";
+}
+
+function extractClaims(text: string): JsonObject[] {
+  return text
+    .split(/[.!?\n]+/)
+    .map(claim => claim.trim())
+    .filter(Boolean)
+    .map((claim, index) => ({
+      id: `claim_${index + 1}`,
+      text: claim,
+    }));
+}

--- a/src/peer-notebook/repositories.ts
+++ b/src/peer-notebook/repositories.ts
@@ -19,6 +19,7 @@ export interface PeerNotebookRepository {
   saveInvocation(invocation: PeerInvocationRecord): Promise<void>;
   updateInvocation(invocation: PeerInvocationRecord): Promise<void>;
   getInvocation(workspaceId: string, invocationId: string): Promise<PeerInvocationRecord | null>;
+  listInvocations(workspaceId: string): Promise<PeerInvocationRecord[]>;
   appendTraceEvent(event: Omit<PeerTraceEventRecord, "id" | "seq" | "timestampAt">): Promise<PeerTraceEventRecord>;
   listTraceEvents(workspaceId: string, invocationId: string): Promise<PeerTraceEventRecord[]>;
   saveArtifactInput(input: SaveArtifactInput): Promise<PeerArtifactRecord>;
@@ -68,13 +69,17 @@ export class InMemoryPeerNotebookRepository implements PeerNotebookRepository {
 
   async updateInvocation(invocation: PeerInvocationRecord): Promise<void> {
     if (!this.invocations.has(invocationKey(invocation.workspaceId, invocation.id))) {
-      throw new PeerNotebookError("peer_not_found", `Invocation ${invocation.id} does not exist`);
+      throw new PeerNotebookError("invocation_not_found", `Invocation ${invocation.id} does not exist`);
     }
     await this.saveInvocation(invocation);
   }
 
   async getInvocation(workspaceId: string, invocationId: string): Promise<PeerInvocationRecord | null> {
     return this.invocations.get(invocationKey(workspaceId, invocationId)) ?? null;
+  }
+
+  async listInvocations(workspaceId: string): Promise<PeerInvocationRecord[]> {
+    return [...this.invocations.values()].filter(invocation => invocation.workspaceId === workspaceId);
   }
 
   async appendTraceEvent(

--- a/src/peer-notebook/repositories.ts
+++ b/src/peer-notebook/repositories.ts
@@ -1,0 +1,148 @@
+import { createHash, randomUUID } from "node:crypto";
+import type {
+  ArtifactKind,
+  JsonValue,
+  PeerArtifactRecord,
+  PeerInvocationRecord,
+  PeerManifestRecord,
+  PeerNotebookRecord,
+  PeerTraceEventRecord,
+} from "./types.js";
+import { PeerNotebookError } from "./types.js";
+import { canonicalizeJson } from "./manifest.js";
+
+export interface PeerNotebookRepository {
+  savePeer(peer: PeerNotebookRecord): Promise<void>;
+  getPeerByPeerId(workspaceId: string, peerId: string): Promise<PeerNotebookRecord | null>;
+  saveManifest(manifest: PeerManifestRecord): Promise<void>;
+  getManifest(workspaceId: string, manifestId: string): Promise<PeerManifestRecord | null>;
+  saveInvocation(invocation: PeerInvocationRecord): Promise<void>;
+  updateInvocation(invocation: PeerInvocationRecord): Promise<void>;
+  getInvocation(workspaceId: string, invocationId: string): Promise<PeerInvocationRecord | null>;
+  appendTraceEvent(event: Omit<PeerTraceEventRecord, "id" | "seq" | "timestampAt">): Promise<PeerTraceEventRecord>;
+  listTraceEvents(workspaceId: string, invocationId: string): Promise<PeerTraceEventRecord[]>;
+  saveArtifactInput(input: SaveArtifactInput): Promise<PeerArtifactRecord>;
+  getArtifact(workspaceId: string, artifactId: string): Promise<PeerArtifactRecord | null>;
+  listArtifacts(workspaceId: string, invocationId: string): Promise<PeerArtifactRecord[]>;
+}
+
+export interface SaveArtifactInput {
+  id?: string;
+  workspaceId: string;
+  invocationId: string | null;
+  peerRecordId: string | null;
+  peerId: string | null;
+  kind: ArtifactKind;
+  name: string;
+  mimeType: string;
+  content: JsonValue;
+  preview?: JsonValue;
+}
+
+export class InMemoryPeerNotebookRepository implements PeerNotebookRepository {
+  private peers = new Map<string, PeerNotebookRecord>();
+  private manifests = new Map<string, PeerManifestRecord>();
+  private invocations = new Map<string, PeerInvocationRecord>();
+  private traceEvents = new Map<string, PeerTraceEventRecord[]>();
+  private artifacts = new Map<string, PeerArtifactRecord>();
+
+  async savePeer(peer: PeerNotebookRecord): Promise<void> {
+    this.peers.set(peerKey(peer.workspaceId, peer.peerId), { ...peer });
+  }
+
+  async getPeerByPeerId(workspaceId: string, peerId: string): Promise<PeerNotebookRecord | null> {
+    return this.peers.get(peerKey(workspaceId, peerId)) ?? null;
+  }
+
+  async saveManifest(manifest: PeerManifestRecord): Promise<void> {
+    this.manifests.set(manifestKey(manifest.workspaceId, manifest.id), { ...manifest });
+  }
+
+  async getManifest(workspaceId: string, manifestId: string): Promise<PeerManifestRecord | null> {
+    return this.manifests.get(manifestKey(workspaceId, manifestId)) ?? null;
+  }
+
+  async saveInvocation(invocation: PeerInvocationRecord): Promise<void> {
+    this.invocations.set(invocationKey(invocation.workspaceId, invocation.id), { ...invocation });
+  }
+
+  async updateInvocation(invocation: PeerInvocationRecord): Promise<void> {
+    if (!this.invocations.has(invocationKey(invocation.workspaceId, invocation.id))) {
+      throw new PeerNotebookError("peer_not_found", `Invocation ${invocation.id} does not exist`);
+    }
+    await this.saveInvocation(invocation);
+  }
+
+  async getInvocation(workspaceId: string, invocationId: string): Promise<PeerInvocationRecord | null> {
+    return this.invocations.get(invocationKey(workspaceId, invocationId)) ?? null;
+  }
+
+  async appendTraceEvent(
+    event: Omit<PeerTraceEventRecord, "id" | "seq" | "timestampAt">,
+  ): Promise<PeerTraceEventRecord> {
+    const key = invocationKey(event.workspaceId, event.invocationId);
+    const existing = this.traceEvents.get(key) ?? [];
+    const record: PeerTraceEventRecord = {
+      ...event,
+      id: randomUUID(),
+      seq: existing.length + 1,
+      timestampAt: new Date().toISOString(),
+    };
+    this.traceEvents.set(key, [...existing, record]);
+    return record;
+  }
+
+  async listTraceEvents(workspaceId: string, invocationId: string): Promise<PeerTraceEventRecord[]> {
+    return [...(this.traceEvents.get(invocationKey(workspaceId, invocationId)) ?? [])];
+  }
+
+  async saveArtifactInput(input: SaveArtifactInput): Promise<PeerArtifactRecord> {
+    const payload = canonicalizeJson(input.content);
+    const id = input.id ?? randomUUID();
+    const record: PeerArtifactRecord = {
+      id,
+      workspaceId: input.workspaceId,
+      invocationId: input.invocationId,
+      peerRecordId: input.peerRecordId,
+      peerId: input.peerId,
+      kind: input.kind,
+      name: input.name,
+      mimeType: input.mimeType,
+      byteSize: Buffer.byteLength(payload, "utf8"),
+      sha256: createHash("sha256").update(payload, "utf8").digest("hex"),
+      storageBackend: "memory",
+      storagePath: `memory://${input.workspaceId}/${input.peerId ?? "unowned"}/${id}/${input.name}`,
+      preview: input.preview,
+      content: input.content,
+      createdAt: new Date().toISOString(),
+    };
+    this.artifacts.set(artifactKey(record.workspaceId, record.id), record);
+    return record;
+  }
+
+  async getArtifact(workspaceId: string, artifactId: string): Promise<PeerArtifactRecord | null> {
+    return this.artifacts.get(artifactKey(workspaceId, artifactId)) ?? null;
+  }
+
+  async listArtifacts(workspaceId: string, invocationId: string): Promise<PeerArtifactRecord[]> {
+    return [...this.artifacts.values()].filter(
+      artifact => artifact.workspaceId === workspaceId && artifact.invocationId === invocationId,
+    );
+  }
+}
+
+function peerKey(workspaceId: string, peerId: string): string {
+  return `${workspaceId}:${peerId}`;
+}
+
+function manifestKey(workspaceId: string, manifestId: string): string {
+  return `${workspaceId}:${manifestId}`;
+}
+
+function invocationKey(workspaceId: string, invocationId: string): string {
+  return `${workspaceId}:${invocationId}`;
+}
+
+function artifactKey(workspaceId: string, artifactId: string): string {
+  return `${workspaceId}:${artifactId}`;
+}

--- a/src/peer-notebook/runtime-provider.ts
+++ b/src/peer-notebook/runtime-provider.ts
@@ -1,0 +1,53 @@
+import type { BrokerProxyClient } from "./broker-proxy.js";
+import type {
+  ArtifactKind,
+  JsonObject,
+  JsonValue,
+  RuntimeProviderName,
+} from "./types.js";
+
+export interface RuntimeProviderDescription {
+  provider: RuntimeProviderName;
+  isolation: "mock" | "none" | "external";
+  supportsCancel: boolean;
+  supportsSnapshots: boolean;
+}
+
+export interface RuntimeInvocationInput {
+  invocationId: string;
+  workspaceId: string;
+  peerId: string;
+  manifestHash: string;
+  tool: string;
+  args: JsonObject;
+  brokerProxyUrl: string;
+  scopedToken: string;
+  budgets: {
+    maxDurationMs: number;
+    maxToolCalls: number;
+    maxArtifactBytes: number;
+  };
+  brokerProxy: BrokerProxyClient;
+}
+
+export interface RuntimeArtifactOutput {
+  artifactId: string;
+  kind: ArtifactKind;
+  name: string;
+  mimeType: string;
+  content: JsonValue;
+  preview?: JsonValue;
+}
+
+export interface RuntimeInvocationResult {
+  result: JsonValue;
+  artifacts: RuntimeArtifactOutput[];
+}
+
+export interface RuntimeProvider {
+  describe(): RuntimeProviderDescription;
+  invoke(input: RuntimeInvocationInput): Promise<RuntimeInvocationResult>;
+  cancel(input: { invocationId: string }): Promise<void>;
+  "snapshot/export"(input: { invocationId: string }): Promise<JsonValue>;
+  heartbeat(input: { peerRuntimeId: string; invocationId: string }): Promise<void>;
+}

--- a/src/peer-notebook/types.ts
+++ b/src/peer-notebook/types.ts
@@ -1,0 +1,190 @@
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
+export type JsonObject = { [key: string]: JsonValue };
+
+export type PeerManifestStatus = "draft" | "approved" | "active" | "retired" | "rejected";
+export type PeerNotebookStatus = "draft" | "active" | "disabled" | "archived";
+export type PeerInvocationStatus =
+  | "queued"
+  | "running"
+  | "completed"
+  | "failed"
+  | "denied"
+  | "timeout"
+  | "cancelled";
+
+export type RuntimeProviderName = "mock" | "local-process" | "smolvm";
+export type ArtifactKind = "notebook_export" | "json" | "log" | "dataset" | "report" | "binary";
+
+export interface JsonSchemaSubset {
+  type?: "object" | "array" | "string" | "number" | "boolean" | "null";
+  properties?: Record<string, JsonSchemaSubset>;
+  required?: string[];
+  items?: JsonSchemaSubset;
+  additionalProperties?: boolean;
+}
+
+export interface PeerToolManifest {
+  name: string;
+  description: string;
+  inputSchema: JsonSchemaSubset;
+  outputSchema: JsonSchemaSubset;
+}
+
+export interface PeerManifest {
+  schemaVersion: "peer-notebook.v0";
+  peerId: string;
+  notebookId: string;
+  runtime: {
+    provider: RuntimeProviderName;
+    image?: string;
+    cpus?: number;
+    memoryMiB?: number;
+    timeoutMs?: number;
+  };
+  exposes: {
+    tools: PeerToolManifest[];
+    resources: JsonValue[];
+    prompts: JsonValue[];
+  };
+  mayCall: {
+    mcpTools: string[];
+  };
+  network: {
+    enabled: boolean;
+    allowHosts: string[];
+  };
+  filesystem: {
+    mounts: Array<{
+      name: string;
+      mode: "ro" | "rw";
+      target: string;
+    }>;
+  };
+  secrets: {
+    bindings: JsonValue[];
+  };
+  persistence: {
+    snapshot?: "manual" | "never" | "onInvoke";
+    exportNotebookOnInvoke?: boolean;
+    retainArtifactsDays?: number;
+  };
+  budgets: {
+    maxDurationMs: number;
+    maxToolCalls: number;
+    maxArtifactBytes: number;
+  };
+}
+
+export interface ManifestDraftSource {
+  name: string;
+  content: string;
+  sourceType?: "file" | "cell";
+}
+
+export interface CompiledPeerManifest {
+  manifest: PeerManifest;
+  canonicalJson: string;
+  manifestHash: string;
+  status: "draft";
+  compiledFrom: {
+    sourceName: string;
+    sourceType: "file" | "cell";
+  };
+}
+
+export interface PeerNotebookRecord {
+  id: string;
+  workspaceId: string;
+  peerId: string;
+  displayName: string;
+  description?: string;
+  status: PeerNotebookStatus;
+  activeManifestId: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PeerManifestRecord {
+  id: string;
+  workspaceId: string;
+  peerRecordId: string;
+  peerId: string;
+  version: number;
+  schemaVersion: string;
+  manifest: PeerManifest;
+  manifestHash: string;
+  status: PeerManifestStatus;
+  compiledFrom: CompiledPeerManifest["compiledFrom"];
+  createdAt: string;
+}
+
+export interface PeerInvocationRecord {
+  id: string;
+  workspaceId: string;
+  peerRecordId: string;
+  peerId: string;
+  manifestId: string;
+  manifestHash: string;
+  toolName: string;
+  argsHash: string;
+  resultHash: string | null;
+  status: PeerInvocationStatus;
+  runtimeProvider: RuntimeProviderName;
+  result: JsonValue | null;
+  error: JsonValue | null;
+  createdAt: string;
+  startedAt: string | null;
+  completedAt: string | null;
+}
+
+export interface PeerTraceEventRecord {
+  id: string;
+  workspaceId: string;
+  invocationId: string;
+  seq: number;
+  eventType: string;
+  severity: "debug" | "info" | "warn" | "error";
+  timestampAt: string;
+  body?: string;
+  attrs: JsonObject;
+}
+
+export interface PeerArtifactRecord {
+  id: string;
+  workspaceId: string;
+  invocationId: string | null;
+  peerRecordId: string | null;
+  peerId: string | null;
+  kind: ArtifactKind;
+  name: string;
+  mimeType: string;
+  byteSize: number;
+  sha256: string;
+  storageBackend: "memory";
+  storagePath: string;
+  preview?: JsonValue;
+  content: JsonValue;
+  createdAt: string;
+}
+
+export class PeerNotebookError extends Error {
+  constructor(
+    public readonly code:
+      | "manifest_compile_error"
+      | "peer_not_found"
+      | "peer_not_active"
+      | "manifest_not_active"
+      | "tool_not_found"
+      | "invalid_args"
+      | "invalid_result"
+      | "runtime_provider_not_found"
+      | "artifact_not_found"
+      | "outbound_denied",
+    message: string,
+    public readonly details?: JsonValue,
+  ) {
+    super(message);
+    this.name = "PeerNotebookError";
+  }
+}

--- a/src/peer-notebook/types.ts
+++ b/src/peer-notebook/types.ts
@@ -172,6 +172,7 @@ export class PeerNotebookError extends Error {
   constructor(
     public readonly code:
       | "manifest_compile_error"
+      | "invocation_not_found"
       | "peer_not_found"
       | "peer_not_active"
       | "manifest_not_active"
@@ -180,7 +181,8 @@ export class PeerNotebookError extends Error {
       | "invalid_result"
       | "runtime_provider_not_found"
       | "artifact_not_found"
-      | "outbound_denied",
+      | "outbound_denied"
+      | "timeout",
     message: string,
     public readonly details?: JsonValue,
   ) {


### PR DESCRIPTION
## Summary

Implements the smallest viable MCP Peer Notebooks claim-extractor pilot control-plane slice.

Adds `src/peer-notebook/` with:

- `peer.manifest.json` draft compilation and validation
- canonical manifest JSON hashing as `sha256:<hex>`
- in-memory peer, manifest, invocation, trace, and artifact repositories
- broker facade shape: `peer.invoke({ peerId, tool, args })`
- runtime provider interface
- mock claim-extractor runtime provider
- broker proxy allow/deny policy for outbound calls
- focused Vitest coverage for the pilot invariants

## Scope Notes

- Uses mock runtime provider only
- No Supabase migrations
- No web app pages
- No local-process provider
- No smolvm provider
- No public/direct runtime MCP surface
- Cloud Run remains API/control plane only

## Validation

- `pnpm exec vitest run src/peer-notebook/__tests__`
- `pnpm check:types`
- `pnpm check:lint`
- `pnpm build:local`

## Tracking

Beads: `thoughtbox-nb5`
