### PR TITLE
docs(peer-notebook): prepare durable control plane handoff

### DIFF
--- a/.specs/mcp-peer-notebooks/NEXT-IMPLEMENTATION-HANDOFF.md
+++ b/.specs/mcp-peer-notebooks/NEXT-IMPLEMENTATION-HANDOFF.md
@@ -1,26 +1,108 @@
 # MCP Peer Notebooks Implementation Handoff
 
-**Status**: Follow-on handoff after the MCP-facing mock broker pilot
+**Status**: Post-merge handoff for ADR-022 remaining implementation
 **Date**: 2026-04-30
 **Governing ADR/spec**: ADR-022 and `SPEC-CONTROL-PLANE.md`
-**Current issue**: `thoughtbox-39o`
+**Merged pilot branch**: `feat/peer-notebook-mcp-surface`
+**Next unit**: ADR-022 Part 1/5 Durable Control Plane (`thoughtbox-y4x`)
+**Kickoff prompt**: `PROMPT-PART-1-DURABLE-CONTROL-PLANE.md`
 
-## Completed In This Slice
+## Merged Baseline
 
-- Added `thoughtbox_peer_notebook` as the smallest MCP-facing pilot surface for
-  the existing mock `claim-extractor` broker.
-- Kept state in memory and execution mock-only.
-- Supported artifact seed, peer invoke, invocation read, trace event list, and
-  artifact read operations.
-- Bootstrapped one deterministic active `claim-extractor` manifest per
-  workspace using `compilePeerManifestDraft()`.
-- Registered only the mock runtime provider; `local-process` and `smolvm`
-  remain deferred.
+The merged baseline on `main` includes the first MCP-facing mock peer notebook
+surface:
 
-## Still Deferred
+- Public MCP tool: `thoughtbox_peer_notebook`.
+- Supported operations:
+  - `peer_artifact_seed`
+  - `peer_invoke`
+  - `peer_get_invocation`
+  - `peer_list_trace_events`
+  - `peer_get_artifact`
+- Deterministic active `claim-extractor` peer per workspace.
+- Manifest compilation/hashing from a static `peer.manifest.json` source.
+- In-memory peer, manifest, invocation, trace, and artifact repository.
+- Mock-only runtime through `MockPeerRuntimeProvider`.
+- Broker proxy allow/deny behavior, including denied outbound trace events.
+- MCP client coverage through `createMcpServer` and `InMemoryTransport`.
+- Discovery surface through `thoughtbox://peer-notebook/pilot` and Code Mode
+  search catalog public-tool metadata.
+- Structured MCP error payloads preserving `PeerNotebookError.code` and
+  `details`.
+- Trace listing now rejects unknown invocation ids with `invocation_not_found`.
+- Workspace bootstrap is serialized per workspace.
 
