### PR TITLE
Feat/peer notebook mcp surface

### DIFF
--- a/.claude/skills/peer-notebook-delivery-guard/SKILL.md
+++ b/.claude/skills/peer-notebook-delivery-guard/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: peer-notebook-delivery-guard
+description: >
+  Govern ADR-022 MCP peer notebook implementation units. Use before or during
+  durable control-plane, manifest lifecycle, web app inspection, runtime
+  provider, or isolation/policy hardening work to prevent mock substitution,
+  scope drift, and incomplete acceptance evidence.
+argument-hint: <unit name or implementation plan>
+user-invocable: true
+allowed-tools: Read, Glob, Grep, Bash, Edit, Write
+---
+
+Guard MCP peer notebook delivery for: $ARGUMENTS
+
+## Purpose
+
+This skill is the delivery guardrail for ADR-022. It keeps large implementation
+units aligned with the brokered peer notebook end state:
+
+- governed peer identities
+- approved manifests
+- brokered inbound invocation
+- broker-proxied outbound access
+- durable invocations, traces, and artifacts
+- web-app inspection
+- real runtime providers behind explicit contracts
+
+Use this skill whenever work touches `.specs/mcp-peer-notebooks/`,
+`.adr/staging/ADR-022.json`, `src/peer-notebook/`, peer notebook Supabase
+migrations, peer notebook web app routes, or runtime providers.
+
+## Required Reads
+
+Read these before planning or editing:
+
+1. `AGENTS.md`
+2. `.adr/staging/ADR-022.json`
+3. `.specs/mcp-peer-notebooks/SPEC-CONTROL-PLANE.md`
+4. `.specs/mcp-peer-notebooks/README.md`
+5. `.specs/mcp-peer-notebooks/NEXT-IMPLEMENTATION-HANDOFF.md`
+
+If the work touches app UI, also read `apps/web/AGENTS.md`.
+
+## Hard Rule
+
+Mocks are contract fixtures, not final substitutes.
+
+A mock, in-memory store, stubbed provider, fake broker target, or local-only
+stand-in may prove shape, schema, trace semantics, and client reachability. It
+does not satisfy the production requirement for the capability it represents.
+
+Before any unit is complete, every mocked or in-memory component touched must
+be either:
+
+1. replaced by a real implementation behind the same contract,
+2. narrowed to test-only/non-production use by code and docs, or
+3. explicitly deferred with a Beads issue that names the real replacement.
+
+If a mock fulfills the function of the thing it mocks in a final acceptance
+claim, the unit is not complete.
+
+## Large Unit Boundaries
+
+Pick exactly one primary unit unless the user explicitly asks for a larger
+combined effort.
+
+| Unit | Capability Produced | Explicit Non-Goals |
+| --- | --- | --- |
+| Durable Control Plane | Supabase-backed peers, manifests, invocations, traces, and artifacts while runtime remains mock-capable | Web app pages, real runtime isolation |
+| Manifest Lifecycle And Notebook Graduation | Compile `peer.manifest.json` from real notebook source, store drafts, approve/activate/retire manifests | Runtime provider expansion, UI beyond minimal admin/read APIs |
+| Web App Inspection Surface | Peer registry/detail, invocation list/detail, trace timeline, artifact preview from durable rows | New runtime providers, migration redesign |
+| Real Runtime Provider Path | `local-process` integration provider behind runtime contract, marked development-only | Production isolation claims |
+| Production Isolation And Policy Hardening | Isolated execution provider, enforced network/filesystem/secrets/budget policy, adversarial acceptance | Treating local-process or mock as production |
+
+If work crosses a unit boundary, stop and create/link Beads issues for the
+extra unit before proceeding.
+
+## Workflow
+
+### 1. Classify The Unit
+
+Write a short classification before editing:
+
+```text
+Unit:
+ADR claims advanced:
+Spec sections touched:
+Production capability expected:
+Mocks/in-memory components involved:
+Explicit non-goals:
+Beads issue:
+```
+
+If there is no Beads issue, create one with `bd create ... --json`, claim it,
+and link discovered follow-ups with `discovered-from`.
+
+### 2. Define Acceptance Before Code
+
+Every unit must have observable acceptance criteria before implementation:
+
+- positive path
+- negative path
+- workspace scoping path where relevant
+- trace/artifact/read-model evidence where relevant
+- mock accountability outcome
+
+Acceptance must name concrete files, rows, API responses, UI states, or tests.
+Avoid acceptance phrased only as "implemented support for X."
+
+### 3. Mock Accountability Gate
+
+Before code review or completion, produce this table:
+
+| Component | Real Capability It Stands In For | Current Scope | Replaced/Narrowed/Deferred | Beads Follow-Up |
+| --- | --- | --- | --- | --- |
+| `MockPeerRuntimeProvider` | Runtime execution provider | test/pilot | deferred | `thoughtbox-...` |
+
+Rules:
+
+- `Current Scope` must be `test-only`, `pilot-only`, `development-only`, or
+  `production`.
+- `production` is allowed only for real implementations.
+- If `Deferred`, the follow-up issue is mandatory.
+- If the unit claims final acceptance for a capability, the corresponding row
+  cannot be `mock`, `in-memory`, or `stub`.
+
+### 4. Unit Failure-Mode Gates
+
+Apply only the gate for the active unit.
+
+#### Durable Control Plane
+
+Reject the unit if:
+
+- schema names drift from `SPEC-CONTROL-PLANE.md` without a spec update
+- workspace scoping is not tested
+- in-memory repository remains the only implementation
+- trace or artifact writes can partially succeed without visible status/error
+- durable seed -> invoke -> trace -> artifact flow is untested
+
+Required evidence:
+
+- migration files
+- repository contract tests against Supabase-shaped storage
+- verification query or test proving invocation, trace, and artifact rows exist
+
+#### Manifest Lifecycle And Notebook Graduation
+
+Reject the unit if:
+
+- compiling a manifest executes notebook code
+- draft manifests can be invoked
+- notebook edits silently change active capabilities
+- manifest hash is unstable across equivalent JSON
+- approval/activation can be bypassed
+
+Required evidence:
+
+- malformed JSON, duplicate manifest, draft, active, retired, and expansion
+  denial tests
+- active manifest hash asserted during invocation
+
+#### Web App Inspection Surface
+
+Reject the unit if:
+
+- UI reads mock/local state instead of durable rows
+- denied calls are hidden
+- artifact previews fetch unbounded full payloads
+- workspace filtering is not represented in query tests or fixtures
+- `src/observatory` becomes a deployed dependency
+
+Required evidence:
+
+- browser or component tests for peer detail, invocation detail, denied event,
+  and artifact preview states
+
+#### Real Runtime Provider Path
+
+Reject the unit if:
+
+- `local-process` is described as production isolation
+- provider behavior diverges from mock contract tests
+- runtime can bypass broker proxy for Thoughtbox/MCP calls
+- runtime writes final artifacts outside broker-owned artifact paths
+- timeout/cancel/failure transitions are ambiguous
+
+Required evidence:
+
+- shared provider contract tests
+- explicit development-only labeling for local-process
+- queued -> running -> terminal status tests
+
+#### Production Isolation And Policy Hardening
+
+Reject the unit if:
+
+- Cloud Run becomes the privileged execution host
+- network, filesystem, secrets, or outbound tool policy is doc-only
+- budget counters are not enforced and traceable
+- denied outbound calls can reach the target
+- mock or local-process satisfies production isolation acceptance
+
+Required evidence:
+
+- adversarial tests for denied network/tool/filesystem/secrets access
+- isolated provider end-to-end acceptance
+- persisted budget and denial trace events
+
+### 5. Implementation Discipline
+
+- Preserve broker/repository/runtime contracts unless the ADR/spec changes.
+- Add real implementations beside mocks; do not mutate mocks into production
+  implementations.
+- Keep deferred surfaces deferred unless this unit explicitly owns them.
+- Update `.specs/` and ADR artifacts in the same commit as behavior changes.
+- Do not touch unrelated dirty files.
+
+### 6. Completion Report
+
+End with:
+
+```text
+Peer Notebook Delivery Guard Report
+
+Unit:
+Beads issue:
+ADR/spec alignment:
+Mocks touched:
+Mock accountability:
+Acceptance evidence:
+Tests run:
+Deferred issues filed:
+Known risks:
+Ready for PR/merge: yes|no
+```
+
+If `Ready for PR/merge` is `yes`, there must be no untracked mock replacement
+work hidden in prose.

