### PR TITLE
fix(otel): parameterize file exporter path; honor CLAUDE_CODE_TMPDIR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,6 @@ thoughtbox-web-two/
 
 .specs/channel-daemon/chatgpt01.md
 rlm-code/
+
+# OTEL collector file-exporter output (host backing for /var/log/otel)
+otel-collector/data/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,8 +66,20 @@ services:
   otel-collector:
     image: otel/opentelemetry-collector-contrib:0.113.0
     command: ["--config=/etc/otelcol/config.yaml"]
+    # Run as root so the container can write to the mounted host path
+    # regardless of who owns it. Avoids uid 10001 / macOS perm friction.
+    user: "0:0"
+    environment:
+      # In-container directory the file exporter writes to. Fixed — it's
+      # the mount point. The HOST backing is the volume below, which
+      # honors CLAUDE_CODE_TMPDIR when set in the shell that runs compose.
+      OTEL_FILE_EXPORT_DIR: /var/log/otel
     volumes:
       - ./otel-collector/config-with-prometheus.yaml:/etc/otelcol/config.yaml:ro
+      # Sub-namespace under CLAUDE_CODE_TMPDIR so collector output doesn't
+      # share a directory with Claude Code's per-uid runtime tmpdir
+      # (claude-<uid>/). Files land at $CLAUDE_CODE_TMPDIR/otel/ on host.
+      - ${CLAUDE_CODE_TMPDIR:-./otel-collector/data}/otel:/var/log/otel
     ports:
       - "4318:4318"
       - "8889:8889"

--- a/otel-collector/config-with-prometheus.yaml
+++ b/otel-collector/config-with-prometheus.yaml
@@ -31,13 +31,15 @@ exporters:
     namespace: mcp
   debug:
     verbosity: basic
+  # OTEL_FILE_EXPORT_DIR resolves inside the container; the host backing
+  # is set in docker-compose.yml and honors CLAUDE_CODE_TMPDIR when present.
   file/logs:
-    path: /tmp/claude-code-events.jsonl
+    path: ${env:OTEL_FILE_EXPORT_DIR}/claude-code-events.jsonl
     rotation:
       max_megabytes: 100
       max_days: 7
   file/metrics:
-    path: /tmp/claude-code-metrics.jsonl
+    path: ${env:OTEL_FILE_EXPORT_DIR}/claude-code-metrics.jsonl
     rotation:
       max_megabytes: 50
       max_days: 7

--- a/otel-collector/config.yaml
+++ b/otel-collector/config.yaml
@@ -15,16 +15,19 @@ exporters:
   debug:
     verbosity: detailed
 
-  # File exporter for persistent logs
+  # File exporter for persistent logs.
+  # Path is configurable via OTEL_FILE_EXPORT_DIR (in-container); the host
+  # backing of that directory is set in docker-compose.yml and honors
+  # CLAUDE_CODE_TMPDIR when present.
   file/logs:
-    path: /tmp/claude-code-events.jsonl
+    path: ${env:OTEL_FILE_EXPORT_DIR}/claude-code-events.jsonl
     rotation:
       max_megabytes: 100
       max_days: 7
       max_backups: 5
 
   file/metrics:
-    path: /tmp/claude-code-metrics.jsonl
+    path: ${env:OTEL_FILE_EXPORT_DIR}/claude-code-metrics.jsonl
     rotation:
       max_megabytes: 50
       max_days: 7

--- a/otel-collector/enable-telemetry.sh
+++ b/otel-collector/enable-telemetry.sh
@@ -6,6 +6,13 @@
 #
 # Or add these to your shell profile (~/.zshrc, ~/.bashrc)
 
+# Where the OTEL collector should drop file-exported logs/metrics on the
+# HOST. docker-compose interpolates this; if unset, falls back to the
+# project-local ./otel-collector/data directory. Honors any project- or
+# user-level override of CLAUDE_CODE_TMPDIR already in the shell env.
+: "${CLAUDE_CODE_TMPDIR:=$(cd "$(dirname "${BASH_SOURCE[0]}")/data" && pwd)}"
+export CLAUDE_CODE_TMPDIR
+
 # Required: Enable telemetry
 export CLAUDE_CODE_ENABLE_TELEMETRY=1
 


### PR DESCRIPTION
## Summary

The OTEL Collector file exporter hardcoded `/tmp/claude-code-{events,metrics}.jsonl` inside the distroless container. The default uid (10001) cannot write to the container's `/tmp` on macOS bind-mount setups, producing:

```
can't open new logfile: open /tmp/claude-code-metrics.jsonl: permission denied
```

Host-side `chmod` or symlinking does not reach the container filesystem, so this needs a config + compose fix rather than a host workaround.

## Changes

- **`otel-collector/config.yaml`, `otel-collector/config-with-prometheus.yaml`** — Replace hardcoded `/tmp/...` with `${env:OTEL_FILE_EXPORT_DIR}/...` so the in-container target is configurable instead of baked into a checked-in file.
- **`docker-compose.yml`** (otel-collector service):
  - `OTEL_FILE_EXPORT_DIR=/var/log/otel` (in-container mount point — fixed).
  - Bind-mount `${CLAUDE_CODE_TMPDIR:-./otel-collector/data}/otel:/var/log/otel`. The `/otel` sub-namespace prevents collector output from sharing a directory with Claude Code's per-uid runtime tmpdir (`claude-<uid>/`).
  - `user: "0:0"` so writes succeed regardless of bind-mount ownership on macOS.
- **`otel-collector/enable-telemetry.sh`** — Default `CLAUDE_CODE_TMPDIR` to project-local `./otel-collector/data` when not already exported.
- **`.gitignore`** — Ignore `otel-collector/data/`.

## Behavior

| `CLAUDE_CODE_TMPDIR` exported in shell? | Files land at |
|---|---|
| Yes (e.g. `~/.claude/tmp`) | `$CLAUDE_CODE_TMPDIR/otel/claude-code-*.jsonl` |
| No | `./otel-collector/data/otel/claude-code-*.jsonl` |

## Test plan

- [x] `docker compose up -d otel-collector` starts cleanly with no logfile error
- [x] OTLP HTTP POSTs to `localhost:4318/v1/metrics` return `200 partialSuccess: {}`
- [x] File exporter writes to the configured host path; size grows under load
- [x] Sub-namespace (`/otel/`) keeps output isolated from `claude-<uid>/`
- [x] Verified via `lsof` that there is one writer and one active file (no duplicate writes)

## Notes

- `docker-compose` interpolates `${CLAUDE_CODE_TMPDIR}` from the shell that invokes it, **not** from Claude Code's `settings.json`. Users who want the override to apply automatically should export it from their shell rc, an `.env` file, or `enable-telemetry.sh`.
- For Cloud Run / stateless deployments, the file exporter remains a footgun — an OTLP exporter to a managed sink is the right move there. Out of scope for this PR.