-- Supabase migrations and durable peer/artifact storage.
-- Web app pages for peer registry, invocations, traces, and artifacts.
-- Local-process provider.
-- smolvm provider and execution-plane infrastructure.
-- Public/direct runtime MCP.
+## Delivery Guard
+
+Future work must use `.claude/skills/peer-notebook-delivery-guard/SKILL.md`.
+
+Hard rule:
+
+> Mocks are contract fixtures, not final substitutes.
+
+Every remaining unit must list each mock, in-memory store, stubbed provider, or
+local-only stand-in it touches and state whether that component was replaced,
+narrowed to test/non-production use, or deferred with a Beads follow-up.
+
+## Remaining Large Units
+
+1. **Durable Control Plane** (`thoughtbox-y4x`)
+   - Supabase migrations and repository implementation.
+   - Durable peer notebooks, manifests, invocations, trace events, and artifacts.
+   - Supabase Storage payload path or explicit bounded payload strategy.
+   - Workspace-scoped durable seed -> invoke -> trace -> artifact acceptance.
+   - Runtime may remain mock-only, but persistence cannot remain in-memory.
+
+2. **Manifest Lifecycle And Notebook Graduation** (`thoughtbox-g5t`)
+   - Compile `peer.manifest.json` from actual notebook sources.
+   - Store drafts, approve/activate/retire manifests, and enforce active hash.
+   - Prove notebook edits do not silently change active capabilities.
+
+3. **Web App Inspection Surface** (`thoughtbox-2ot`)
+   - Peer registry/detail.
+   - Invocation list/detail.
+   - Trace timeline with denied outbound calls.
+   - Artifact preview from durable rows, not mock/local state.
+
+4. **Real Runtime Provider Path** (`thoughtbox-s7f`)
+   - Development-only `local-process` provider behind the runtime contract.
+   - Contract parity with mock provider.
+   - Explicit non-production isolation labeling.
+
+5. **Production Isolation And Policy Hardening** (`thoughtbox-vdw`)
+   - smolvm or equivalent isolated provider.
+   - Enforced network, filesystem, secrets, outbound budget, and denial policy.
+   - Mock/local-process cannot satisfy production acceptance.
+
+## Part 1/5 Scope Lock
+
+The next implementation unit is **Durable Control Plane**.
+
+Do:
+
+- Add Supabase-backed persistence behind the peer notebook repository contract.
+- Add migrations for the ADR-022 table contract, adjusted only where current
+  repo conventions require it.
+- Preserve the broker facade and runtime provider boundary.
+- Keep the mock runtime provider as a test/pilot fixture.
+- Prove durable seed -> invoke -> trace -> artifact state.
+
+Do not:
+
+- Build web app pages.
+- Implement `local-process`.
+- Implement smolvm or production isolation.
+- Add direct/public runtime MCP.
+- Treat in-memory repository or mock runtime as final production behavior.
+
+## Open Risks For Part 1/5
+
+- Supabase table contract names may need small adaptation to match existing
+  workspace scoping conventions.
+- Artifact payload storage needs a bounded v0 choice: full Supabase Storage
+  write if practical, or explicit metadata/preview-first behavior with a
+  follow-up issue for full payload persistence.
+- Repository tests must not pass solely against in-memory fixtures.
+- The broker currently bootstraps a static `claim-extractor` manifest; Part 1
+  should persist that active pilot state durably without claiming full notebook
+  graduation.

