### PR TITLE
feat(tournament): TV Remote wedge spec + tournament workflows

### DIFF
--- a/.claude/workflows/tv-remote-salvage.js
+++ b/.claude/workflows/tv-remote-salvage.js
@@ -1,0 +1,123 @@
+export const meta = {
+  name: 'tv-remote-salvage',
+  description:
+    'Re-gate and judge the 18 EXISTING tv-remote candidate branches (no regeneration). Fixes the BASE bug from the first run: restores the ruler from feat/tv-remote-tournament and fails loudly if it is absent, then judges gate-survivors and ranks them.',
+  phases: [
+    { title: 'Gate', detail: 'hermetic re-gate of existing branches against the canonical harness' },
+    { title: 'Judge', detail: 'panel scores deduped survivors on a spec rubric' },
+    { title: 'Rank', detail: 'synthesize a ranked comparison and name the winner' },
+  ],
+}
+
+// The bundle (spec + harness + tooling) lives here; candidates forked from main
+// and carry only their implementation. The gate restores the ruler from BASE.
+const BASE = 'feat/tv-remote-tournament'
+const SPEC = '.specs/agent-governance-substrate/SPEC-TV-REMOTE-WEDGE.md'
+const HARNESS = '.claude/workflows/tv-remote/acceptance.mjs'
+const WAVE = (args && args.waveSize) || 4 // gentle: gate builds are RAM-heavy
+const LENSES = ['spec-fidelity', 'design-quality', 'simplicity-and-safety']
+const JWAVE = Math.max(1, Math.floor(12 / LENSES.length))
+// Only the candidates with real implementations (19-24 were empty/partial).
+const CANDS = Array.from({ length: 18 }, (_, k) => ({ i: k + 1, branch: `tournament/candidate-${k + 1}` }))
+
+const GATE_SCHEMA = {
+  type: 'object', additionalProperties: false,
+  required: ['pass', 'buildPassed', 'rulerPresent', 'phases', 'diffHash', 'rawTail'],
+  properties: {
+    pass: { type: 'boolean', description: 'true iff rulerPresent AND buildPassed AND all phases A-E true' },
+    buildPassed: { type: 'boolean' },
+    rulerPresent: { type: 'boolean', description: 'true iff the harness + spec were actually present after restore from BASE' },
+    phases: {
+      type: 'object', additionalProperties: false, required: ['A', 'B', 'C', 'D', 'E'],
+      properties: { A: { type: 'boolean' }, B: { type: 'boolean' }, C: { type: 'boolean' }, D: { type: 'boolean' }, E: { type: 'boolean' } },
+    },
+    diffHash: { type: 'string' },
+    rawTail: { type: 'string', description: 'verbatim last ~40 lines of output' },
+  },
+}
+const JUDGE_SCHEMA = {
+  type: 'object', additionalProperties: false, required: ['score', 'rationale', 'grafts', 'risks'],
+  properties: {
+    score: { type: 'number' }, rationale: { type: 'string' },
+    grafts: { type: 'array', items: { type: 'string' } }, risks: { type: 'array', items: { type: 'string' } },
+  },
+}
+
+function chunk(arr, n) { const o = []; for (let i = 0; i < arr.length; i += n) o.push(arr.slice(i, i + n)); return o }
+
+function gatePrompt(branch) {
+  return [
+    'You are an OBJECTIVE, HERMETIC GATE RUNNER. Run commands and report results verbatim. Do not fix, improve, or judge. Any deviation corrupts the tournament.',
+    '',
+    'SAFETY: operate ONLY inside your own worktree cwd. Never `cd` to the primary repo checkout and never run a bare `git checkout <branch>` (it can move the primary working tree). Detached SHA checkout in your worktree is fine.',
+    'Steps (you are in your own isolated worktree):',
+    '1. `SHA=$(git rev-parse ' + branch + ')` then `git checkout "$SHA"` (detached).',
+    '2. Restore the ruler + tooling from ' + BASE + ': `git checkout ' + BASE + ' -- ' + HARNESS + ' ' + SPEC + ' package.json pnpm-lock.yaml scripts/`',
+    '3. FAIL LOUD: `test -f ' + HARNESS + ' && test -f ' + SPEC + '`. If either is missing, set rulerPresent=false, pass=false, and STOP — do not guess a verdict. Otherwise rulerPresent=true.',
+    '4. `rm -f .tournament-result.json`; `pnpm install --frozen-lockfile`; `pnpm build` (record buildPassed).',
+    '5. `R=$(mktemp); TB_RESULT_PATH="$R" node ' + HARNESS + '; cat "$R"`. Read phases A-E ONLY from "$R". Missing/empty file => pass=false.',
+    '6. `git diff ' + BASE + '...$SHA | shasum -a 256 | cut -d" " -f1` => diffHash.',
+    '',
+    '`pass` is true ONLY if rulerPresent AND build succeeded AND all A-E are true in the result file. Never infer a pass you did not observe.',
+  ].join('\n')
+}
+function judgePrompt(s, lens) {
+  const r = {
+    'spec-fidelity': 'Satisfies the spec beyond passing the harness? Check c1-c8: real interception, server-computed verdicts from stored constraints (not hardcoded), dual-backend routing through the storage switch, fail-open, lesson retrieval, traces linked to constraints.',
+    'design-quality': 'Constraint/lesson model + retrieval well-factored and consistent with SPEC-ENVIRONMENTAL-LEARNING-GATES (reversibility selects the rung; validators over gates)? Enforcement cleanly placed?',
+    'simplicity-and-safety': 'Simplest thing that works? Minimal new surface, no dead code, no broken existing tests/hooks, no regressions to the shipped {blocked,...} consumers, no new deps.',
+  }
+  return [
+    'Judge ONE candidate on ONE lens. Be skeptical; default low.',
+    'Lens: ' + lens + ' — ' + r[lens],
+    'Read ' + SPEC + ' (on ' + BASE + '), then the diff: `git diff ' + BASE + '...' + s.branch + '`. It passed the objective gate; grade the quality dimension, watching for a thin implementation that satisfied the harness without honoring spec intent.',
+    'Return score 0-10, terse rationale with file:line, grafts, risks.',
+  ].join('\n')
+}
+function synthPrompt(ranked, spread) {
+  const t = ranked.map((r, n) => `${n + 1}. candidate ${r.i} (${r.branch}) score ${r.score.toFixed(2)}${r.dupes ? ` [+${r.dupes} dup]` : ''}`).join('\n')
+  return ['Write a concise ranked merge-decision report (markdown).', `Score spread: ${spread.toFixed(2)} (if small, the field converged — say so).`, 'Ranked survivors:', t, '', 'For the top 3: distinguishing design choice, why it ranked there, ideas to graft from runners-up. End with: which branch to check out and what to graft before merge.'].join('\n')
+}
+async function judgeOne(s) {
+  const votes = await parallel(LENSES.map((l) => () => agent(judgePrompt(s, l), { label: `judge:${s.i}:${l}`, phase: 'Judge', schema: JUDGE_SCHEMA })))
+  const v = votes.filter(Boolean)
+  return { ...s, score: v.length ? v.reduce((a, x) => a + x.score, 0) / v.length : 0, votes: v }
+}
+
+phase('Gate')
+const gated = []
+for (const wave of chunk(CANDS, WAVE)) {
+  const batch = await parallel(wave.map((c) => () => agent(gatePrompt(c.branch), { label: `gate:${c.i}`, phase: 'Gate', isolation: 'worktree', schema: GATE_SCHEMA }).then((g) => ({ ...c, gate: g }))))
+  gated.push(...batch.filter(Boolean))
+  log(`gate wave done — ${gated.length}/${CANDS.length}`)
+}
+const survivors = gated.filter((c) => c.gate && c.gate.pass)
+log(`${survivors.length}/${gated.length} survivors`)
+if (survivors.length === 0) {
+  return { winner: null, reason: 'no candidate passed the corrected gate', gated: gated.map((g) => ({ i: g.i, pass: g.gate && g.gate.pass, rulerPresent: g.gate && g.gate.rulerPresent })) }
+}
+
+phase('Judge')
+const byHash = new Map(); const unique = []
+for (const s of survivors) {
+  const h = s.gate.diffHash
+  if (h && byHash.has(h)) { byHash.get(h).dupes += 1; continue }
+  const rec = { ...s, dupes: 0 }; if (h) byHash.set(h, rec); unique.push(rec)
+}
+log(`${unique.length} unique survivors (${survivors.length - unique.length} folded)`)
+const judged = []
+for (const wave of chunk(unique, JWAVE)) {
+  const batch = await parallel(wave.map((s) => () => judgeOne(s)))
+  judged.push(...batch.filter(Boolean))
+}
+const ranked = judged.sort((a, b) => b.score - a.score)
+const spread = ranked.length ? ranked[0].score - ranked[ranked.length - 1].score : 0
+
+phase('Rank')
+const report = await agent(synthPrompt(ranked, spread), { label: 'synthesize', phase: 'Rank' })
+return {
+  winner: ranked[0] ? { candidate: ranked[0].i, branch: ranked[0].branch, score: ranked[0].score } : null,
+  ranked: ranked.map((r) => ({ candidate: r.i, branch: r.branch, score: Number(r.score.toFixed(2)), nearIdentical: r.dupes })),
+  scoreSpread: Number(spread.toFixed(2)), survivors: survivors.length, judged: ranked.length,
+  report,
+}