--- a/.specs/mcp-peer-notebooks/NEXT-IMPLEMENTATION-HANDOFF.md
+++ b/.specs/mcp-peer-notebooks/NEXT-IMPLEMENTATION-HANDOFF.md
@@ -1,0 +1,26 @@
+# MCP Peer Notebooks Implementation Handoff
+
+**Status**: Follow-on handoff after the MCP-facing mock broker pilot
+**Date**: 2026-04-30
+**Governing ADR/spec**: ADR-022 and `SPEC-CONTROL-PLANE.md`
+**Current issue**: `thoughtbox-39o`
+
+## Completed In This Slice
+
+- Added `thoughtbox_peer_notebook` as the smallest MCP-facing pilot surface for
+  the existing mock `claim-extractor` broker.
+- Kept state in memory and execution mock-only.
+- Supported artifact seed, peer invoke, invocation read, trace event list, and
+  artifact read operations.
+- Bootstrapped one deterministic active `claim-extractor` manifest per
+  workspace using `compilePeerManifestDraft()`.
+- Registered only the mock runtime provider; `local-process` and `smolvm`
+  remain deferred.
+
+## Still Deferred
+
+- Supabase migrations and durable peer/artifact storage.
+- Web app pages for peer registry, invocations, traces, and artifacts.
+- Local-process provider.
+- smolvm provider and execution-plane infrastructure.
+- Public/direct runtime MCP.

--- a/.specs/mcp-peer-notebooks/README.md
+++ b/.specs/mcp-peer-notebooks/README.md
@@ -2,6 +2,8 @@
 
 **Status**: Research note / ADR-022 index
 **Created**: 2026-04-30
+**Current implementation**: Mock control-plane and MCP-facing pilot under
+`src/peer-notebook/`
 
 ## HDD Artifacts
 
@@ -51,6 +53,13 @@ Confirmed current capabilities:
   commands with `child_process.spawn`: `node`, `npx tsx`, or `pnpm install`.
 - Code Mode uses Node `vm` for JavaScript orchestration and explicitly treats it
   as defense-in-depth, not a true security boundary.
+- `src/peer-notebook/` contains the mock-only control-plane pilot: manifest
+  draft compilation from `peer.manifest.json`, canonical manifest hashing,
+  in-memory peer/manifest/invocation/trace/artifact repositories,
+  `peer.invoke({ peerId, tool, args })`, a runtime provider interface, a mock
+  `claim-extractor` provider, broker-proxy allow/deny policy tests, and the
+  MCP-facing `thoughtbox_peer_notebook` surface for in-memory seed/invoke/read
+  operations.
 - Existing specs already point toward related directions:
   - `.specs/thoughtbox-v1-finalstretch/SPEC-NOTEBOOK-RLM.md`
   - `.specs/SPEC-SRC-002-preview-lifecycle.md`
@@ -60,14 +69,14 @@ Confirmed current capabilities:
 
 Important non-capabilities today:
 
-- No peer notebook manifest.
-- No peer registry.
+- No durable Supabase peer notebook manifest, registry, invocation, trace, or
+  artifact tables yet.
 - No brokered notebook-to-notebook MCP routing.
-- No runtime lifecycle manager for notebook workers.
-- No durable artifact table/model specific to notebook outputs.
+- No runtime lifecycle manager for notebook workers beyond the mock provider
+  contract.
 - No web app view for peer invocations, peer traces, or peer artifacts.
 - No secure isolated execution boundary for notebook code.
-- No smolvm integration.
+- No local-process or smolvm provider integration.
 
 ## Product Concept
 

--- a/.specs/mcp-peer-notebooks/SPEC-CONTROL-PLANE.md
+++ b/.specs/mcp-peer-notebooks/SPEC-CONTROL-PLANE.md
@@ -15,6 +15,12 @@ Peer execution runs elsewhere through a runtime provider.
 This spec is documentation-only. It does not add runtime code, migrations, or
 web app routes.
 
+Implementation note: the `thoughtbox-39o` follow-on slice adds the first
+MCP-facing pilot surface, `thoughtbox_peer_notebook`, for the existing in-memory
+mock `claim-extractor` broker. It proves broker reachability through the MCP
+server without changing the deferred Supabase, web app, local-process, smolvm,
+or public/direct runtime MCP scope.
+
 ## Non-Goals
 
 - Do not implement peer runtime code.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,7 @@ If the user invokes one of these names, or the task clearly matches one, open th
 - **Mandatory workflow**: `hdd` (architectural decisions and new features)
 - **Conditional protocols**: `ulysses-protocol` (2+ consecutive surprises), `theseus-protocol` (refactoring tasks)
 - **Implementation**: `implement`
+- **Peer notebook delivery**: `peer-notebook-delivery-guard` (ADR-022 large-unit boundaries, mock accountability, acceptance gates)
 - **Research and knowledge**: `research-task`, `knowledge`, `synthesize`, `distill`, `capture-learning`, `session-review`, `assumptions`, `eval`, `taste`, `diagram`
 - **Coordination and autonomy**: `team`, `hub-collab`, `deploy-team-hub`, `experiment`, `ulc-loop`, `loop-status`, `status`, `escalate`, `claude-prompt`
 

--- a/src/code-mode/__tests__/server-surface.test.ts
+++ b/src/code-mode/__tests__/server-surface.test.ts
@@ -12,8 +12,13 @@ const silentLogger = {
   error: () => {},
 };
 