--- a/.specs/mcp-peer-notebooks/PROMPT-PART-1-DURABLE-CONTROL-PLANE.md
+++ b/.specs/mcp-peer-notebooks/PROMPT-PART-1-DURABLE-CONTROL-PLANE.md
@@ -1,0 +1,127 @@
+# Kickoff Prompt: ADR-022 Part 1/5 Durable Control Plane
+
+Use this prompt to start the next implementation session.
+
+```markdown
+We are in the Thoughtbox repo on `main`.
+
+Goal: implement ADR-022 Part 1/5, **Durable Control Plane**, tracked by Beads
+issue `thoughtbox-y4x`.
+
+First read:
+
+- `AGENTS.md`
+- `.claude/skills/peer-notebook-delivery-guard/SKILL.md`
+- `.adr/staging/ADR-022.json`
+- `.specs/mcp-peer-notebooks/README.md`
+- `.specs/mcp-peer-notebooks/SPEC-CONTROL-PLANE.md`
+- `.specs/mcp-peer-notebooks/NEXT-IMPLEMENTATION-HANDOFF.md`
+- `src/peer-notebook/`
+- `src/server-factory.ts`
+- existing Supabase storage/migration patterns:
+  - `supabase/migrations/`
+  - `src/persistence/`
+  - `src/knowledge/`
+  - any current workspace-scoped Supabase repositories
+
+Use the `peer-notebook-delivery-guard` skill. Classification:
+
+- Unit: Durable Control Plane.
+- ADR claims advanced: c1, c5; supports h1 and prepares h3.
+- Spec sections touched: Supabase Table Contract, Artifact Payload Strategy,
+  Invocation Flow, Broker Proxy Contract.
+- Production capability expected: durable control-plane rows and artifact
+  metadata/payload handling for the existing brokered mock peer pilot.
+- Mocks/in-memory components involved: `InMemoryPeerNotebookRepository`,
+  `MockPeerRuntimeProvider`.
+- Explicit non-goals: web app pages, manifest graduation from real notebooks,
+  `local-process`, smolvm, direct/public runtime MCP.
+- Beads issue: `thoughtbox-y4x`.
+
+Scope:
+
+1. Add Supabase migrations for peer notebook control-plane persistence:
+   - `peer_notebooks`
+   - `peer_manifests`
+   - `peer_invocations`
+   - `peer_trace_events`
+   - `peer_artifacts`
+   - storage bucket/path strategy for peer artifacts, if supported by existing
+     migration conventions
+
+2. Add a Supabase-backed implementation behind the existing peer notebook
+   repository contract.
+
+3. Wire hosted/Supabase mode so `thoughtbox_peer_notebook` uses durable peer
+   notebook storage when workspace-scoped Supabase storage is available, while
+   preserving in-memory behavior for local tests.
+
+4. Keep `MockPeerRuntimeProvider` as a contract fixture only. Do not represent
+   it as a production runtime implementation.
+
+5. Preserve the current public MCP surface:
+   - `peer_artifact_seed`
+   - `peer_invoke`
+   - `peer_get_invocation`
+   - `peer_list_trace_events`
+   - `peer_get_artifact`
+
+6. Prove durable acceptance:
+   - Seed an artifact.
+   - Invoke `claim-extractor.extract_claims`.
+   - Persist invocation row.
+   - Persist allowed and denied trace events.
+   - Persist output artifact metadata and payload/preview according to the v0
+     artifact strategy.
+   - Read invocation, trace events, and artifact back through
+     `thoughtbox_peer_notebook`.
+
+Mock accountability gate:
+
+| Component | Real Capability It Stands In For | Current Scope | Required Outcome |
+| --- | --- | --- | --- |
+| `InMemoryPeerNotebookRepository` | durable peer notebook control-plane persistence | test/local only | replaced for Supabase mode by real repository |
+| `MockPeerRuntimeProvider` | runtime execution provider | test/pilot only | retained as contract fixture; not production runtime |
+
+Do not:
+
+- Build Next.js pages.
+- Implement notebook-derived manifest approval lifecycle.
+- Implement `local-process`.
+- Implement smolvm or production isolation.
+- Add direct peer runtime MCP.
+- Let in-memory repository satisfy Part 1 acceptance.
+
+Acceptance criteria:
+
+- Supabase migrations match `SPEC-CONTROL-PLANE.md` unless an explicit spec note
+  explains a repo-convention adjustment.
+- Workspace scoping is represented in schema and tests.
+- Supabase repository passes contract tests equivalent to in-memory behavior.
+- The MCP client flow can seed -> invoke -> list traces -> read artifact with
+  durable storage in Supabase-backed mode.
+- Invalid args still reject before runtime dispatch.
+- Unknown trace invocation still returns `invocation_not_found`.
+- Denied outbound call still records `denied_outbound_call` and does not reach
+  a target.
+- `MockPeerRuntimeProvider` remains test/pilot-only in docs and code comments.
+
+Run:
+
+- focused peer notebook tests
+- relevant Supabase/migration tests or local reset/diff checks, depending on
+  existing project conventions
+- `pnpm check:types`
+- `pnpm check:lint`
+- `pnpm build:local`
+
+Before finishing:
+
+- Update `.specs/mcp-peer-notebooks/NEXT-IMPLEMENTATION-HANDOFF.md`.
+- Update README/spec/ADR if implementation changes the documented contract.
+- Complete the peer-notebook-delivery-guard report.
+- File Beads issues for any deferred artifact payload, RLS, retention, or web
+  app follow-up discovered during implementation.
+- Close `thoughtbox-y4x` only if durable control-plane acceptance is genuinely
+  met.
+```