--- a/.claude/workflows/tv-remote-tournament.js
+++ b/.claude/workflows/tv-remote-tournament.js
@@ -10,17 +10,24 @@ export const meta = {
   ],
 }
 
-// --- knobs (override via args) -------------------------------------------------
+// --- knobs ---------------------------------------------------------------------
+// WARNING: the `args` channel proved unreliable in practice (a run launched with
+// {candidates:2, base:...} silently used these defaults instead). SET THESE
+// VALUES HERE before launching, and edit-then-relaunch the file rather than
+// trusting args. The args fallback is kept only as a convenience.
+//
 // WAVE is RAM-bound, NOT the runtime's 14-agent ceiling: ~6-8 concurrent `tsc`
-// builds is the safe envelope on a 16-core / 64 GB Codespace. Both Generate and
-// Gate compile, so both are throttled to WAVE candidates at a time.
-const N = (args && args.candidates) || 30
+// builds is the safe envelope on a 16-core / 64 GB Codespace.
+// N=10 default: best-of-10 gives real selection value at ~1/3 the token cost of 30.
+const N = (args && args.candidates) || 10
 const WAVE = (args && args.waveSize) || 6
 const SPEC = '.specs/agent-governance-substrate/SPEC-TV-REMOTE-WEDGE.md'
 const HARNESS = '.claude/workflows/tv-remote/acceptance.mjs'
-// The branch that carries the spec + harness; candidates fork from it and the
-// gate restores tooling from it. Must be the branch you launch the run from.
-const BASE = (args && args.base) || 'main'
+// BASE must be the branch that CARRIES the spec + harness (the bundle). If it is
+// wrong, the gate's ruler restore fails — the gate now fails loudly rather than
+// faking a pass. Set this to the branch you launch from (NOT 'main' unless the
+// bundle has been merged to main).
+const BASE = (args && args.base) || 'feat/tv-remote-tournament'
 const LENSES = ['spec-fidelity', 'design-quality', 'simplicity-and-safety']
 // Keep judge fan-out under the runtime's ~14-agent ceiling: survivors-per-wave x lenses <= ~12.
 const JWAVE = Math.max(1, Math.floor(12 / LENSES.length))