-describe("createMcpServer Code Mode surface", () => {
-  it("registers only the two public Code Mode tools", async () => {
+describe("createMcpServer tool surface", () => {
+  it("registers Code Mode and peer notebook public tools", async () => {
+    const previousSupabaseUrl = process.env.SUPABASE_URL;
+    const previousSupabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    process.env.SUPABASE_URL = "https://example.supabase.co";
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "test-service-role-key";
+
     const server = await createMcpServer({
       storage: new InMemoryStorage(),
       logger: silentLogger,
@@ -31,11 +36,26 @@ describe("createMcpServer Code Mode surface", () => {
       const { tools } = await client.listTools();
       const toolNames = tools.map((tool) => tool.name).sort();
 
-      expect(toolNames).toEqual(["thoughtbox_execute", "thoughtbox_search"]);
+      expect(toolNames).toEqual([
+        "thoughtbox_execute",
+        "thoughtbox_peer_notebook",
+        "thoughtbox_search",
+      ]);
       expect(client.getInstructions()).toContain("thoughtbox_search");
       expect(client.getInstructions()).toContain("thoughtbox_execute");
+      expect(client.getInstructions()).toContain("thoughtbox_peer_notebook");
     } finally {
       await Promise.allSettled([client.close(), server.close()]);
+      restoreEnv("SUPABASE_URL", previousSupabaseUrl);
+      restoreEnv("SUPABASE_SERVICE_ROLE_KEY", previousSupabaseServiceKey);
     }
   });
 });
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}

--- a/src/code-mode/__tests__/server-surface.test.ts
+++ b/src/code-mode/__tests__/server-surface.test.ts
@@ -133,6 +133,25 @@ describe("createMcpServer tool surface", () => {
           }),
         ]),
       );
+
+      const invalid = await client.callTool({
+        name: "thoughtbox_peer_notebook",
+        arguments: {
+          operation: "peer_invoke",
+          peerId: "claim-extractor",
+          tool: "extract_claims",
+          args: {},
+        },
+      });
+      const invalidPayload = parseToolJson<{
+        error: string;
+        code: string;
+        details: { errors: string[] };
+      }>(invalid);
+
+      expect(invalid.isError).toBe(true);
+      expect(invalidPayload.code).toBe("invalid_args");
+      expect(invalidPayload.details.errors).toEqual(expect.any(Array));
     } finally {
       await Promise.allSettled([client.close(), server.close()]);
       restoreEnv("SUPABASE_URL", previousSupabaseUrl);

--- a/src/code-mode/__tests__/server-surface.test.ts
+++ b/src/code-mode/__tests__/server-surface.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
 import { createMcpServer } from "../../server-factory.js";
 import { InMemoryStorage } from "../../persistence/index.js";
@@ -44,6 +45,94 @@ describe("createMcpServer tool surface", () => {
       expect(client.getInstructions()).toContain("thoughtbox_search");
       expect(client.getInstructions()).toContain("thoughtbox_execute");
       expect(client.getInstructions()).toContain("thoughtbox_peer_notebook");
+
+      const { resources } = await client.listResources();
+      expect(resources.map(resource => resource.uri)).toContain("thoughtbox://peer-notebook/pilot");
+    } finally {
+      await Promise.allSettled([client.close(), server.close()]);
+      restoreEnv("SUPABASE_URL", previousSupabaseUrl);
+      restoreEnv("SUPABASE_SERVICE_ROLE_KEY", previousSupabaseServiceKey);
+    }
+  });
+
+  it("invokes the mock peer notebook pilot through the MCP client", async () => {
+    const previousSupabaseUrl = process.env.SUPABASE_URL;
+    const previousSupabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    process.env.SUPABASE_URL = "https://example.supabase.co";
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "test-service-role-key";
+
+    const server = await createMcpServer({
+      storage: new InMemoryStorage(),
+      logger: silentLogger,
+      workspaceId: "workspace_peer_e2e",
+    });
+    const client = new Client(
+      { name: "peer-notebook-e2e-client", version: "1.0.0" },
+      { capabilities: {} },
+    );
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+    try {
+      await server.connect(serverTransport);
+      await client.connect(clientTransport);
+
+      const seeded = parseToolJson<{
+        artifact: { id: string; workspaceId: string; content: string };
+      }>(await client.callTool({
+        name: "thoughtbox_peer_notebook",
+        arguments: {
+          operation: "peer_artifact_seed",
+          text: "First claim. Second claim.",
+          name: "input.txt",
+        },
+      }));
+
+      expect(seeded.artifact.workspaceId).toBe("workspace_peer_e2e");
+      expect(seeded.artifact.content).toBe("First claim. Second claim.");
+
+      const invoked = parseToolJson<{
+        invocationId: string;
+        result: { claimsArtifactId: string; claimCount: number };
+        artifactRefs: Array<{ artifactId: string; name: string }>;
+      }>(await client.callTool({
+        name: "thoughtbox_peer_notebook",
+        arguments: {
+          operation: "peer_invoke",
+          peerId: "claim-extractor",
+          tool: "extract_claims",
+          args: { textArtifactId: seeded.artifact.id },
+        },
+      }));
+
+      expect(invoked.result).toEqual({
+        claimsArtifactId: `${invoked.invocationId}-claims`,
+        claimCount: 2,
+      });
+      expect(invoked.artifactRefs).toEqual([
+        expect.objectContaining({
+          artifactId: `${invoked.invocationId}-claims`,
+          name: "claims.json",
+        }),
+      ]);
+
+      const traced = parseToolJson<{
+        events: Array<{ eventType: string; attrs: { target?: string } }>;
+      }>(await client.callTool({
+        name: "thoughtbox_peer_notebook",
+        arguments: {
+          operation: "peer_list_trace_events",
+          invocationId: invoked.invocationId,
+        },
+      }));
+
+      expect(traced.events).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            eventType: "denied_outbound_call",
+            attrs: { target: "thoughtbox.knowledge.queryGraph" },
+          }),
+        ]),
+      );
     } finally {
       await Promise.allSettled([client.close(), server.close()]);
       restoreEnv("SUPABASE_URL", previousSupabaseUrl);
@@ -58,4 +147,10 @@ function restoreEnv(key: string, value: string | undefined): void {
   } else {
     process.env[key] = value;
   }
+}
+
+function parseToolJson<T>(result: CallToolResult): T {
+  const text = result.content.find(item => item.type === "text")?.text;
+  expect(text).toBeDefined();
+  return JSON.parse(text as string) as T;
 }

--- a/src/code-mode/search-index.ts
+++ b/src/code-mode/search-index.ts
@@ -19,8 +19,14 @@ import {
   OBSERVABILITY_OPERATIONS,
 } from "../observability/operations.js";
 import { BRANCH_OPERATIONS } from "../branch/operations.js";