--- a/.specs/mcp-peer-notebooks/README.md
+++ b/.specs/mcp-peer-notebooks/README.md
@@ -10,6 +10,8 @@
 - ADR: [ADR-022 Brokered MCP Peer Notebook Control Plane](../../.adr/staging/ADR-022.json)
 - Spec: [SPEC-CONTROL-PLANE.md](./SPEC-CONTROL-PLANE.md)
 - Diagrams: [DIAGRAMS.md](./DIAGRAMS.md)
+- Current handoff: [NEXT-IMPLEMENTATION-HANDOFF.md](./NEXT-IMPLEMENTATION-HANDOFF.md)
+- Part 1 kickoff prompt: [PROMPT-PART-1-DURABLE-CONTROL-PLANE.md](./PROMPT-PART-1-DURABLE-CONTROL-PLANE.md)
 - Tracking issue: `thoughtbox-pnf`
 
 ## Summary
@@ -24,6 +26,49 @@ auditable work without requiring the primary agent to drive every internal
 reasoning step through Thoughtbox. Thoughtbox becomes the control substrate:
 workspace auth, peer registry, capability enforcement, invocation routing,
 trace persistence, artifact metadata, and web app inspection.
+
+## Current Status After MCP Pilot Merge
+
+Merged on `main`:
+
+- `thoughtbox_peer_notebook` public MCP tool.
+- In-memory `claim-extractor` pilot with artifact seed, peer invoke,
+  invocation read, trace list, and artifact read operations.
+- Mock-only runtime provider.
+- Broker proxy allow/deny trace coverage.
+- MCP client integration coverage through `createMcpServer` and
+  `InMemoryTransport`.
+- Discovery through Code Mode search metadata and
+  `thoughtbox://peer-notebook/pilot`.
+
+The pilot proves broker shape and MCP reachability. It does not complete the
+production control plane because peer notebooks, manifests, invocations, trace
+events, and artifacts are still in-memory.
+
+Future work must use `.claude/skills/peer-notebook-delivery-guard/SKILL.md`.
+Its hard rule is: mocks are contract fixtures, not final substitutes.
+
+## Remaining Delivery Units
+
+1. **Durable Control Plane** (`thoughtbox-y4x`)
+   - Supabase-backed peers, manifests, invocations, trace events, and artifact
+     metadata while the runtime remains mock-capable.
+
+2. **Manifest Lifecycle And Notebook Graduation** (`thoughtbox-g5t`)
+   - Compile, approve, activate, retire, and enforce notebook-derived manifests.
+
+3. **Web App Inspection Surface** (`thoughtbox-2ot`)
+   - Peer registry/detail, invocation detail, denied-call trace timeline, and
+     artifact preview from durable rows.
+
+4. **Real Runtime Provider Path** (`thoughtbox-s7f`)
+   - Development-only `local-process` provider behind the runtime contract.
+
+5. **Production Isolation And Policy Hardening** (`thoughtbox-vdw`)
+   - smolvm or equivalent isolated provider plus enforced network, filesystem,
+     secrets, outbound budget, and denial policy.
+
+Next implementation prompt: [PROMPT-PART-1-DURABLE-CONTROL-PLANE.md](./PROMPT-PART-1-DURABLE-CONTROL-PLANE.md).
 
 ## Current Repo Reality
 


### PR DESCRIPTION
## Summary

- Updates the ADR-022 peer notebook handoff after the MCP-facing pilot merged.
- Adds the five remaining delivery units with Beads issue IDs and mock-accountability guidance.
- Adds a kickoff prompt for Part 1/5: Durable Control Plane.

## Validation

- `git diff --check`
- Commit hook ran `pnpm check:cycles`
- Commit hook ran `pnpm check:lint`

## Notes

This is docs-only. The next implementation unit is `thoughtbox-y4x`, using `.specs/mcp-peer-notebooks/PROMPT-PART-1-DURABLE-CONTROL-PLANE.md`.