@@ -41,10 +48,11 @@ const BUILD_SCHEMA = {
 const GATE_SCHEMA = {
   type: 'object',
   additionalProperties: false,
-  required: ['pass', 'buildPassed', 'phases', 'diffHash', 'rawTail'],
+  required: ['pass', 'buildPassed', 'rulerPresent', 'phases', 'diffHash', 'rawTail'],
   properties: {
-    pass: { type: 'boolean', description: 'true iff buildPassed AND every acceptance phase passed, read from the result file' },
+    pass: { type: 'boolean', description: 'true iff rulerPresent AND buildPassed AND every acceptance phase passed, read from the result file' },
     buildPassed: { type: 'boolean' },
+    rulerPresent: { type: 'boolean', description: 'true iff the harness + spec were actually present after restore from BASE (false = wrong base, auto-fail)' },
     phases: {
       type: 'object',
       additionalProperties: false,
@@ -94,6 +102,7 @@ function buildPrompt(i, branch) {
     'The harness keys every check off a per-run nonce and verifies a NEGATIVE CONTROL (the action is allowed before a constraint is seeded, blocked after). A hardcoded string match WILL FAIL. Your verdict must actually derive from the seeded, stored constraint, and traces must carry the real constraintId.',
     '',
     'WORKTREE PROTOCOL:',
+    '- SAFETY: operate ONLY inside your own worktree directory. Never `cd` to the primary repo checkout and never run a bare `git checkout <branch>` that could move the primary working tree. All git commands run from your worktree cwd.',
     '- You are in an isolated git worktree. Create your branch from ' + BASE + ': `git checkout -b ' + branch + ' ' + BASE + '`.',
     '- Implement the wedge. Run `pnpm install --frozen-lockfile` then `pnpm build` and iterate until clean.',
     '- Commit ALL work to ' + branch + ' (working tree must end clean): `git add -A && git commit`. Do not push.',
@@ -113,13 +122,14 @@ function gatePrompt(i, sha) {
     '1. Detached-checkout the candidate commit (works across worktrees): `git checkout ' + sha + '`.',
     '2. Restore the tooling + ruler from ' + BASE + ' so a candidate cannot tamper with its own grading (do NOT restore the candidate hook, which is under test):',
     '   `git checkout ' + BASE + ' -- ' + HARNESS + ' ' + SPEC + ' package.json pnpm-lock.yaml scripts/`',
-    '3. `rm -f .tournament-result.json` (ignore any committed copy). Then `pnpm install --frozen-lockfile` and `pnpm build`. Record whether build succeeded (exit 0).',
-    '4. Run the harness writing its verdict to an unpredictable path the candidate cannot have planted:',
+    '3. FAIL LOUD: `test -f ' + HARNESS + ' && test -f ' + SPEC + '`. If either is missing the BASE is wrong — set rulerPresent=false, pass=false, and STOP. Do not guess a verdict. Otherwise rulerPresent=true.',
+    '4. `rm -f .tournament-result.json` (ignore any committed copy). Then `pnpm install --frozen-lockfile` and `pnpm build`. Record whether build succeeded (exit 0).',
+    '5. Run the harness writing its verdict to an unpredictable path the candidate cannot have planted:',
     '   `R=$(mktemp); TB_RESULT_PATH="$R" node ' + HARNESS + '; cat "$R"`',
     '   The harness boots the candidate server on the fs backend, drives phases A-E, and exits non-zero on any failure. Read phases A-E ONLY from "$R". If "$R" is missing/empty, treat pass=false.',
-    '5. Compute the dedup hash: `git diff ' + BASE + '...' + sha + ' | shasum -a 256 | cut -d" " -f1` and report it as diffHash.',
+    '6. Compute the dedup hash: `git diff ' + BASE + '...' + sha + ' | shasum -a 256 | cut -d" " -f1` and report it as diffHash.',
     '',
-    '`pass` is true ONLY if build succeeded AND all of A-E are true in the result file you printed. Never infer a pass you did not observe in that file.',
+    '`pass` is true ONLY if rulerPresent AND build succeeded AND all of A-E are true in the result file you printed. Never infer a pass you did not observe in that file.',
   ].join('\n')
 }
 

--- a/.claude/workflows/tv-remote-tournament.js
+++ b/.claude/workflows/tv-remote-tournament.js
@@ -1,0 +1,229 @@
+export const meta = {
+  name: 'tv-remote-tournament',
+  description:
+    'Generate N independent implementations of SPEC-TV-REMOTE-WEDGE, gate each against the canonical acceptance harness in a hermetic worktree, judge gate-survivors on a spec rubric, and return a ranked report naming the winning branch.',
+  phases: [
+    { title: 'Generate', detail: 'N build agents, one git branch each, worktree-isolated' },
+    { title: 'Gate', detail: 'hermetic runner: detached SHA checkout, restore tooling from main, run build + acceptance (objective)' },
+    { title: 'Judge', detail: 'panel scores deduped gate-survivors on a spec rubric using their diffs' },
+    { title: 'Rank', detail: 'synthesize a ranked comparison and name the winner' },
+  ],
+}
+
+// --- knobs (override via args) -------------------------------------------------
+// WAVE is RAM-bound, NOT the runtime's 14-agent ceiling: ~6-8 concurrent `tsc`
+// builds is the safe envelope on a 16-core / 64 GB Codespace. Both Generate and
+// Gate compile, so both are throttled to WAVE candidates at a time.
+const N = (args && args.candidates) || 30
+const WAVE = (args && args.waveSize) || 6
+const SPEC = '.specs/agent-governance-substrate/SPEC-TV-REMOTE-WEDGE.md'
+const HARNESS = '.claude/workflows/tv-remote/acceptance.mjs'
+// The branch that carries the spec + harness; candidates fork from it and the
+// gate restores tooling from it. Must be the branch you launch the run from.
+const BASE = (args && args.base) || 'main'
+const LENSES = ['spec-fidelity', 'design-quality', 'simplicity-and-safety']
+// Keep judge fan-out under the runtime's ~14-agent ceiling: survivors-per-wave x lenses <= ~12.
+const JWAVE = Math.max(1, Math.floor(12 / LENSES.length))
+
+const BUILD_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['committed', 'sha', 'selfBuildPassed', 'filesChanged', 'approach'],
+  properties: {
+    committed: { type: 'boolean', description: 'true iff all work is committed and `git status` is clean on the candidate branch' },
+    sha: { type: 'string', description: 'commit SHA of the candidate branch tip (git rev-parse HEAD); empty string if not committed' },
+    selfBuildPassed: { type: 'boolean', description: 'result of the candidate self-running pnpm build' },
+    filesChanged: { type: 'array', items: { type: 'string' } },
+    approach: { type: 'string', description: 'one-paragraph summary of the design choices that distinguish this candidate' },
+  },
+}
+
+const GATE_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['pass', 'buildPassed', 'phases', 'diffHash', 'rawTail'],
+  properties: {
+    pass: { type: 'boolean', description: 'true iff buildPassed AND every acceptance phase passed, read from the result file' },
+    buildPassed: { type: 'boolean' },
+    phases: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['A', 'B', 'C', 'D', 'E'],
+      properties: {
+        A: { type: 'boolean' }, B: { type: 'boolean' }, C: { type: 'boolean' },
+        D: { type: 'boolean' }, E: { type: 'boolean' },
+      },
+    },
+    diffHash: { type: 'string', description: 'sha256 of `git diff main...<sha>` for dedup of near-identical candidates' },
+    rawTail: { type: 'string', description: 'verbatim last ~40 lines of build+harness output' },
+  },
+}
+
+const JUDGE_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['score', 'rationale', 'grafts', 'risks'],
+  properties: {
+    score: { type: 'number', description: '0-10 on the assigned lens' },
+    rationale: { type: 'string' },
+    grafts: { type: 'array', items: { type: 'string' }, description: 'ideas worth stealing into the winner' },
+    risks: { type: 'array', items: { type: 'string' } },
+  },
+}
+
+function chunk(arr, n) {
+  const out = []
+  for (let i = 0; i < arr.length; i += n) out.push(arr.slice(i, i + n))
+  return out
+}
+
+function buildPrompt(i, branch) {
+  return [
+    'NON-NEGOTIABLE CONSTRAINTS (from the decided architecture; violating any fails the candidate):',
+    '- Dual backend: route action-trace + gate-lesson persistence through the central THOUGHTBOX_STORAGE switch (src/index.ts). NEVER sniff process.env.SUPABASE_URL directly.',
+    '- Fail-open: if the enforcement endpoint is unreachable the interception MUST allow the action (never hard-block on infra error).',
+    '- DO NOT add new dependencies. package.json, the lockfile, and root scripts/ are restored from ' + BASE + ' at gate time, so any new dep will break your gate build.',
+    '- Do not edit the acceptance harness (' + HARNESS + '), the spec, or any existing test. Do not touch ' + BASE + '. Do not push.',
+    '- Conventional Commits; absolute imports; <=100 lines/function.',
+    '',
+    'TASK: Implement the TV Remote wedge exactly as specified. Read these first, in full:',
+    '  1. ' + SPEC + '  (the contract — especially the PINNED enforcement contract, the pinned support routes, the pinned hook path, and Acceptance phases A-E)',
+    '  2. ' + HARNESS + '  (the exact ruler your work is graded by — read it so you know what to satisfy, but DO NOT modify it)',
+    'Then read what already exists and EXTEND it rather than rebuild: plugins/thoughtbox-claude-code/scripts/protocol_gate.sh, src/http/protocol-http.ts, src/notebook/validator.ts, src/code-mode/execute-tool.ts (buildTbObject), src/index.ts (storage switch).',
+    '',
+    'The harness keys every check off a per-run nonce and verifies a NEGATIVE CONTROL (the action is allowed before a constraint is seeded, blocked after). A hardcoded string match WILL FAIL. Your verdict must actually derive from the seeded, stored constraint, and traces must carry the real constraintId.',
+    '',
+    'WORKTREE PROTOCOL:',
+    '- You are in an isolated git worktree. Create your branch from ' + BASE + ': `git checkout -b ' + branch + ' ' + BASE + '`.',
+    '- Implement the wedge. Run `pnpm install --frozen-lockfile` then `pnpm build` and iterate until clean.',
+    '- Commit ALL work to ' + branch + ' (working tree must end clean): `git add -A && git commit`. Do not push.',
+    '- Capture the commit SHA: `git rev-parse HEAD`, and return it as `sha`.',
+    '',
+    'The design (constraint representation, storage shape, retrieval/ranking, rung selection, where enforcement logic lives, action-button naming beyond the pinned harness seam) is YOURS to choose — that is what you are judged on. Make deliberate, defensible choices.',
+    '',
+    'Return the structured result. `committed` is true only if `git status` is clean on ' + branch + '.',
+  ].join('\n')
+}
+
+function gatePrompt(i, sha) {
+  return [
+    'You are an OBJECTIVE, HERMETIC GATE RUNNER. You do not fix, improve, or judge code. You run commands and report results verbatim. Any deviation corrupts the tournament.',
+    '',
+    'Steps (run exactly; you are in your own isolated worktree):',
+    '1. Detached-checkout the candidate commit (works across worktrees): `git checkout ' + sha + '`.',
+    '2. Restore the tooling + ruler from ' + BASE + ' so a candidate cannot tamper with its own grading (do NOT restore the candidate hook, which is under test):',
+    '   `git checkout ' + BASE + ' -- ' + HARNESS + ' ' + SPEC + ' package.json pnpm-lock.yaml scripts/`',
+    '3. `rm -f .tournament-result.json` (ignore any committed copy). Then `pnpm install --frozen-lockfile` and `pnpm build`. Record whether build succeeded (exit 0).',
+    '4. Run the harness writing its verdict to an unpredictable path the candidate cannot have planted:',
+    '   `R=$(mktemp); TB_RESULT_PATH="$R" node ' + HARNESS + '; cat "$R"`',
+    '   The harness boots the candidate server on the fs backend, drives phases A-E, and exits non-zero on any failure. Read phases A-E ONLY from "$R". If "$R" is missing/empty, treat pass=false.',
+    '5. Compute the dedup hash: `git diff ' + BASE + '...' + sha + ' | shasum -a 256 | cut -d" " -f1` and report it as diffHash.',
+    '',
+    '`pass` is true ONLY if build succeeded AND all of A-E are true in the result file you printed. Never infer a pass you did not observe in that file.',
+  ].join('\n')
+}
+
+function judgePrompt(s, lens) {
+  const rubric = {
+    'spec-fidelity':
+      'Does it satisfy the spec beyond passing the harness? Check claims c1-c8: real interception generalization, server-computed verdicts from stored constraints (not caller-supplied or hardcoded), dual-backend routing through the storage switch, fail-open, lesson retrieval at the operation boundary, traces linked to constraints.',
+    'design-quality':
+      'Is the constraint/lesson model and its retrieval/ranking well-factored and consistent with SPEC-ENVIRONMENTAL-LEARNING-GATES (reversibility selects the rung; validators over gates; information-destroying caution)? Is enforcement cleanly placed?',
+    'simplicity-and-safety':
+      'Is it the simplest thing that works? Minimal new surface, no speculative machinery, no dead code, no broken existing tests/hooks, no regressions to the shipped {blocked,...} consumers, no new dependencies.',
+  }
+  return [
+    'Judge ONE candidate on ONE lens. Be skeptical; default low and make the candidate earn the score.',
+    'Lens: ' + lens + ' — ' + rubric[lens],
+    '',
+    'Read ' + SPEC + ', then the candidate diff: `git diff ' + BASE + '...' + s.sha + '`. It passed the objective acceptance gate, so do not re-grade correctness-by-test; grade the quality dimension above and watch specifically for a thin implementation that satisfied the harness without honoring the spec intent.',
+    'Return score 0-10, a terse rationale citing file:line from the diff, ideas worth grafting into the winner, and risks.',
+  ].join('\n')
+}
+
+function synthPrompt(ranked, spread) {
+  const table = ranked
+    .map((r, n) => `${n + 1}. candidate ${r.i} (branch ${r.branch}, sha ${r.sha.slice(0, 8)}) score ${r.score.toFixed(2)}${r.dupes ? ` [+${r.dupes} near-identical]` : ''}`)
+    .join('\n')
+  return [
+    'Write a concise ranked comparison report (markdown) for a senior engineer choosing which candidate to merge.',
+    `Mean judge score spread across survivors: ${spread.toFixed(2)} (if small, the field converged and the top pick is near-noise — say so).`,
+    'Ranked gate-survivors:',
+    table,
+    '',
+    'For the top 3: the distinguishing design choice, the strongest reason it ranked where it did, and specific ideas worth grafting from runners-up into the winner. End with a one-line recommendation: which branch to check out, and what to graft before merge.',
+  ].join('\n')
+}
+
+async function runCandidate(i) {
+  const branch = `tournament/candidate-${i}`
+  const build = await agent(buildPrompt(i, branch), {
+    label: `build:${i}`, phase: 'Generate', isolation: 'worktree', schema: BUILD_SCHEMA,
+  })
+  if (!build || !build.committed || !build.sha) {
+    log(`candidate ${i}: no committed SHA, dropped`)
+    return null
+  }
+  const gate = await agent(gatePrompt(i, build.sha), {
+    label: `gate:${i}`, phase: 'Gate', isolation: 'worktree', schema: GATE_SCHEMA,
+  })
+  return { i, branch, sha: build.sha, approach: build.approach, gate }
+}
+
+async function judgeOne(s) {
+  const votes = await parallel(
+    LENSES.map((lens) => () => agent(judgePrompt(s, lens), { label: `judge:${s.i}:${lens}`, phase: 'Judge', schema: JUDGE_SCHEMA })),
+  )
+  const v = votes.filter(Boolean)
+  const score = v.length ? v.reduce((a, x) => a + x.score, 0) / v.length : 0
+  return { ...s, score, votes: v }
+}
+
+// --- run -----------------------------------------------------------------------
+phase('Generate')
+const ids = Array.from({ length: N }, (_, k) => k + 1)
+const candidates = []
+for (const wave of chunk(ids, WAVE)) {
+  const batch = await parallel(wave.map((i) => () => runCandidate(i)))
+  candidates.push(...batch.filter(Boolean))
+  log(`wave done — ${candidates.length}/${N} candidates processed`)
+}
+
+phase('Judge')
+const survivors = candidates.filter((c) => c.gate && c.gate.pass)
+log(`${survivors.length}/${candidates.length} candidates passed the acceptance gate`)
+if (survivors.length === 0) {
+  return { winner: null, reason: 'no candidate passed the acceptance gate', candidates }
+}
+
+// Dedup near-identical candidates (same model + same pinned contract converge) before spending judges.
+const byHash = new Map()
+const unique = []
+for (const s of survivors) {
+  const h = s.gate.diffHash
+  if (h && byHash.has(h)) { byHash.get(h).dupes += 1; continue }
+  const rec = { ...s, dupes: 0 }
+  if (h) byHash.set(h, rec)
+  unique.push(rec)
+}
+log(`${unique.length} unique candidates after dedup (${survivors.length - unique.length} near-identical folded)`)
+
+const judged = []
+for (const wave of chunk(unique, JWAVE)) {
+  const batch = await parallel(wave.map((s) => () => judgeOne(s)))
+  judged.push(...batch.filter(Boolean))
+}
+const ranked = judged.sort((a, b) => b.score - a.score)
+const spread = ranked.length ? ranked[0].score - ranked[ranked.length - 1].score : 0
+
+phase('Rank')
+const report = await agent(synthPrompt(ranked, spread), { label: 'synthesize', phase: 'Rank' })
+return {
+  winner: ranked[0] ? { candidate: ranked[0].i, branch: ranked[0].branch, sha: ranked[0].sha, score: ranked[0].score } : null,
+  ranked: ranked.map((r) => ({ candidate: r.i, branch: r.branch, score: Number(r.score.toFixed(2)), nearIdentical: r.dupes })),
+  scoreSpread: Number(spread.toFixed(2)),
+  gateSurvivors: survivors.length,
+  uniqueSurvivors: unique.length,
+  totalCandidates: candidates.length,
+  report,
+}

