### PR TITLE
fix(branch): gate branch toolhost to hosted mode

### DIFF
--- a/src/code-mode/__tests__/execute-tool.test.ts
+++ b/src/code-mode/__tests__/execute-tool.test.ts
@@ -136,6 +136,17 @@ describe("thoughtbox_execute", () => {
     expect(output.result).toBeDefined();
   });
 
+  it("tb.branch.* returns a hosted-mode error when no branchHandler is wired", async () => {
+    // createExecuteTool() omits branchHandler, mirroring local/self-hosted mode.
+    const tool = createExecuteTool();
+    const result = await tool.handle({
+      code: `async () => { return await tb.branch.list({ sessionId: "s1" }); }`,
+    });
+    const output = JSON.parse(result.content[0].text);
+    expect(output.result).toBeNull();
+    expect(output.error).toContain("hosted mode");
+  });
+
   it("can call tb.thought()", async () => {
     const tool = createExecuteTool();
     const result = await tool.handle({

--- a/src/code-mode/execute-tool.ts
+++ b/src/code-mode/execute-tool.ts
@@ -42,7 +42,13 @@ export interface ExecuteToolDeps {
   theseusTool: TheseusTool;
   ulyssesTool: UlyssesTool;
   observabilityHandler: ObservabilityGatewayHandler;
-  branchHandler: BranchHandler;
+  /**
+   * Hosted-mode only. The branch toolhost spawns Supabase Edge Function
+   * workers and requires Supabase credentials, so it is left undefined in
+   * local/self-hosted mode. `tb.branch.*` then returns a clear error instead
+   * of crashing session setup.
+   */
+  branchHandler?: BranchHandler;
 }
 
 export const EXECUTE_TOOL = {
@@ -134,6 +140,17 @@ interface TbContext {
 function buildTbObject(deps: ExecuteToolDeps, ctx: TbContext): Record<string, unknown> {
   const { thoughtTool, sessionTool, knowledgeTool, notebookTool,
           theseusTool, ulyssesTool, observabilityHandler, branchHandler } = deps;
+
+  const requireBranchHandler = (): BranchHandler => {
+    if (!branchHandler) {
+      throw new Error(
+        "Branch operations require hosted mode. The branch toolhost spawns " +
+          "Supabase Edge Function workers and needs SUPABASE_URL and " +
+          "SUPABASE_SERVICE_ROLE_KEY; it is unavailable in local/self-hosted mode.",
+      );
+    }
+    return branchHandler;
+  };
 
   return {
     thought: async (input: ThoughtToolInput) => {
@@ -280,13 +297,13 @@ function buildTbObject(deps: ExecuteToolDeps, ctx: TbContext): Record<string, un
 
     branch: {
       spawn: async (args: Record<string, unknown>) =>
-        unwrapToolResult(await branchHandler.processTool("spawn", args)),
+        unwrapToolResult(await requireBranchHandler().processTool("spawn", args)),
       merge: async (args: Record<string, unknown>) =>
-        unwrapToolResult(await branchHandler.processTool("merge", args)),
+        unwrapToolResult(await requireBranchHandler().processTool("merge", args)),
       list: async (args: Record<string, unknown>) =>
-        unwrapToolResult(await branchHandler.processTool("list", args)),
+        unwrapToolResult(await requireBranchHandler().processTool("list", args)),
       get: async (args: Record<string, unknown>) =>
-        unwrapToolResult(await branchHandler.processTool("get", args)),
+        unwrapToolResult(await requireBranchHandler().processTool("get", args)),
     },
   };
 }

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -552,14 +552,21 @@ Use \`console.log()\` for debugging — output captured in response logs.`;
     serviceRoleKey: process.env.SUPABASE_SERVICE_ROLE_KEY,
   });
 
-  // Branch handler — requires Supabase credentials
-  const branchSupabaseUrl = process.env.SUPABASE_URL ?? "";
-  const branchServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY ?? "";
-  const branchHandler = new BranchHandler({
-    supabaseUrl: branchSupabaseUrl,
-    serviceRoleKey: branchServiceKey,
-    workspaceId: args.workspaceId ?? "default",
-  });
+  // Branch handler — hosted mode only. The branch toolhost spawns Supabase
+  // Edge Function workers and constructs a Supabase client at init, so it is
+  // only wired when Supabase credentials are present. In local/self-hosted
+  // mode it is left undefined; `tb.branch.*` then returns a clear "hosted
+  // mode" error instead of crashing session setup on a missing SUPABASE_URL.
+  const branchSupabaseUrl = process.env.SUPABASE_URL;
+  const branchServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  const branchHandler =
+    branchSupabaseUrl && branchServiceKey
+      ? new BranchHandler({
+          supabaseUrl: branchSupabaseUrl,
+          serviceRoleKey: branchServiceKey,
+          workspaceId: args.workspaceId ?? "default",
+        })
+      : undefined;
 
   // =============================================================================
   // Code Mode Tools (replaces individual tool registrations)


### PR DESCRIPTION
## Problem

Connecting to the local Thoughtbox MCP server returned **HTTP 500** on every session. The cause was not auth — the server logged `[MCP] Unauthenticated request in local mode` (it accepted the request) and then **crashed during session construction**:

```
MCP ERROR: Error: supabaseUrl is required.
    at new BranchHandlers (dist/branch/handlers.js)
    at createMcpServer (dist/server-factory.js)
```

`server-factory.ts` built the branch toolhost **unconditionally** with empty-string fallbacks (`process.env.SUPABASE_URL ?? ""`), and `BranchHandlers` constructs a `supabase-js` client at init — so `createClient("")` threw on every new MCP session when no Supabase env was present (the documented local docker-compose case).

The branch toolhost is inherently hosted-only: `spawn` returns a Supabase **Edge Function** worker URL signed with the service-role key. It has no local equivalent.

## Fix (interim — option B)

- **Gate construction**: only build `BranchHandler` when `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` are present; otherwise leave it `undefined` (`server-factory.ts`).
- **Make the dep optional**: `ExecuteToolDeps.branchHandler?` — this also fixes a latent type hole (the existing `execute-tool.test.ts` already omitted it).
- **Graceful degradation**: `tb.branch.*` returns a clear "requires hosted mode" error instead of crashing.

Hosted behavior is unchanged (creds present → handler constructed exactly as before).

## Verification

- `tsc --noEmit` ✅ · `oxlint` 0/0 ✅ · `check:cycles` ✅ · gitleaks ✅
- `vitest`: 526 passed (added 1), same 7 pre-existing failures (tracked in #346)
- **Live smoke**: built `dist`, ran `node dist/index.js` in local mode (no `SUPABASE_URL`), `POST /mcp initialize` → **HTTP 200** (was 500), server log shows `Creating server for MCP session` with no `supabaseUrl is required`.

## Follow-up

The architecturally-correct fix — route the branch toolhost through a dual-backend `BranchStore` so local mode uses in-memory/filesystem — is tracked in **#347** (and closes the `architecture.test` violation noted in #346).

🤖 Generated with [Claude Code](https://claude.com/claude-code)