### PR TITLE
test(ci): EXPERIMENT — verify pg_net + service re-inclusion greens Test Suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,10 @@ jobs:
           version: 2.84.2
 
       - name: Start local Supabase
-        run: supabase start -x realtime,storage-api,imgproxy,mailpit,postgres-meta,studio,edge-runtime,logflare,vector,supavisor
+        # storage-api + edge-runtime are included (not in -x): the peer-notebook
+        # tests need Storage and the intelligence-pipeline/branch-workers tests
+        # invoke edge functions.
+        run: supabase start -x realtime,imgproxy,mailpit,postgres-meta,studio,logflare,vector,supavisor
 
       - name: Run test suite
         run: pnpm test

--- a/supabase/migrations/20260408033928_add_hub_tables_vectors_pgmq_realtime.sql
+++ b/supabase/migrations/20260408033928_add_hub_tables_vectors_pgmq_realtime.sql
@@ -4,7 +4,7 @@
 -- 1. Enable extensions required for queue processing and scheduled worker invocation.
 CREATE EXTENSION IF NOT EXISTS pgmq;
 CREATE EXTENSION IF NOT EXISTS pg_cron;
-CREATE EXTENSION IF NOT EXISTS pg_net;
+CREATE EXTENSION IF NOT EXISTS pg_net WITH SCHEMA extensions;
 
 -- 2. pgmq queues for intelligence pipeline.
 SELECT FROM pgmq.create('thought_processing');


### PR DESCRIPTION
Throwaway experiment branch. Combines #357 (pg_net extensions schema) + #355's ci.yml change (re-include storage-api + edge-runtime). Goal: confirm Test Suite goes green. Do not merge — will be deleted once it proves the recipe.