--- a/.claude/workflows/tv-remote/RUNBOOK.md
+++ b/.claude/workflows/tv-remote/RUNBOOK.md
@@ -1,0 +1,57 @@
+# TV Remote Tournament — Codespaces Runbook
+
+What runs where, and the three host constraints that will bite if ignored. Sourced from the Codespaces capability research (2026-06-06).
+
+## The 16-core box: what it gives and what it costs
+
+- **16 cores / 64 GB RAM / 128 GB disk.** Disk is a hard cap — not expandable. $1.44/hr compute.
+- The free quota (~120 core-hours personal) = **only ~7.5 hours of 16-core**. The Anthropic API spend for ~30 candidate builds dwarfs the compute bill — budget that separately.
+
+## Three constraints that break the run if ignored
+
+1. **Disk (128 GB hard cap).** 30 worktrees × `node_modules` would exhaust it. Mitigated by the **shared pnpm store** set in `.devcontainer/devcontainer.json` (`pnpm config set store-dir /workspaces/.pnpm-store`). pnpm hardlinks, so 30 worktrees cost ~one `node_modules` of disk. Do not remove that line.
+2. **Idle suspend.** Default 30 min, **max 240 min**, and **terminal *output* resets it — CPU load alone does not.** Create the codespace with `--idle-timeout 240m` and keep output flowing (the heartbeat below, or the interactive `/workflows` view).
+3. **RAM/OOM.** 14 parallel `tsc` blows 64 GB. The workflow caps build+gate to **waves of 6** (`waveSize`), below the runtime's 14-agent ceiling. Don't raise `waveSize` past ~8 on this box.
+
+## Setup (once)
+
+1. **Secret:** add a Codespaces secret `ANTHROPIC_API_KEY` (Settings → Codespaces → secrets), scoped to this repo. It is injected as an env var at runtime (not build time).
+2. **Create the codespace on the 16-core machine with a long idle timeout:**
+   ```bash
+   gh codespace create -R <owner>/thoughtbox -b feat/tv-remote-tournament \
+     -m largePremiumLinux --idle-timeout 240m
+   ```
+   (`largePremiumLinux` = the 16-core tier; confirm the exact machine name with `gh api /user/codespaces/<name>/machines` — org policy can restrict tiers.)
+3. The devcontainer provisions Node 22 + pnpm + the `claude` CLI and runs `pnpm install && pnpm build`. Optionally enable a **prebuild** (repo Settings → Codespaces) to make cold-start fast — it caches the baseline clone+install+build, not the 30-way fan-out.
+
+## Run it
+
+**Recommended: interactive + tmux** (most reliable for a multi-hour run — the `/workflows` view streams output, which keeps the box awake):
+```bash
+tmux new -s tournament
+claude          # then type:  /tv-remote-tournament
+#   watch progress in another pane:  (inside claude)  /workflows
+```
+Detach with `Ctrl-b d`; the run continues. Reattach with `tmux attach -t tournament`.
+
+**Headless** (`scripts/run-codespace.sh`) — see the OPEN QUESTION below before relying on it:
+```bash
+./.claude/workflows/tv-remote/run-codespace.sh
+```
+
+## OPEN QUESTION — verify before trusting the headless path
+
+Dynamic workflows run in the **background** relative to the session. It is **not yet verified** that `claude -p "/tv-remote-tournament"` blocks until the background workflow *completes* rather than returning when the launching turn ends (which would orphan the run). **De-risk cheaply first:** run a trivial throwaway workflow via `claude -p` and confirm the process stays alive until it finishes. Until confirmed, prefer the interactive+tmux path. This is the single biggest operational unknown in the plan.
+
+## After the run
+
+The workflow returns `{ winner: { branch }, ranked[], report }`. Inspect the winner:
+```bash
+git checkout tournament/candidate-<n>
+git diff main...HEAD
+```
+Branches `tournament/candidate-*` are local to the codespace. Push only the winner (after review), delete the rest.
+
+## Host alternative (if this becomes recurring)
+
+Codespaces is workable for a one-off with the mitigations above, but it's an interactive-dev product fighting a long headless batch job. For repeat runs or >128 GB disk / >64 GB RAM, a **GitHub Actions 16-core larger runner** (no idle model; runs to completion; ~$2.52/hr) or a **self-hosted runner** on a box you size is a better fit.