+import { PEER_NOTEBOOK_TOOL } from "../peer-notebook/tool.js";
 
 export interface SearchCatalog {
+  publicTools: Array<{
+    name: string;
+    description: string;
+    operations?: string[];
+  }>;
   operations: Record<string, Record<string, {
     title: string;
     description: string;
@@ -203,6 +209,28 @@ function indexOperations(
 
 export function buildSearchCatalog(): SearchCatalog {
   const catalog: SearchCatalog = {
+    publicTools: [
+      {
+        name: "thoughtbox_search",
+        description: "Discover Thoughtbox operations, prompts, resources, and public tool surfaces by querying this catalog with JavaScript.",
+      },
+      {
+        name: "thoughtbox_execute",
+        description: "Run JavaScript against the tb SDK for Thoughtbox operation modules.",
+      },
+      {
+        name: PEER_NOTEBOOK_TOOL.name,
+        description: PEER_NOTEBOOK_TOOL.description,
+        operations: [
+          "peer_artifact_seed",
+          "peer_invoke",
+          "peer_get_invocation",
+          "peer_list_trace_events",
+          "peer_get_artifact",
+        ],
+      },
+    ],
+
     operations: {
       session: indexOperations(SESSION_OPERATIONS),
       notebook: indexOperations(NOTEBOOK_OPERATIONS),
@@ -307,6 +335,12 @@ export function buildSearchCatalog(): SearchCatalog {
         name: "Notebook Operations Catalog",
         uri: "thoughtbox://notebook/operations",
         description: "Complete catalog of notebook operations with schemas and examples",
+        mimeType: "application/json",
+      },
+      {
+        name: "Peer Notebook Pilot",
+        uri: "thoughtbox://peer-notebook/pilot",
+        description: "Mock peer notebook pilot surface and operation quick reference",
         mimeType: "application/json",
       },
       {

--- a/src/code-mode/search-tool.ts
+++ b/src/code-mode/search-tool.ts
@@ -33,6 +33,7 @@ export const SEARCH_TOOL = {
 The \`catalog\` object is available in scope:
 
 interface SearchCatalog {
+  publicTools: Array<{ name: string; description: string; operations?: string[] }>;
   operations: Record<string, Record<string, {
     title: string;
     description: string;
@@ -44,11 +45,13 @@ interface SearchCatalog {
   resourceTemplates: Array<{ name: string; uriTemplate: string; description: string; mimeType: string }>;
 }
 
-Modules in catalog.operations: session, thought, knowledge, notebook, theseus, ulysses, observability
+Modules in catalog.operations: session, thought, knowledge, notebook, theseus, ulysses, observability, branch
+Public MCP tools in catalog.publicTools: thoughtbox_search, thoughtbox_execute, thoughtbox_peer_notebook
 Legacy entrypoints like init and hub are intentionally absent from the Code Mode catalog.
 
 Examples:
 - List all modules: \`async () => Object.keys(catalog.operations)\`
+- List public tools: \`async () => catalog.publicTools\`
 - Find session operations: \`async () => catalog.operations.session\`
 - Search by keyword: \`async () => { const q = "entity"; return Object.entries(catalog.operations).flatMap(([mod, ops]) => Object.entries(ops).filter(([_, op]) => op.description.toLowerCase().includes(q)).map(([name, op]) => ({ module: mod, name, title: op.title }))) }\`
 - Find prompts: \`async () => catalog.prompts.filter(p => p.name.includes('spec'))\`

--- a/src/peer-notebook/__tests__/tool.test.ts
+++ b/src/peer-notebook/__tests__/tool.test.ts
@@ -4,6 +4,8 @@ import {
   MockPeerRuntimeProvider,
   PeerNotebookHandler,
   PeerNotebookTool,
+  type PeerManifestRecord,
+  type PeerNotebookRecord,
 } from "../index.js";
 
 describe("thoughtbox_peer_notebook", () => {
@@ -92,6 +94,15 @@ describe("thoughtbox_peer_notebook", () => {
     );
   });
 
+  it("rejects trace event reads for unknown invocations", async () => {
+    const { tool } = setupTool();
+
+    await expect(tool.handle({
+      operation: "peer_list_trace_events",
+      invocationId: "missing_invocation",
+    })).rejects.toMatchObject({ code: "invocation_not_found" });
+  });
+
   it("uses only the mock runtime provider", async () => {
     const { tool, handler } = setupTool();
     const seeded = await tool.handle({
@@ -128,6 +139,29 @@ describe("thoughtbox_peer_notebook", () => {
     expect(inputArtifact.artifact.storageBackend).toBe("memory");
     expect(inputArtifact.artifact.content).toBe("First claim.");
   });
+
+  it("serializes concurrent first-call bootstrap per workspace", async () => {
+    const repository = new CountingPeerNotebookRepository();
+    const handler = new PeerNotebookHandler({
+      repository,
+      workspaceId: "workspace_test",
+    });
+    const tool = new PeerNotebookTool(handler);
+
+    await Promise.all([
+      tool.handle({
+        operation: "peer_artifact_seed",
+        text: "First claim.",
+      }),
+      tool.handle({
+        operation: "peer_artifact_seed",
+        text: "Second claim.",
+      }),
+    ]);
+
+    expect(repository.peerSaves).toBe(1);
+    expect(repository.manifestSaves).toBe(1);
+  });
 });
 
 function setupTool() {
@@ -144,4 +178,21 @@ function setupTool() {
     provider,
     tool: new PeerNotebookTool(handler),
   };
+}
+
+class CountingPeerNotebookRepository extends InMemoryPeerNotebookRepository {
+  peerSaves = 0;
+  manifestSaves = 0;
+
+  override async savePeer(peer: PeerNotebookRecord): Promise<void> {
+    this.peerSaves += 1;
+    await Promise.resolve();
+    return super.savePeer(peer);
+  }
+
+  override async saveManifest(manifest: PeerManifestRecord): Promise<void> {
+    this.manifestSaves += 1;
+    await Promise.resolve();
+    return super.saveManifest(manifest);
+  }
 }

--- a/src/peer-notebook/__tests__/tool.test.ts
+++ b/src/peer-notebook/__tests__/tool.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import {
+  InMemoryPeerNotebookRepository,
+  MockPeerRuntimeProvider,
+  PeerNotebookHandler,
+  PeerNotebookTool,
+} from "../index.js";
+
+describe("thoughtbox_peer_notebook", () => {
+  it("seeds an input text artifact in the current workspace", async () => {
+    const { tool } = setupTool();
+
+    const result = await tool.handle({
+      operation: "peer_artifact_seed",
+      text: "First claim. Second claim.",
+      name: "input.txt",
+    });
+
+    expect(result.artifact.workspaceId).toBe("workspace_test");
+    expect(result.artifact.kind).toBe("text");
+    expect(result.artifact.name).toBe("input.txt");
+    expect(result.artifact.mimeType).toBe("text/plain");
+    expect(result.artifact.content).toBe("First claim. Second claim.");
+  });
+
+  it("invokes claim-extractor.extract_claims and returns a claims.json artifact reference", async () => {
+    const { tool } = setupTool();
+    const seeded = await tool.handle({
+      operation: "peer_artifact_seed",
+      text: "First claim. Second claim.",
+    });
+
+    const result = await tool.handle({
+      operation: "peer_invoke",
+      peerId: "claim-extractor",
+      tool: "extract_claims",
+      args: { textArtifactId: seeded.artifact.id },
+    });
+
+    expect(result.result).toEqual({
+      claimsArtifactId: `${result.invocationId}-claims`,
+      claimCount: 2,
+    });
+    expect(result.artifactRefs).toEqual([
+      expect.objectContaining({
+        artifactId: `${result.invocationId}-claims`,
+        name: "claims.json",
+        kind: "json",
+        mimeType: "application/json",
+      }),
+    ]);
+  });
+
+  it("rejects invalid args before runtime dispatch", async () => {
+    const { tool, provider } = setupTool();
+
+    await expect(tool.handle({
+      operation: "peer_invoke",
+      peerId: "claim-extractor",
+      tool: "extract_claims",
+      args: {},
+    })).rejects.toMatchObject({ code: "invalid_args" });
+
+    expect(provider.invocations).toHaveLength(0);
+  });
+
+  it("lists denied outbound calls from invocation trace events", async () => {
+    const { tool } = setupTool();
+    const seeded = await tool.handle({
+      operation: "peer_artifact_seed",
+      text: "First claim.",
+    });
+    const invoked = await tool.handle({
+      operation: "peer_invoke",
+      peerId: "claim-extractor",
+      tool: "extract_claims",
+      args: { textArtifactId: seeded.artifact.id },
+    });
+
+    const traced = await tool.handle({
+      operation: "peer_list_trace_events",
+      invocationId: invoked.invocationId,
+    });
+
+    expect(traced.events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          eventType: "denied_outbound_call",
+          attrs: { target: "thoughtbox.knowledge.queryGraph" },
+        }),
+      ]),
+    );
+  });
+
+  it("uses only the mock runtime provider", async () => {
+    const { tool, handler } = setupTool();
+    const seeded = await tool.handle({
+      operation: "peer_artifact_seed",
+      text: "First claim.",
+    });
+    const invoked = await tool.handle({
+      operation: "peer_invoke",
+      peerId: "claim-extractor",
+      tool: "extract_claims",
+      args: { textArtifactId: seeded.artifact.id },
+    });
+
+    const invocation = await tool.handle({
+      operation: "peer_get_invocation",
+      invocationId: invoked.invocationId,
+    });
+
+    expect(handler.getRuntimeProviderNames()).toEqual(["mock"]);
+    expect(invocation.invocation.runtimeProvider).toBe("mock");
+  });
+
+  it("reads seeded and produced artifacts from memory", async () => {
+    const { tool } = setupTool();
+    const seeded = await tool.handle({
+      operation: "peer_artifact_seed",
+      text: "First claim.",
+    });
+    const inputArtifact = await tool.handle({
+      operation: "peer_get_artifact",
+      artifactId: seeded.artifact.id,
+    });
+
+    expect(inputArtifact.artifact.storageBackend).toBe("memory");
+    expect(inputArtifact.artifact.content).toBe("First claim.");
+  });
+});
+
+function setupTool() {
+  const repository = new InMemoryPeerNotebookRepository();
+  const provider = new MockPeerRuntimeProvider();
+  const handler = new PeerNotebookHandler({
+    repository,
+    mockRuntimeProvider: provider,
+    workspaceId: "workspace_test",
+  });
+
+  return {
+    handler,
+    provider,
+    tool: new PeerNotebookTool(handler),
+  };
+}

--- a/src/peer-notebook/handler.ts
+++ b/src/peer-notebook/handler.ts
@@ -1,0 +1,259 @@
+import { createPeerBroker } from "./broker.js";
+import { compilePeerManifestDraft } from "./manifest.js";
+import { MockPeerRuntimeProvider } from "./mock-runtime-provider.js";
+import { InMemoryPeerNotebookRepository, type PeerNotebookRepository } from "./repositories.js";
+import { PeerNotebookError } from "./types.js";
+import type {
+  JsonObject,
+  PeerArtifactRecord,
+  PeerInvocationRecord,
+  PeerManifest,
+  PeerManifestRecord,
+  PeerNotebookRecord,
+  PeerTraceEventRecord,
+  RuntimeProviderName,
+} from "./types.js";
+
+const CLAIM_EXTRACTOR_PEER_ID = "claim-extractor";
+const CLAIM_EXTRACTOR_PEER_RECORD_ID = "peer_record_claim_extractor";
+const CLAIM_EXTRACTOR_MANIFEST_ID = "manifest_claim_extractor_active";
+const CLAIM_EXTRACTOR_NOTEBOOK_ID = "nb_claim_extractor";
+const BOOTSTRAP_TIMESTAMP = "2026-04-30T00:00:00.000Z";
+
+export interface PeerNotebookHandlerOptions {
+  workspaceId?: string;
+  getWorkspaceId?: () => string | undefined;
+  repository?: PeerNotebookRepository;
+  mockRuntimeProvider?: MockPeerRuntimeProvider;
+}
+
+export interface PeerArtifactSeedInput {
+  text: string;
+  name?: string;
+}
+
+export interface PeerInvokeToolInput {
+  peerId: string;
+  tool: string;
+  args: JsonObject;
+}
+
+export class PeerNotebookHandler {
+  private readonly repository: PeerNotebookRepository;
+  private readonly mockRuntimeProvider: MockPeerRuntimeProvider;
+  private readonly bootstrappedWorkspaces = new Set<string>();
+
+  constructor(private readonly options: PeerNotebookHandlerOptions = {}) {
+    this.repository = options.repository ?? new InMemoryPeerNotebookRepository();
+    this.mockRuntimeProvider = options.mockRuntimeProvider ?? new MockPeerRuntimeProvider();
+  }
+
+  getRuntimeProviderNames(): RuntimeProviderName[] {
+    return ["mock"];
+  }
+
+  async seedArtifact(input: PeerArtifactSeedInput): Promise<{ artifact: PeerArtifactRecord }> {
+    const workspaceId = this.resolveWorkspaceId();
+    await this.bootstrapWorkspace(workspaceId);
+
+    const artifact = await this.repository.saveArtifactInput({
+      workspaceId,
+      invocationId: null,
+      peerRecordId: null,
+      peerId: null,
+      kind: "text",
+      name: input.name ?? "input.txt",
+      mimeType: "text/plain",
+      content: input.text,
+      preview: previewText(input.text),
+    });
+
+    return { artifact };
+  }
+
+  async invoke(input: PeerInvokeToolInput) {
+    const workspaceId = this.resolveWorkspaceId();
+    await this.bootstrapWorkspace(workspaceId);
+
+    const broker = createPeerBroker({
+      workspaceId,
+      repository: this.repository,
+      runtimeProviders: {
+        mock: this.mockRuntimeProvider,
+      },
+    });
+
+    const result = await broker.peer.invoke(input);
+    const artifacts = await this.repository.listArtifacts(workspaceId, result.invocationId);
+
+    return {
+      ...result,
+      artifactRefs: artifacts.map(toArtifactRef),
+    };
+  }
+
+  async getInvocation(invocationId: string): Promise<{ invocation: PeerInvocationRecord }> {
+    const workspaceId = this.resolveWorkspaceId();
+    await this.bootstrapWorkspace(workspaceId);
+
+    const invocation = await this.repository.getInvocation(workspaceId, invocationId);
+    if (!invocation) {
+      throw new PeerNotebookError("invocation_not_found", `Invocation ${invocationId} does not exist`);
+    }
+
+    return { invocation };
+  }
+
+  async listTraceEvents(invocationId: string): Promise<{ events: PeerTraceEventRecord[] }> {
+    const workspaceId = this.resolveWorkspaceId();
+    await this.bootstrapWorkspace(workspaceId);
+
+    return {
+      events: await this.repository.listTraceEvents(workspaceId, invocationId),
+    };
+  }
+
+  async getArtifact(artifactId: string): Promise<{ artifact: PeerArtifactRecord }> {
+    const workspaceId = this.resolveWorkspaceId();
+    await this.bootstrapWorkspace(workspaceId);
+
+    const artifact = await this.repository.getArtifact(workspaceId, artifactId);
+    if (!artifact) {
+      throw new PeerNotebookError("artifact_not_found", `Artifact ${artifactId} does not exist`);
+    }
+
+    return { artifact };
+  }
+
+  private resolveWorkspaceId(): string {
+    return this.options.getWorkspaceId?.() ?? this.options.workspaceId ?? "default";
+  }
+
+  private async bootstrapWorkspace(workspaceId: string): Promise<void> {
+    if (this.bootstrappedWorkspaces.has(workspaceId)) {
+      return;
+    }
+
+    const existing = await this.repository.getPeerByPeerId(workspaceId, CLAIM_EXTRACTOR_PEER_ID);
+    if (existing?.activeManifestId) {
+      this.bootstrappedWorkspaces.add(workspaceId);
+      return;
+    }
+
+    const compiled = compilePeerManifestDraft([
+      {
+        name: "peer.manifest.json",
+        sourceType: "file",
+        content: JSON.stringify(claimExtractorManifest()),
+      },
+    ]);
+
+    const peer: PeerNotebookRecord = {
+      id: CLAIM_EXTRACTOR_PEER_RECORD_ID,
+      workspaceId,
+      peerId: CLAIM_EXTRACTOR_PEER_ID,
+      displayName: "Claim extractor",
+      description: "Deterministic mock peer that extracts sentence-level claims from a text artifact.",
+      status: "active",
+      activeManifestId: CLAIM_EXTRACTOR_MANIFEST_ID,
+      createdAt: BOOTSTRAP_TIMESTAMP,
+      updatedAt: BOOTSTRAP_TIMESTAMP,
+    };
+
+    const manifest: PeerManifestRecord = {
+      id: CLAIM_EXTRACTOR_MANIFEST_ID,
+      workspaceId,
+      peerRecordId: peer.id,
+      peerId: peer.peerId,
+      version: 1,
+      schemaVersion: compiled.manifest.schemaVersion,
+      manifest: compiled.manifest,
+      manifestHash: compiled.manifestHash,
+      status: "active",
+      compiledFrom: compiled.compiledFrom,
+      createdAt: BOOTSTRAP_TIMESTAMP,
+    };
+
+    await this.repository.savePeer(peer);
+    await this.repository.saveManifest(manifest);
+    this.bootstrappedWorkspaces.add(workspaceId);
+  }
+}
+
+function claimExtractorManifest(): PeerManifest {
+  return {
+    schemaVersion: "peer-notebook.v0",
+    peerId: CLAIM_EXTRACTOR_PEER_ID,
+    notebookId: CLAIM_EXTRACTOR_NOTEBOOK_ID,
+    runtime: {
+      provider: "mock",
+      timeoutMs: 120_000,
+    },
+    exposes: {
+      tools: [
+        {
+          name: "extract_claims",
+          description: "Extract atomic claims from a text artifact",
+          inputSchema: {
+            type: "object",
+            properties: {
+              textArtifactId: { type: "string" },
+            },
+            required: ["textArtifactId"],
+            additionalProperties: false,
+          },
+          outputSchema: {
+            type: "object",
+            properties: {
+              claimsArtifactId: { type: "string" },
+              claimCount: { type: "number" },
+            },
+            required: ["claimsArtifactId", "claimCount"],
+            additionalProperties: false,
+          },
+        },
+      ],
+      resources: [],
+      prompts: [],
+    },
+    mayCall: {
+      mcpTools: ["artifact.get"],
+    },
+    network: {
+      enabled: false,
+      allowHosts: [],
+    },
+    filesystem: {
+      mounts: [],
+    },
+    secrets: {
+      bindings: [],
+    },
+    persistence: {
+      snapshot: "manual",
+      exportNotebookOnInvoke: true,
+      retainArtifactsDays: 30,
+    },
+    budgets: {
+      maxDurationMs: 120_000,
+      maxToolCalls: 10,
+      maxArtifactBytes: 10_000_000,
+    },
+  };
+}
+
+function previewText(text: string): string {
+  return text.length > 500 ? `${text.slice(0, 497)}...` : text;
+}
+
+function toArtifactRef(artifact: PeerArtifactRecord) {
+  return {
+    artifactId: artifact.id,
+    kind: artifact.kind,
+    name: artifact.name,
+    mimeType: artifact.mimeType,
+    byteSize: artifact.byteSize,
+    sha256: artifact.sha256,
+    preview: artifact.preview,
+  };
+}

--- a/src/peer-notebook/handler.ts
+++ b/src/peer-notebook/handler.ts
@@ -42,6 +42,7 @@ export class PeerNotebookHandler {
   private readonly repository: PeerNotebookRepository;
   private readonly mockRuntimeProvider: MockPeerRuntimeProvider;
   private readonly bootstrappedWorkspaces = new Set<string>();
+  private readonly bootstrapPromises = new Map<string, Promise<void>>();
 
   constructor(private readonly options: PeerNotebookHandlerOptions = {}) {
     this.repository = options.repository ?? new InMemoryPeerNotebookRepository();
@@ -108,6 +109,11 @@ export class PeerNotebookHandler {
     const workspaceId = this.resolveWorkspaceId();
     await this.bootstrapWorkspace(workspaceId);
 
+    const invocation = await this.repository.getInvocation(workspaceId, invocationId);
+    if (!invocation) {
+      throw new PeerNotebookError("invocation_not_found", `Invocation ${invocationId} does not exist`);
+    }
+
     return {
       events: await this.repository.listTraceEvents(workspaceId, invocationId),
     };
@@ -134,6 +140,20 @@ export class PeerNotebookHandler {
       return;
     }
 
+    const existingPromise = this.bootstrapPromises.get(workspaceId);
+    if (existingPromise) {
+      await existingPromise;
+      return;
+    }
+
+    const bootstrapPromise = this.performBootstrapWorkspace(workspaceId).finally(() => {
+      this.bootstrapPromises.delete(workspaceId);
+    });
+    this.bootstrapPromises.set(workspaceId, bootstrapPromise);
+    await bootstrapPromise;
+  }
+
+  private async performBootstrapWorkspace(workspaceId: string): Promise<void> {
     const existing = await this.repository.getPeerByPeerId(workspaceId, CLAIM_EXTRACTOR_PEER_ID);
     if (existing?.activeManifestId) {
       this.bootstrappedWorkspaces.add(workspaceId);

--- a/src/peer-notebook/index.ts
+++ b/src/peer-notebook/index.ts
@@ -7,6 +7,10 @@ export { validateJsonSchemaSubset } from "./json-schema.js";
 export { MockPeerRuntimeProvider } from "./mock-runtime-provider.js";
 export { InMemoryPeerNotebookRepository } from "./repositories.js";
 export type { PeerNotebookRepository, SaveArtifactInput } from "./repositories.js";
+export { PeerNotebookHandler } from "./handler.js";
+export type { PeerNotebookHandlerOptions, PeerArtifactSeedInput, PeerInvokeToolInput } from "./handler.js";
+export { PEER_NOTEBOOK_TOOL, PeerNotebookTool, peerNotebookToolInputSchema } from "./tool.js";
+export type { PeerNotebookToolInput } from "./tool.js";
 export type {
   CompiledPeerManifest,
   JsonObject,

--- a/src/peer-notebook/tool.ts
+++ b/src/peer-notebook/tool.ts
@@ -1,0 +1,85 @@
+import { z } from "zod";
+import { PeerNotebookHandler } from "./handler.js";
+import type { JsonObject } from "./types.js";
+
+const operationSchema = z.enum([
+  "peer_artifact_seed",
+  "peer_invoke",
+  "peer_get_invocation",
+  "peer_list_trace_events",
+  "peer_get_artifact",
+]);
+
+export const peerNotebookToolInputSchema = z.object({
+  operation: operationSchema,
+  text: z.string().optional().describe("Text content for peer_artifact_seed"),
+  name: z.string().optional().describe("Optional artifact name for peer_artifact_seed"),
+  peerId: z.string().optional().describe("Peer id for peer_invoke"),
+  tool: z.string().optional().describe("Exposed peer tool name for peer_invoke"),
+  args: z.record(z.unknown()).optional().describe("JSON arguments for peer_invoke"),
+  invocationId: z.string().optional().describe("Invocation id for invocation and trace reads"),
+  artifactId: z.string().optional().describe("Artifact id for peer_get_artifact"),
+});
+
+export type PeerNotebookToolInput = z.infer<typeof peerNotebookToolInputSchema>;
+
+export const PEER_NOTEBOOK_TOOL = {
+  name: "thoughtbox_peer_notebook",
+  description: "Brokered MCP peer notebook pilot surface. Seeds in-memory text artifacts, invokes the mock claim-extractor peer, and reads invocations, traces, and artifacts.",
+  inputSchema: peerNotebookToolInputSchema,
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+  },
+};
+
+export class PeerNotebookTool {
+  constructor(private readonly handler: PeerNotebookHandler) {}
+
+  async handle(input: PeerNotebookToolInput) {
+    switch (input.operation) {
+      case "peer_artifact_seed":
+        return this.handler.seedArtifact({
+          text: requiredString(input.text, "text", input.operation),
+          name: input.name,
+        });
+
+      case "peer_invoke":
+        return this.handler.invoke({
+          peerId: requiredString(input.peerId, "peerId", input.operation),
+          tool: requiredString(input.tool, "tool", input.operation),
+          args: requiredJsonObject(input.args, "args", input.operation),
+        });
+
+      case "peer_get_invocation":
+        return this.handler.getInvocation(
+          requiredString(input.invocationId, "invocationId", input.operation),
+        );
+
+      case "peer_list_trace_events":
+        return this.handler.listTraceEvents(
+          requiredString(input.invocationId, "invocationId", input.operation),
+        );
+
+      case "peer_get_artifact":
+        return this.handler.getArtifact(
+          requiredString(input.artifactId, "artifactId", input.operation),
+        );
+    }
+  }
+}
+
+function requiredString(value: string | undefined, field: string, operation: string): string {
+  if (!value) {
+    throw new Error(`${operation} requires '${field}'`);
+  }
+  return value;
+}
+
+function requiredJsonObject(value: Record<string, unknown> | undefined, field: string, operation: string): JsonObject {
+  if (!value || Array.isArray(value)) {
+    throw new Error(`${operation} requires object '${field}'`);
+  }
+  return value as JsonObject;
+}

--- a/src/peer-notebook/types.ts
+++ b/src/peer-notebook/types.ts
@@ -14,7 +14,7 @@ export type PeerInvocationStatus =
   | "cancelled";
 
 export type RuntimeProviderName = "mock" | "local-process" | "smolvm";
-export type ArtifactKind = "notebook_export" | "json" | "log" | "dataset" | "report" | "binary";
+export type ArtifactKind = "notebook_export" | "json" | "text" | "log" | "dataset" | "report" | "binary";
 
 export interface JsonSchemaSubset {
   type?: "object" | "array" | "string" | "number" | "boolean" | "null";

--- a/src/prompts/list-mcp-assets.ts
+++ b/src/prompts/list-mcp-assets.ts
@@ -23,24 +23,6 @@ export const LIST_MCP_ASSETS_PROMPT = {
 };
 
 /**
- * Thoughtbox tool schema (mirrored from index.ts)
- */
-const THOUGHTBOX_PARAMS = [
-  { name: "thought", type: "string", required: true, description: "Your current thinking step" },
-  { name: "nextThoughtNeeded", type: "boolean", required: true, description: "Whether another thought step is needed" },
-  { name: "thoughtNumber", type: "integer", required: true, description: "Current thought number (1→N forward, N→1 backward)" },
-  { name: "totalThoughts", type: "integer", required: true, description: "Estimated total thoughts needed" },
-  { name: "isRevision", type: "boolean", required: false, description: "Whether this revises previous thinking" },
-  { name: "revisesThought", type: "integer", required: false, description: "Which thought is being reconsidered" },
-  { name: "branchFromThought", type: "integer", required: false, description: "Branching point thought number" },
-  { name: "branchId", type: "string", required: false, description: "Branch identifier" },
-  { name: "needsMoreThoughts", type: "boolean", required: false, description: "If more thoughts are needed" },
-  { name: "includeGuide", type: "boolean", required: false, description: "Request the patterns cookbook guide" },
-  { name: "sessionTitle", type: "string", required: false, description: "Title for the reasoning session" },
-  { name: "sessionTags", type: "array", required: false, description: "Tags for cross-chat discovery" },
-];
-
-/**
  * Generates the list_mcp_assets prompt content dynamically
  */
 export function getListMcpAssetsContent(): string {
@@ -55,22 +37,31 @@ Thoughtbox provides cognitive enhancement tools for LLM agents - infrastructure 
 
 ---
 
-## Tools
+## Public Tools
 
-### 1. \`thoughtbox\` — Step-by-Step Reasoning
+### 1. \`thoughtbox_search\` — Catalog Search
 
-Step-by-step thinking tool for complex problem-solving.
-- Supports forward thinking (1→N), backward thinking (N→1), branching, and revision
-- Automatic patterns cookbook at thought 1 and final thought
-- Use for multi-step analysis, planning, hypothesis generation, system design
+Discover Thoughtbox operation modules, prompts, resources, and public tool surfaces by querying the server catalog with JavaScript.
 
-**Parameters:**
+### 2. \`thoughtbox_execute\` — Code Mode Operation Runner
 
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-${THOUGHTBOX_PARAMS.map(p => `| \`${p.name}\` | ${p.type} | ${p.required ? "Yes" : "No"} | ${p.description} |`).join("\n")}
+Run JavaScript against the \`tb\` SDK to use Thoughtbox operation modules such as session, thought, knowledge, notebook, protocol, observability, and branch operations.
 
-### 2. \`notebook\` — Notebook Evidence Engine
+### 3. \`thoughtbox_peer_notebook\` — Mock Peer Notebook Pilot
+
+Brokered MCP peer notebook pilot surface for the deterministic in-memory \`claim-extractor\` peer.
+
+Supported operations:
+
+| Operation | Purpose |
+|-----------|---------|
+| \`peer_artifact_seed\` | Seed an in-memory text artifact |
+| \`peer_invoke\` | Invoke \`claim-extractor.extract_claims\` |
+| \`peer_get_invocation\` | Read invocation metadata |
+| \`peer_list_trace_events\` | Read broker/runtime trace events, including denied outbound calls |
+| \`peer_get_artifact\` | Read seeded or produced artifacts |
+
+### Notebook Evidence Engine
 
 Toolhost for interactive notebooks with JavaScript/TypeScript. Notebooks are also a visible evidence engine: executable Markdown artifacts with prose, code, deterministic validators, structured outputs, and replayable runs.
 
@@ -108,6 +99,7 @@ ${NOTEBOOK_OPERATIONS.map(op => `| \`${op.name}\` | ${op.category} | ${op.descri
 | \`system://status\` | Notebook server health snapshot |
 | \`thoughtbox://notebook/operations\` | Notebook operations catalog (JSON) |
 | \`thoughtbox://notebook/capabilities\` | Notebook Evidence Engine modes, templates, outputs, and recommended use cases |
+| \`thoughtbox://peer-notebook/pilot\` | Mock peer notebook pilot surface and operation quick reference |
 | \`thoughtbox://patterns-cookbook\` | Thoughtbox reasoning patterns guide |
 | \`thoughtbox://architecture\` | Server architecture and implementation guide |
 
@@ -125,53 +117,35 @@ ${NOTEBOOK_OPERATIONS.map(op => `| \`${op.name}\` | ${op.category} | ${op.descri
 
 ## Quick Start
 
-### Thoughtbox Reasoning
+### Code Mode And Peer Notebook Pilot
 
 \`\`\`javascript
-// Start a reasoning session
-thoughtbox({
-  thought: "Breaking down the problem into key decision areas...",
-  thoughtNumber: 1,
-  totalThoughts: 10,
-  nextThoughtNeeded: true,
-  sessionTitle: "Architecture Decision",
-  sessionTags: ["architecture", "planning"]
+// Discover operations and public tool surfaces
+thoughtbox_search({
+  code: "async () => ({ modules: Object.keys(catalog.operations), publicTools: catalog.publicTools })"
 })
 
-// Branch to explore alternatives
-thoughtbox({
-  thought: "Exploring approach A: Use SQL database...",
-  thoughtNumber: 5,
-  totalThoughts: 10,
-  branchFromThought: 4,
-  branchId: "sql-approach",
-  nextThoughtNeeded: true
-})
-\`\`\`
-
-### Notebooks
-
-\`\`\`javascript
-// Create notebook
-notebook({
-  operation: "create",
-  args: { title: "Data Analysis", language: "typescript" }
+// Start a reasoning session through Code Mode
+thoughtbox_execute({
+  code: "async () => tb.thought({ thought: 'Breaking down the problem into key decision areas...', thoughtNumber: 1, totalThoughts: 10, nextThoughtNeeded: true, sessionTitle: 'Architecture Decision', sessionTags: ['architecture', 'planning'] })"
 })
 
-// Add and run code
-notebook({
-  operation: "add_cell",
-  args: {
-    notebookId: "abc123",
-    cellType: "code",
-    content: "console.log('Hello!');",
-    filename: "hello.ts"
-  }
+// Seed a peer artifact, invoke claim extraction, then inspect traces
+const seeded = await thoughtbox_peer_notebook({
+  operation: "peer_artifact_seed",
+  text: "First claim. Second claim."
 })
 
-notebook({
-  operation: "run_cell",
-  args: { notebookId: "abc123", cellId: "cell456" }
+const invoked = await thoughtbox_peer_notebook({
+  operation: "peer_invoke",
+  peerId: "claim-extractor",
+  tool: "extract_claims",
+  args: { textArtifactId: seeded.artifact.id }
+})
+
+await thoughtbox_peer_notebook({
+  operation: "peer_list_trace_events",
+  invocationId: invoked.invocationId
 })
 \`\`\`
 
@@ -191,10 +165,10 @@ notebook({
 
 ## Summary Statistics
 
-- **Tools:** 2 (thoughtbox, notebook)
+- **Public Tools:** 3 (thoughtbox_search, thoughtbox_execute, thoughtbox_peer_notebook)
 - **Notebook Operations:** ${NOTEBOOK_OPERATIONS.length}
 - **Prompts:** 2
-- **Static Resources:** 6+
+- **Static Resources:** 7+
 - **Resource Templates:** 3
 
 `;

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -55,6 +55,7 @@ import { KnowledgeTool } from "./knowledge/tool.js";
 import { SessionTool } from "./sessions/tool.js";
 import { ThoughtTool } from "./thought/tool.js";
 import { NotebookTool } from "./notebook/tool.js";
+import { PEER_NOTEBOOK_TOOL, PeerNotebookHandler, PeerNotebookTool } from "./peer-notebook/index.js";
 import {
   TheseusTool,
   UlyssesTool,
@@ -159,9 +160,10 @@ export async function createMcpServer(args: CreateMcpServerArgs = {}): Promise<M
 
   const THOUGHTBOX_INSTRUCTIONS = `Thoughtbox is a structured reasoning server using Code Mode.
 
-Two tools:
+Three tools:
 - \`thoughtbox_search\`: Write JavaScript to query the operation/prompt/resource catalog
 - \`thoughtbox_execute\`: Write JavaScript using the \`tb\` SDK to chain operations
+- \`thoughtbox_peer_notebook\`: Seed artifacts and invoke the mock brokered claim-extractor peer
 
 Workflow: search to discover available operations, then execute code against them.
 Use \`console.log()\` for debugging — output captured in response logs.`;
@@ -211,6 +213,10 @@ Use \`console.log()\` for debugging — output captured in response logs.`;
   thoughtHandler.setEventEmitter(eventEmitter);
 
   const notebookHandler = new NotebookHandler();
+  let resolvedWorkspaceId = args.workspaceId || process.env.THOUGHTBOX_PROJECT || "default";
+  const peerNotebookHandler = new PeerNotebookHandler({
+    getWorkspaceId: () => resolvedWorkspaceId,
+  });
 
   const sessionHandler = new SessionHandler({
     storage,
@@ -304,6 +310,7 @@ Use \`console.log()\` for debugging — output captured in response logs.`;
   const sessionTool = new SessionTool(sessionHandler);
   const thoughtTool = new ThoughtTool(thoughtHandler);
   const notebookTool = new NotebookTool(notebookHandler);
+  const peerNotebookTool = new PeerNotebookTool(peerNotebookHandler);
 
   // Resolve project scope.
   //
@@ -327,6 +334,7 @@ Use \`console.log()\` for debugging — output captured in response logs.`;
 
     const project = args.workspaceId || process.env.THOUGHTBOX_PROJECT;
     if (project) {
+      resolvedWorkspaceId = project;
       try {
         await storage.setProject(project);
         if (knowledgeStorage) await knowledgeStorage.setProject(project);
@@ -362,6 +370,7 @@ Use \`console.log()\` for debugging — output captured in response logs.`;
         const name = root.name
           || root.uri.split('/').filter(Boolean).pop()
           || 'default';
+        resolvedWorkspaceId = name;
         await storage.setProject(name);
         if (knowledgeStorage) await knowledgeStorage.setProject(name);
         if (protocolHandler) protocolHandler.setProject(name);
@@ -467,8 +476,9 @@ Use \`console.log()\` for debugging — output captured in response logs.`;
 
   registerTool(SEARCH_TOOL, searchTool);
   registerTool(EXECUTE_TOOL, executeTool);
+  registerTool(PEER_NOTEBOOK_TOOL, peerNotebookTool);
 
-  logger.info('Code Mode tools registered (search + execute)');
+  logger.info('Code Mode tools registered (search + execute) and peer notebook tool registered');
 
   // Register prompts using McpServer's registerPrompt API
   server.registerPrompt(

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -147,6 +147,26 @@ const defaultLogger: Logger = {
   error(message: string, ...args: unknown[]) { console.error(`[ERROR] ${message}`, ...args); },
 };
 
+function serializeToolError(err: unknown): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    error: err instanceof Error ? err.message : String(err),
+  };
+
+  if (err && typeof err === "object") {
+    if ("code" in err && typeof err.code === "string") {
+      payload.code = err.code;
+    }
+    if ("details" in err && err.details !== undefined) {
+      payload.details = err.details;
+    }
+    if ("data" in err && err.data !== undefined) {
+      payload.data = err.data;
+    }
+  }
+
+  return payload;
+}
+
 function getPeerNotebookPilotResourceContent(): string {
   return JSON.stringify({
     tool: PEER_NOTEBOOK_TOOL.name,
@@ -459,7 +479,7 @@ Use \`console.log()\` for debugging — output captured in response logs.`;
           };
         } catch (err: any) {
           return {
-            content: [{ type: "text" as const, text: JSON.stringify({ error: err.message }, null, 2) }],
+            content: [{ type: "text" as const, text: JSON.stringify(serializeToolError(err), null, 2) }],
             isError: true,
           };
         }

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -147,6 +147,59 @@ const defaultLogger: Logger = {
   error(message: string, ...args: unknown[]) { console.error(`[ERROR] ${message}`, ...args); },
 };
 
+function getPeerNotebookPilotResourceContent(): string {
+  return JSON.stringify({
+    tool: PEER_NOTEBOOK_TOOL.name,
+    description: PEER_NOTEBOOK_TOOL.description,
+    scope: {
+      persistence: "in-memory",
+      runtimeProviders: ["mock"],
+      deferred: [
+        "Supabase persistence",
+        "web app peer views",
+        "local-process provider",
+        "smolvm provider",
+        "public direct runtime MCP",
+      ],
+    },
+    pilotPeer: {
+      peerId: "claim-extractor",
+      exposedTool: "extract_claims",
+      args: { textArtifactId: "artifact id returned by peer_artifact_seed" },
+      result: { claimsArtifactId: "produced claims.json artifact id", claimCount: "number" },
+      deniedProbe: "thoughtbox.knowledge.queryGraph",
+    },
+    operations: [
+      {
+        operation: "peer_artifact_seed",
+        purpose: "Seed an in-memory text artifact for the current workspace",
+        requiredFields: ["text"],
+        optionalFields: ["name"],
+      },
+      {
+        operation: "peer_invoke",
+        purpose: "Invoke claim-extractor.extract_claims through the broker facade",
+        requiredFields: ["peerId", "tool", "args"],
+      },
+      {
+        operation: "peer_get_invocation",
+        purpose: "Read invocation metadata by invocationId",
+        requiredFields: ["invocationId"],
+      },
+      {
+        operation: "peer_list_trace_events",
+        purpose: "Read trace events, including denied outbound broker-proxy calls",
+        requiredFields: ["invocationId"],
+      },
+      {
+        operation: "peer_get_artifact",
+        purpose: "Read seeded or produced in-memory artifacts by artifactId",
+        requiredFields: ["artifactId"],
+      },
+    ],
+  }, null, 2);
+}
+
 /**
  * Side-effect-free server factory.
  * - No transport binding
@@ -955,6 +1008,24 @@ mcp__thoughtbox__thoughtbox({
   );
 
   server.registerResource(
+    "peer-notebook-pilot",
+    "thoughtbox://peer-notebook/pilot",
+    {
+      description: "Mock peer notebook pilot surface: artifact seed, claim-extractor invocation, invocation/trace/artifact reads",
+      mimeType: "application/json",
+    },
+    async (uri) => ({
+      contents: [
+        {
+          uri: uri.toString(),
+          mimeType: "application/json",
+          text: getPeerNotebookPilotResourceContent(),
+        },
+      ],
+    })
+  );
+
+  server.registerResource(
     "patterns-cookbook",
     "thoughtbox://patterns-cookbook",
     {
@@ -1577,6 +1648,12 @@ mcp__thoughtbox__thoughtbox({
         uri: "thoughtbox://notebook/capabilities",
         name: "Notebook Evidence Engine Capabilities",
         description: "Notebook modes, templates, outputs, and recommended use cases",
+        mimeType: "application/json",
+      },
+      {
+        uri: "thoughtbox://peer-notebook/pilot",
+        name: "Peer Notebook Pilot",
+        description: "Mock peer notebook pilot surface: artifact seed, claim-extractor invocation, invocation/trace/artifact reads",
         mimeType: "application/json",
       },
       {


### PR DESCRIPTION
## Summary

Adds the first MCP-facing mock peer notebook surface for ADR-022:

- Registers public MCP tool `thoughtbox_peer_notebook`
- Supports in-memory artifact seed, peer invoke, invocation read, trace list, and artifact read operations
- Bootstraps deterministic active `claim-extractor` peer per workspace
- Keeps runtime mock-only through `MockPeerRuntimeProvider`
- Adds MCP client coverage using `createMcpServer` + `InMemoryTransport`
- Adds lightweight discovery docs/catalog entries, including `thoughtbox://peer-notebook/pilot`

## Scope

This is intentionally a narrow pilot surface. It does **not** add:

- Supabase migrations or durable peer notebook storage
- Web app peer notebook pages
- `local-process` runtime provider
- `smolvm` runtime provider
- Public/direct runtime MCP

## Validation

- `pnpm exec vitest run src/peer-notebook src/code-mode/__tests__/server-surface.test.ts`
- `pnpm check:types`
- `pnpm check:lint`
- `pnpm build:local`

## Tracking

- `thoughtbox-39o` implemented the MCP-facing mock peer notebook surface
- `thoughtbox-bgo` covered the pre-PR hardening pass
