### PR TITLE
fix(db): create pg_net in extensions schema for clean replay

### DIFF
--- a/supabase/migrations/20260408033928_add_hub_tables_vectors_pgmq_realtime.sql
+++ b/supabase/migrations/20260408033928_add_hub_tables_vectors_pgmq_realtime.sql
@@ -4,7 +4,7 @@
 -- 1. Enable extensions required for queue processing and scheduled worker invocation.
 CREATE EXTENSION IF NOT EXISTS pgmq;
 CREATE EXTENSION IF NOT EXISTS pg_cron;
-CREATE EXTENSION IF NOT EXISTS pg_net;
+CREATE EXTENSION IF NOT EXISTS pg_net WITH SCHEMA extensions;
 
 -- 2. pgmq queues for intelligence pipeline.
 SELECT FROM pgmq.create('thought_processing');


### PR DESCRIPTION
## Problem

Migration `20260408033928_add_hub_tables_vectors_pgmq_realtime.sql` created `pg_net` with no target schema:

```sql
CREATE EXTENSION IF NOT EXISTS pg_net;
```

On a fresh database — the CI `supabase start` replay — `pgmq` and `pg_cron` are pre-provisioned by Supabase's local stack, but `pg_net` is not. So `pg_net` takes the real `CREATE EXTENSION` path and fails:

```
ERROR: no schema has been selected to create in (SQLSTATE 3F000)
At statement: CREATE EXTENSION IF NOT EXISTS pg_net
```

This breaks **Schema Drift Check** and **Test Suite** on every migration PR.

## Fix

Pin `pg_net` to the `extensions` schema, matching the convention already used later in `20260409232440_remote_schema.sql` (`create extension if not exists "pg_net" with schema "extensions"`). The end-state schema is unchanged, so no drift is introduced.

Scoped to `pg_net` only — `pgmq` and `pg_cron` are left as-is because they install into their own expected schemas and do not hit the failing path.

## Verification
- oxlint: 0 warnings / 0 errors
- Editing an already-applied migration only affects fresh replays (CI / new environments); `db push` does not re-apply the existing version to staging/prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)