--- a/.claude/workflows/tv-remote/RUNBOOK.md
+++ b/.claude/workflows/tv-remote/RUNBOOK.md
@@ -2,6 +2,10 @@
 
 What runs where, and the three host constraints that will bite if ignored. Sourced from the Codespaces capability research (2026-06-06).
 
+## ⚠️ Run from a throwaway clone, not your working repo (observed hazard)
+
+In practice, the build/gate agents' git operations **move the primary checkout's HEAD** (every local run so far yanked the working tree to `main`, off the launch branch). It's harmless on an ephemeral Codespace, but on a local machine it repeatedly corrupts your working tree. **Mitigation:** run the tournament from a dedicated clone or worktree of the repo, never your active checkout. After any run, verify `git branch --show-current` and `git checkout <your-branch>` if it moved. Also: the `args` channel to the workflow proved unreliable — set `N`/`BASE`/`waveSize` by editing the workflow file, not via args.
+
 ## The 16-core box: what it gives and what it costs
 
 - **16 cores / 64 GB RAM / 128 GB disk.** Disk is a hard cap — not expandable. $1.44/hr compute.

--- a/.claude/workflows/tv-remote/acceptance.mjs
+++ b/.claude/workflows/tv-remote/acceptance.mjs
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+// Canonical acceptance harness for SPEC-TV-REMOTE-WEDGE. The tournament gate
+// re-overlays this file from main before running it, so a candidate cannot
+// weaken its own ruler. Pure Node 22 (global fetch), no dependencies.
+//
+// Design against gaming: every phase keys off a per-run NONCE, so a candidate
+// cannot hardcode the command/constraint. Phase A is a negative control (the
+// action is allowed BEFORE seeding, blocked AFTER) which forces the verdict to
+// depend on stored state — not a string match. Run from the repo root AFTER
+// `pnpm build`. Writes the verdict to $TB_RESULT_PATH (default
+// .tournament-result.json) and exits non-zero on any failure.
+
+import { spawn, spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomBytes } from "node:crypto";
+import { createServer } from "node:net";
+
+const N = randomBytes(5).toString("hex");
+const HOOK = "plugins/thoughtbox-claude-code/scripts/protocol_gate.sh";
+const RESULT = process.env.TB_RESULT_PATH || ".tournament-result.json";
+let BASE = "";
+const ctx = {};
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const log = (...a) => console.log("[harness]", ...a);
+const assert = (cond, msg) => { if (!cond) throw new Error(msg); };
+
+function freePort() {
+  return new Promise((res, rej) => {
+    const s = createServer();
+    s.on("error", rej);
+    s.listen(0, () => { const p = s.address().port; s.close(() => res(p)); });
+  });
+}
+
+async function post(path, body) {
+  const res = await fetch(BASE + path, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return res.json().catch(() => ({}));
+}
+
+async function get(path) {
+  const res = await fetch(BASE + path);
+  return res.json().catch(() => ({}));
+}
+
+const enforceCmd = (command, extra = {}) =>
+  post("/protocol/enforcement", {
+    action: { tool: "Bash", command, args: { command, ...extra } },
+    workspaceId: null,
+    sessionId: "harness",
+  });
+
+const seed = (match, lesson) =>
+  post("/protocol/constraints", { operation: "Bash", match, rung: "gate", irreversible: true, lesson });
+
+function runHook(command, thoughtboxUrl) {
+  const input = JSON.stringify({ tool_name: "Bash", tool_input: { command } });
+  return spawnSync("bash", [HOOK], {
+    input, encoding: "utf8", env: { ...process.env, THOUGHTBOX_URL: thoughtboxUrl },
+  }).status;
+}
+
+async function tracesFor(token) {
+  const r = await get("/protocol/traces?limit=100");
+  return (r.traces || []).filter((t) => ((t.action && t.action.command) || "").includes(token));
+}
+
+async function waitForServer(timeoutMs = 60000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const r = await enforceCmd(`probe-${N}`);
+      if (r && (r.decision === "allow" || r.decision === "block")) return true;
+    } catch { /* not up yet */ }
+    await sleep(500);
+  }
+  return false;
+}
+
+// --- phases (each keyed off the per-run nonce N) -----------------------------
+
+async function phaseA() {
+  const cmd = `danger-${N} --execute`;
+  const pre = await enforceCmd(cmd);
+  assert(pre.decision === "allow", `negative control failed: blocked before any constraint was seeded (got ${pre.decision})`);
+  const lesson = `irreversible: do not run danger-${N}`;
+  const s = await seed(`danger-${N}`, lesson);
+  assert(s.constraintId, "seed returned no constraintId");
+  const blk = await enforceCmd(cmd);
+  assert(blk.decision === "block", `expected block after seed, got ${blk.decision}`);
+  assert(blk.rung === "gate", `expected rung gate, got ${blk.rung}`);
+  assert(blk.lesson && blk.lesson.includes(N), "block carried no nonce-bearing lesson (verdict not from stored state)");
+  assert(blk.traceId, "block carried no traceId");
+  const blocked = (await tracesFor(N)).filter((t) => t.decision === "block");
+  assert(blocked.length > 0, "no blocked action-trace persisted for our command");
+  assert(blocked.some((t) => t.constraintId === s.constraintId), "blocked trace not linked to the seeded constraintId");
+  Object.assign(ctx, { cmd, lesson, constraintId: s.constraintId });
+}
+
+async function phaseB() {
+  await seed(`unrelated-${N}`, `avoid unrelated-${N}`); // a second constraint must not bleed
+  const benign = `echo benign-${N}`;
+  const r = await enforceCmd(benign);
+  assert(r.decision === "allow", `benign action blocked (cross-talk): ${r.decision}`);
+  const allowed = (await tracesFor(`benign-${N}`)).filter((t) => t.decision === "allow");
+  assert(allowed.length > 0, "no allowed action-trace persisted for the benign command");
+  const d = await enforceCmd(ctx.cmd);
+  assert(d.decision === "block" && d.lesson === ctx.lesson, "cross-talk: wrong constraint/lesson fired for the gated command");
+}
+
+async function phaseC() {
+  const d = await enforceCmd(ctx.cmd);
+  assert(d.decision === "block", "retrieval: second attempt not blocked");
+  assert(d.lesson === ctx.lesson, "retrieval: lesson not stable across attempts");
+}
+
+function phaseD() {
+  assert(runHook(ctx.cmd, BASE) === 2, "hook did not relay the server BLOCK for the novel seeded command");
+  assert(runHook(`echo ok-${N}`, BASE) === 0, "hook blocked a benign command while the server was reachable");
+  assert(runHook(ctx.cmd, "http://127.0.0.1:9") === 0, "hook did not fail open when the endpoint was unreachable");
+}
+
+async function phaseE() {
+  const cmd = `priv-${N} --go`;
+  await seed(`priv-${N}`, `priv-${N} needs review`);
+  const r = await enforceCmd(cmd, { decision: "allow", success: true, allow: true });
+  assert(r.decision === "block", "self-report bypass: caller-supplied fields overrode the server verdict");
+}
+
+// --- run ---------------------------------------------------------------------
+
+async function main() {
+  const home = mkdtempSync(join(tmpdir(), "tb-harness-"));
+  const port = await freePort();
+  BASE = `http://127.0.0.1:${port}`;
+  const server = spawn("node", ["dist/index.js"], {
+    stdio: ["ignore", "inherit", "inherit"],
+    env: {
+      ...process.env,
+      THOUGHTBOX_STORAGE: "fs",
+      THOUGHTBOX_DATA_DIR: join(home, ".thoughtbox"),
+      HOME: home,
+      PORT: String(port),
+    },
+  });
+  const phases = { A: false, B: false, C: false, D: false, E: false };
+  try {
+    if (!(await waitForServer())) throw new Error("server did not become ready");
+    for (const [k, fn] of [["A", phaseA], ["B", phaseB], ["C", phaseC], ["D", phaseD], ["E", phaseE]]) {
+      try { await fn(); phases[k] = true; } catch (e) { log(`${k} failed:`, e.message); }
+    }
+  } finally {
+    server.kill("SIGTERM");
+  }
+  const pass = Object.values(phases).every(Boolean);
+  writeFileSync(RESULT, JSON.stringify({ pass, phases }, null, 2));
+  log("result", JSON.stringify({ pass, phases }));
+  process.exit(pass ? 0 : 1);
+}
+
+main().catch((e) => {
+  writeFileSync(RESULT, JSON.stringify({ pass: false, phases: { A: false, B: false, C: false, D: false, E: false }, fatal: String(e) }, null, 2));
+  console.error("[harness] fatal", e);
+  process.exit(1);
+});

