### PR TITLE
docs(cleanup): update removed assumptions workflow reference

### DIFF
--- a/docs/aspirational-systems-audit.md
+++ b/docs/aspirational-systems-audit.md
@@ -214,8 +214,8 @@ Highest-risk gaps: agents/operators following root README or skills that call re
 | **Status** | `unwired` |
 | **Confidence** | High |
 | **Claim** | Assumption skill describes verification workflow. |
-| **Wiring** | [`.github/workflows/verify-assumptions.yml`](../.github/workflows/verify-assumptions.yml) L13: `if: false`. |
-| **Cleanup slice** | Re-enable with executable checks or update skill. |
+| **Wiring** | Removed during repo cleanup after remaining hard-disabled with `if: false`. |
+| **Cleanup slice** | Update the assumption skill or create a new executable verification workflow in a dedicated unit if this capability is still desired. |
 
 ### 18. Supabase thought-queue edge function scheduling
 

--- a/prs/docs-update-removed-assumptions-workflow-reference.json
+++ b/prs/docs-update-removed-assumptions-workflow-reference.json
@@ -1,0 +1,17 @@
+{
+  "branch": "docs/update-removed-assumptions-workflow-reference",
+  "summary": "Updates the aspirational systems audit so the assumption registry verification entry no longer links to the removed `verify-assumptions.yml` workflow as current wiring. The entry now records that the hard-disabled workflow was removed during cleanup and leaves any replacement verification workflow as a future dedicated unit.",
+  "claims": [
+    {
+      "id": "c1",
+      "statement": "Repo docs and cleanup governance artifacts explicitly record accepted cleanup decisions, validation evidence, and deferred items so later sessions can continue without re-auditing the same scope.",
+      "evidence_type": "implementation",
+      "evidence_path": "docs/aspirational-systems-audit.md",
+      "evidence_description": "The audit entry for assumption registry verification now reflects that the disabled workflow was removed rather than treating the deleted workflow path as current wiring.",
+      "spec_claim_id": "SPEC-REPO-CLEANUP:c4"
+    }
+  ],
+  "specs": [
+    "SPEC-REPO-CLEANUP"
+  ]
+}


### PR DESCRIPTION
## Summary

Updates the aspirational systems audit so the assumption registry verification entry no longer links to the removed `verify-assumptions.yml` workflow as current wiring. The entry now records that the hard-disabled workflow was removed during cleanup and leaves any replacement verification workflow as a future dedicated unit.

## Specs

- SPEC-REPO-CLEANUP

## Claims

| ID | Statement | Evidence |
|---|---|---|
| `c1` (SPEC-REPO-CLEANUP:c4) | Repo docs and cleanup governance artifacts explicitly record accepted cleanup decisions, validation evidence, and deferred items so later sessions can continue without re-auditing the same scope. | implementation: `docs/aspirational-systems-audit.md` |

---
_Generated from [`prs/docs-update-removed-assumptions-workflow-reference.json`](../../blob/b189c8908ae0ff910df277101482e44811a5a503/prs/docs-update-removed-assumptions-workflow-reference.json)_