--- a/.claude/workflows/tv-remote/run-codespace.sh
+++ b/.claude/workflows/tv-remote/run-codespace.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Headless launcher for the TV Remote tournament on a Codespace.
+# NOTE: verify that `claude -p` blocks until the background workflow completes
+# before trusting this unattended (see RUNBOOK.md "OPEN QUESTION"). Until then
+# the interactive + tmux path in the runbook is the reliable option.
+
+: "${ANTHROPIC_API_KEY:?set ANTHROPIC_API_KEY (Codespaces secret) before running}"
+
+# Codespaces idle timeout resets on TERMINAL OUTPUT, not CPU. Emit a heartbeat
+# so a long compute phase does not suspend the machine mid-run.
+( while true; do printf 'heartbeat %s\n' "$(date -u +%H:%M:%SZ)"; sleep 60; done ) &
+heartbeat_pid=$!
+trap 'kill "${heartbeat_pid}" 2>/dev/null || true' EXIT
+
+stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+claude -p "/tv-remote-tournament" \
+  --permission-mode bypassPermissions \
+  --output-format json | tee "tournament-${stamp}.json"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+{
+  "name": "tv-remote-tournament-runner",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:1-22-bookworm",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": { "version": "22", "pnpmVersion": "latest" },
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "hostRequirements": { "cpus": 16, "memory": "64gb", "storage": "128gb" },
+
+  "// store-dir": "Single content-addressable pnpm store shared by every git worktree. With ~30 worktrees this is the difference between ~one node_modules of disk (hardlinks) and ~30x (disk exhaustion at the 128 GB cap).",
+  "// inotify": "30 parallel toolchains can exhaust the default file-watcher limit; raise it best-effort. Builds run one-shot (no --watch) so this is a safety net.",
+
+  "updateContentCommand": "corepack enable pnpm && pnpm config set store-dir /workspaces/.pnpm-store --global && pnpm install --frozen-lockfile && pnpm build",
+  "postCreateCommand": "npm install -g @anthropic-ai/claude-code && (sudo sysctl -w fs.inotify.max_user_watches=524288 fs.inotify.max_user_instances=1024 || true)",
+
+  "remoteEnv": {
+    "ANTHROPIC_API_KEY": "${localEnv:ANTHROPIC_API_KEY}",
+    "THOUGHTBOX_STORAGE": "fs"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,6 @@ thoughtbox-web-two/
 
 .specs/channel-daemon/chatgpt01.md
 rlm-code/
+
+# tournament gate verdict (never committed; ruler-gaming guard)
+.tournament-result.json

--- a/.specs/agent-governance-substrate/SPEC-TV-REMOTE-WEDGE.md
+++ b/.specs/agent-governance-substrate/SPEC-TV-REMOTE-WEDGE.md
@@ -1,0 +1,175 @@
+---
+spec_id: SPEC-TV-REMOTE-WEDGE
+title: TV Remote Wedge — Hook Interception + Gate/Lesson Enforcement Endpoint
+status: draft
+date: 2026-06-05
+branch: feat/tv-remote-tournament
+claims:
+  - id: c1
+    statement: A PreToolUse interception routes every agent action (Bash, Edit, Write, NotebookEdit, and MCP tool calls) through a single Thoughtbox enforcement endpoint that returns a gate verdict, generalizing the existing mutation-only protocol_gate.sh hook to the full action surface.
+    type: implementation
+    behavioral: false
+    required_evidence: A hook registered for the generalized matcher plus the enforcement endpoint handler; the acceptance harness POSTs each action shape and receives a verdict.
+  - id: c2
+    statement: A categorical or irreversible action (e.g. `git push --force`) for which a gate-eligible constraint is installed is blocked (hook exit 2), and the block carries a retrievable lesson attached to that operation boundary.
+    type: behavioral
+    behavioral: true
+    required_evidence: Acceptance harness Phase A — seed a gate at an operation, POST the matching action, assert decision=block, rung=gate, non-empty lesson.
+  - id: c3
+    statement: A permitted action is allowed (decision=allow, not blocked) and is recorded as a durable action-trace; the validator/advisory rung warns-but-allows per the keystone reversibility rule.
+    type: behavioral
+    behavioral: true
+    required_evidence: Acceptance harness Phase B — POST a benign action, assert decision=allow and that an action-trace row/file was persisted and is readable.
+  - id: c4
+    statement: Every intercepted action is persisted as a durable action-trace, and gate-lessons persist alongside, under BOTH storage backends, routed through the central THOUGHTBOX_STORAGE switch and workspace-scoped.
+    type: implementation
+    behavioral: false
+    required_evidence: Trace + lesson persistence verified by the acceptance harness against the fs backend; the supabase path present in code and schema (parity, not exercised in the gate).
+  - id: c5
+    statement: The gate verdict is computed by server-side validator logic over stored constraints, not by any field the caller supplies; an agent cannot self-report its way past a gate.
+    type: governance
+    behavioral: true
+    required_evidence: Acceptance harness Phase E — POST an action whose args assert success/permission; assert the verdict still blocks. Enforcement path reuses ValidatorService verdict semantics (src/notebook/validator.ts).
+  - id: c6
+    statement: At most three abstracted MCP action-button operations register through the existing OperationDefinition -> buildTbObject path, sufficient to seed a constraint+lesson and read back action-traces.
+    type: implementation
+    behavioral: false
+    required_evidence: New operations in src/<module>/operations.ts, Zod schema, sdk-types stub, search-index import, buildTbObject dispatch; the acceptance harness drives seed + read via the tb SDK.
+  - id: c7
+    statement: A lesson attached to a gate from a prior blocked attempt is surfaced again on a later attempt at the same operation, demonstrating the read side of the environmental-learning loop (retrieval at the operation boundary is stable).
+    type: behavioral
+    behavioral: true
+    required_evidence: Acceptance harness Phase C — repeat the Phase A action after the trace exists; assert the same lesson is returned.
+  - id: c8
+    statement: When the enforcement endpoint is unreachable, interception fails OPEN — the action is allowed (hook exit 0), never blocked on an infrastructure error — preserving the existing protocol_gate.sh fail-open contract.
+    type: behavioral
+    behavioral: true
+    required_evidence: Acceptance harness Phase D — point the client at a dead endpoint, assert allow/exit 0.
+links:
+  - .specs/agent-governance-substrate/SPEC-ENVIRONMENTAL-LEARNING-GATES.md
+  - .specs/thoughtbox-v1-finalstretch/SPEC-DRIFT-PREVENTION-HOOKS.md
+  - plugins/thoughtbox-claude-code/hooks/hooks.json
+  - src/notebook/validator.ts
+  - src/protocol/handler.ts
+---
+
+# SPEC: TV Remote Wedge — Hook Interception + Gate/Lesson Enforcement Endpoint
+
+**Status**: DRAFT — research artifact and tournament input. Not accepted.
+**Parent**: `SPEC-ENVIRONMENTAL-LEARNING-GATES.md` — this is the "concrete near-term wedge" that spec names (its §"Concrete near-term wedge", line 143): a hook-based interception layer that routes actions through Thoughtbox for gating + durable action-memory, plus a few abstracted MCP action buttons, positioning Thoughtbox as the **universal remote's firmware** rather than a replacement set of buttons.
+
+## Why this spec exists
+
+This is the fixed input for a best-of-N tournament: ~30 independent implementations of the wedge are generated in parallel, gated against the acceptance harness below, and ranked by a judge panel. The spec therefore does two jobs and must do them in opposite directions:
+
+- It **pins the contract** (the enforcement request/response shape and the acceptance scenario) so that every candidate is solving the same problem and the gate is the same ruler for all of them.
+- It **leaves the architecture open** (how gates and lessons are represented, stored, retrieved, and ranked; how the rung is selected; where the enforcement logic is factored) so the tournament has something worth selecting over.
+
+Fix the interface; vary the implementation.
+
+## What already exists (do not rebuild)
+
+A candidate that rebuilds these from scratch is wrong. The wedge is a generalization of a working skeleton, mapped here so candidates extend rather than reinvent:
+
+- **`plugins/thoughtbox-claude-code/hooks/hooks.json` + `scripts/protocol_gate.sh`** — a `PreToolUse` hook on `Edit|Write|NotebookEdit` that `POST`s to `${THOUGHTBOX_URL}/protocol/enforcement` and **blocks via exit code 2** on a `{blocked, reason, protocol, required_action}` response. Network failure **fails open** (exit 0). This is the interception skeleton to generalize.
+- **`scripts/otlp_tool_capture.sh`** — a `PostToolUse` hook on all tools emitting every action as an OTLP trace. The trace pipe already exists; action-traces are the durable, queryable counterpart.
+- **`src/notebook/validator.ts` (`ValidatorService`)** — `bind()` freezes a cell + deps to a `snapshotHash`; `run()` spawns a subprocess that writes a verdict to `TB_VERDICT_PATH`; the **verdict, not the agent's claim, drives the transition**. This is the enforcement primitive the gate reuses (keystone §Forms: the validator contract `{pass, reason, evidence}` is "identical to the Ulysses validator-cell contract already shipped").
+- **`src/code-mode/execute-tool.ts` `buildTbObject()` + `src/<module>/operations.ts`** — the registration path for a new `tb` action-button operation (define `OperationDefinition`, add `Tool.handle`, Zod schema, `sdk-types.ts` stub, `search-index.ts` import, `buildTbObject` dispatch).
+- **`src/index.ts` `THOUGHTBOX_STORAGE` switch + FileSystemStorage/SupabaseStorage** — the dual backend. Action-traces and gate-lessons persist under both, workspace-scoped, routed through this switch (NOT by sniffing `process.env.SUPABASE_URL` directly — that is the split-brain bug pattern this repo is actively removing).
+
+## The fixed problem (every candidate delivers this)
+
+1. **Generalize interception.** A `PreToolUse` hook intercepts the full action surface (`Bash`, `Edit`, `Write`, `NotebookEdit`, and `mcp__*` tool calls), not just mutations, and routes each through the enforcement endpoint.
+2. **Enforce at one endpoint.** Extend `POST /protocol/enforcement` to evaluate the action against stored constraints, retrieve any lesson attached at that operation boundary, persist an action-trace, and return the verdict contract below.
+3. **Persist durably.** Action-traces and gate-lessons are written through the central storage switch under both backends, workspace-scoped.
+4. **Expose ≤3 action buttons.** Enough `tb` operations to seed a constraint + lesson and read back traces, so the loop is drivable through the SDK.
+
+### The enforcement contract (PINNED — do not vary)
+
+Request (hook → server), generalized from the shipped mutation-only payload:
+
+```json
+POST {THOUGHTBOX_URL}/protocol/enforcement
+{
+  "action": {
+    "tool": "Bash|Edit|Write|NotebookEdit|mcp__<server>__<tool>",
+    "args": { "...": "verbatim tool input" },
+    "targetPath": "/abs/path or null",
+    "command": "the bash command string or null"
+  },
+  "workspaceId": "string or null",
+  "sessionId": "string or null"
+}
+```
+
+Response (server → hook):
+
+```json
+{
+  "decision": "allow | block",
+  "reason": "human-readable string",
+  "lesson": "string or null (retrieved lesson attached to this operation/gate)",
+  "rung": "advisory | validator | shadow | gate",
+  "traceId": "id of the persisted action-trace",
+  "requiredAction": "reflect | visa | null"
+}
+```
+
+Hook behavior: `decision === "block"` → exit 2, stderr carries `reason` + `lesson`. Otherwise exit 0; on `validator`/`shadow` rungs a non-empty `lesson` may be surfaced to stderr without blocking. Unreachable endpoint → exit 0 (fail open). The legacy `blocked: boolean` field MAY be emitted as an alias for backward compatibility but `decision` is authoritative.
+
+The **rung** values are the keystone's vocabulary (`SPEC-ENVIRONMENTAL-LEARNING-GATES.md` §Structural unification). The wedge must *honor* the reversibility rule — only irreversible/categorical/boundary constraints are gate-eligible; reversible harms cap at `validator` — but it does not need to implement the full promotion/demotion controller (see Out of scope).
+
+### Pinned support routes (the acceptance-harness seam — do not vary)
+
+So the ruler can seed and inspect without coupling to internal design, candidates expose two more routes backed by the same service the action buttons use:
+
+```
+POST {THOUGHTBOX_URL}/protocol/constraints
+  body: { "operation": "Bash", "match": "git push --force", "rung": "gate",
+          "irreversible": true, "lesson": "force-push to a shared branch is unrecoverable; use --force-with-lease on your own branch" }
+  -> { "constraintId": "string" }
+
+GET  {THOUGHTBOX_URL}/protocol/traces?limit=50
+  -> { "traces": [ { "traceId", "action": {...}, "decision", "rung", "constraintId"|null, "at" } ] }
+```
+
+These exist for testability and may be thin wrappers over the same logic the ≤3 action buttons call; their internal implementation is open. The action-button *names* remain the candidate's choice.
+
+### Pinned interception path (so exit-code semantics are testable)
+
+The generalized hook is **extended in place** at `plugins/thoughtbox-claude-code/scripts/protocol_gate.sh`, preserving its existing contract: it reads the PreToolUse JSON on stdin, calls the enforcement endpoint via `${THOUGHTBOX_URL}`, **exits 2 to block** (stderr carries reason + lesson) and **exits 0 to allow**, and **fails open (exit 0) when the endpoint is unreachable**. The harness invokes this script directly to verify the exit-code semantics (block and fail-open). How it generalizes the matcher beyond `Edit|Write|NotebookEdit` is the candidate's choice, but this path and contract are fixed.
+
+## Acceptance contract (the ruler — identical for all candidates)
+
+The tournament injects a fixed acceptance harness (`.claude/workflows/tv-remote/acceptance.mjs`) into each candidate worktree (re-overlaid from main; candidates cannot edit it) and runs it headlessly against a locally started server on the `fs` backend in an isolated data dir. A candidate **passes the gate** iff every phase passes and `pnpm build` succeeds.
+
+**Anti-gaming invariant.** Every phase keys off a per-run **nonce** — the command string and the constraint `match` contain it, so a candidate cannot hardcode them. The verdict must derive from the seeded, stored constraint: a string-match stub fails by construction.
+
+- **Phase A — negative control + block + linked trace.** POST a nonce-bearing action *before* seeding; assert `decision="allow"` (no constraint installed ⇒ must not block). Then seed a gate-eligible constraint (`irreversible:true`, `match` = the nonce token) with a nonce-bearing lesson. POST the action again; assert `decision="block"`, `rung="gate"`, a lesson that contains the nonce, a `traceId`, and a persisted action-trace whose `constraintId` equals the seeded id.
+- **Phase B — allow + no cross-talk.** Seed a *second*, unrelated constraint. Assert a benign nonce-bearing action is allowed and trace-persisted, and that the Phase-A action still blocks with the *Phase-A* lesson (constraints do not bleed).
+- **Phase C — retrieval (env-learning read side).** Repeat the Phase-A action; assert the same lesson is surfaced again (stable retrieval at the operation boundary).
+- **Phase D — hook semantics.** Via the pinned hook: it blocks (exit 2) the *novel seeded* command (proving it relays the server verdict, not a baked-in string), allows (exit 0) a benign command while the server is reachable, and fails open (exit 0) when the endpoint is unreachable.
+- **Phase E — no self-report bypass.** Seed a constraint on a *novel, otherwise-allowed* command; POST it with `args` asserting `decision:"allow"`/success. Assert it still blocks (the server verdict ignores caller-supplied fields).
+
+## What is deliberately open (where the 30 vary)
+
+- Constraint representation and the addressing scheme (per-operation, per-argument-pattern grain — keystone §The grain problem).
+- Storage shape of action-traces and gate-lessons under each backend, and the retrieval/ranking that surfaces the right lesson at an operation (keystone open question §Where constraints live).
+- How the rung is selected and where enforcement logic is factored (in the endpoint, a service, the ValidatorService, or split).
+- Whether the generalized hook replaces or sits beside `protocol_gate.sh`; the matcher strategy.
+- The shape and naming of the ≤3 action-button operations.
+
+## Out of scope (do not implement; future work)
+
+- The **generation step** — auto-authoring a constraint predicate from a session-end surprise (keystone open question; the credit-assignment problem). In the wedge, constraints + lessons are **seeded explicitly** through an action button, not generated. Demonstrate the storage + retrieval + enforcement loop, not the authoring of it.
+- The full promotion/demotion controller, shadow-gate windows, friction-budget accounting (keystone §§Shadow gates, friction budget). The wedge must not contradict them, but implements only static rung honoring.
+- Weight-learning / RL dataset export.
+- Multi-tenant auth hardening on the enforcement endpoint beyond existing workspace scoping.
+
+## Non-negotiable constraints
+
+- Dual-backend parity preserved; route through the central `THOUGHTBOX_STORAGE` switch, never a direct `process.env.SUPABASE_URL` sniff.
+- Fail-open on enforcement network/infra error is mandatory (c8). A wedge that can hard-block an agent because the server is down is a regression.
+- Do not break existing hooks, tests, or the shipped `{blocked,...}` consumers.
+- No new dependencies: `package.json`, the lockfile, and root `scripts/` are restored from main at gate time, so an added dependency breaks the gate build by construction.
+- Conventional Commits; code+spec in the same change; respect repo hard limits (≤100 lines/function, absolute imports).


### PR DESCRIPTION
Adds the spec and dynamic-workflow tooling for generating implementations of the "TV Remote" wedge (hook interception + gate/lesson enforcement) via a best-of-N tournament. This PR is tooling + a draft spec; it does **not** include a wedge implementation.

## What's in the diff

- `.specs/agent-governance-substrate/SPEC-TV-REMOTE-WEDGE.md` — draft spec. Pins the enforcement request/response contract, two support routes (`/protocol/constraints`, `/protocol/traces`), the hook path, and a nonce-keyed acceptance scenario (A–E) with a negative control so the gate cannot be passed by a string-match stub. 8 frontmatter claims. Sibling to `SPEC-ENVIRONMENTAL-LEARNING-GATES.md`.
- `.claude/workflows/tv-remote-tournament.js` — generates N implementations in worktree branches, gates each via a hermetic runner (detached-SHA checkout, restores the ruler from the base branch, fail-loud if absent), judges gate-survivors on a rubric, ranks them.
- `.claude/workflows/tv-remote-salvage.js` — re-gates + judges existing candidate branches without regenerating.
- `.claude/workflows/tv-remote/acceptance.mjs` — canonical acceptance harness (pure Node, boots a candidate server on the fs backend, drives phases A–E, writes a machine verdict).
- `.claude/workflows/tv-remote/RUNBOOK.md`, `run-codespace.sh` — Codespaces host notes (shared pnpm store, idle-timeout, the HEAD-move hazard) and a headless launcher.
- `.devcontainer/devcontainer.json` — 16-core host with a shared pnpm store.
- `.gitignore` — ignores the gate verdict file.

## Known limitations (documented in-file)

- The workflow `args` channel did not reliably reach the script; set `N`/`BASE`/`waveSize` by editing the workflow file.
- Build/gate agents move the primary checkout's HEAD; run from a throwaway clone, not your working repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)