### PR TITLE
fix(branch): sign worker tokens with dedicated TB_BRANCH_SIGNING_SECRET

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,16 @@ ANTHROPIC_API_KEY=your-api-key-here
 # THOUGHTBOX_OBSERVATORY_CORS=*
 
 # =============================================================================
+# Branch Workers (hosted mode)
+# =============================================================================
+# Dedicated HMAC secret shared between this server and the tb-branch Edge
+# Function. Required for tb.branch.* in hosted mode. Set the same value via:
+#   supabase secrets set TB_BRANCH_SIGNING_SECRET=<value>
+# For local edge-runtime tests, put it in supabase/functions/.env as
+# TB_BRANCH_SIGNING_SECRET=local-dev-branch-signing-secret
+# TB_BRANCH_SIGNING_SECRET=
+
+# =============================================================================
 # Development/Testing (Optional)
 # =============================================================================
 # Node environment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,12 @@ jobs:
         with:
           version: 2.84.2
 
+      - name: Seed edge function env
+        # tb-branch verifies worker tokens with TB_BRANCH_SIGNING_SECRET; the
+        # local edge runtime loads supabase/functions/.env. Must match
+        # TB_BRANCH_TEST_SIGNING_SECRET in src/__tests__/supabase-test-helpers.ts.
+        run: echo "TB_BRANCH_SIGNING_SECRET=local-dev-branch-signing-secret" > supabase/functions/.env
+
       - name: Start local Supabase
         # storage-api + edge-runtime are included (not in -x): the peer-notebook
         # tests need Storage and the intelligence-pipeline/branch-workers tests

--- a/.specs/SPEC-BRANCH-WORKERS.md
+++ b/.specs/SPEC-BRANCH-WORKERS.md
@@ -50,7 +50,7 @@ Thin MCP Lite server. ~100 lines. Deployed once, parameterized per invocation.
 - `branch_status` — read this branch's metadata (thought count, status)
 - `branch_read` — read this branch's thoughts
 
-**Auth:** HMAC-signed URL token. Main MCP signs `{ session_id, branch_id, workspace_id, branch_from_thought, expires_at }` using `SUPABASE_SERVICE_ROLE_KEY`. Edge function verifies signature, extracts context.
+**Auth:** HMAC-signed URL token. Main MCP signs `{ session_id, branch_id, workspace_id, branch_from_thought, expires_at }` using `TB_BRANCH_SIGNING_SECRET`, a dedicated secret set identically on the server (env) and the Edge Function (`supabase secrets set`). The Edge function verifies the signature and extracts context. The service role key cannot be the signing secret: the hosted Edge runtime injects its own `SUPABASE_SERVICE_ROLE_KEY` value, which does not match the dashboard key the server holds (verified 2026-06-10 — server-minted tokens were rejected with "Invalid token signature" on both prod and staging).
 
 **DB access:** `supabase-js` with `SUPABASE_SERVICE_ROLE_KEY` (auto-available in edge functions).
 

--- a/src/__tests__/branch-workers.test.ts
+++ b/src/__tests__/branch-workers.test.ts
@@ -8,6 +8,7 @@ import {
   isSupabaseAvailable,
   SUPABASE_TEST_SERVICE_ROLE_KEY,
   SUPABASE_TEST_URL,
+  TB_BRANCH_TEST_SIGNING_SECRET,
   TEST_WORKSPACE_ID,
 } from './supabase-test-helpers.js';
 
@@ -21,7 +22,7 @@ type BranchTokenPayload = {
 
 function signBranchToken(payload: BranchTokenPayload): string {
   const encodedPayload = Buffer.from(JSON.stringify(payload)).toString('base64url');
-  const signature = createHmac('sha256', SUPABASE_TEST_SERVICE_ROLE_KEY)
+  const signature = createHmac('sha256', TB_BRANCH_TEST_SIGNING_SECRET)
     .update(encodedPayload)
     .digest('base64url');
   return `${encodedPayload}.${signature}`;
@@ -100,6 +101,7 @@ describe('Branch workers', () => {
     const handlers = new BranchHandlers({
       supabaseUrl: SUPABASE_TEST_URL,
       serviceRoleKey: SUPABASE_TEST_SERVICE_ROLE_KEY,
+      signingSecret: TB_BRANCH_TEST_SIGNING_SECRET,
       workspaceId: TEST_WORKSPACE_ID,
     });
 
@@ -199,6 +201,7 @@ describe('Branch workers', () => {
     const handlers = new BranchHandlers({
       supabaseUrl: SUPABASE_TEST_URL,
       serviceRoleKey: SUPABASE_TEST_SERVICE_ROLE_KEY,
+      signingSecret: TB_BRANCH_TEST_SIGNING_SECRET,
       workspaceId: TEST_WORKSPACE_ID,
     });
 

--- a/src/__tests__/supabase-test-helpers.ts
+++ b/src/__tests__/supabase-test-helpers.ts
@@ -29,6 +29,14 @@ export const SUPABASE_TEST_DB_URL =
   'postgresql://postgres:postgres@127.0.0.1:54322/postgres';
 
 /**
+ * Shared HMAC secret for tb-branch worker tokens. The local edge runtime must
+ * receive the same value via supabase/functions/.env (TB_BRANCH_SIGNING_SECRET);
+ * CI writes that file before `supabase start`.
+ */
+export const TB_BRANCH_TEST_SIGNING_SECRET =
+  process.env.TB_BRANCH_SIGNING_SECRET || 'local-dev-branch-signing-secret';
+
+/**
  * Create a service_role client for setup/teardown operations.
  * Bypasses RLS policies.
  */

--- a/src/branch/handlers.ts
+++ b/src/branch/handlers.ts
@@ -33,6 +33,13 @@ function encodeBranchWorkerToken(
 export interface BranchHandlerDeps {
   supabaseUrl: string;
   serviceRoleKey: string;
+  /**
+   * Dedicated HMAC secret shared with the tb-branch Edge Function
+   * (TB_BRANCH_SIGNING_SECRET). The service role key cannot be used for
+   * signing: the hosted Edge runtime injects its own SUPABASE_SERVICE_ROLE_KEY
+   * value, which does not match the key this server holds.
+   */
+  signingSecret: string;
   workspaceId: string;
 }
 
@@ -40,12 +47,12 @@ export class BranchHandlers {
   private client: SupabaseClient;
   private supabaseUrl: string;
   private workspaceId: string;
-  private serviceRoleKey: string;
+  private signingSecret: string;
 
   constructor(deps: BranchHandlerDeps) {
     this.supabaseUrl = deps.supabaseUrl;
     this.workspaceId = deps.workspaceId;
-    this.serviceRoleKey = deps.serviceRoleKey;
+    this.signingSecret = deps.signingSecret;
     this.client = createClient(deps.supabaseUrl, deps.serviceRoleKey, {
       auth: { persistSession: false, autoRefreshToken: false },
     });
@@ -112,7 +119,7 @@ export class BranchHandlers {
         branch_from_thought: branchFromThought,
         expires_at: new Date(Date.now() + BRANCH_WORKER_TOKEN_TTL_MS).toISOString(),
       },
-      this.serviceRoleKey
+      this.signingSecret
     );
     const workerUrl =
       `${supabaseUrl}/functions/v1/tb-branch/mcp` +

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -557,13 +557,27 @@ Use \`console.log()\` for debugging — output captured in response logs.`;
   // only wired when Supabase credentials are present. In local/self-hosted
   // mode it is left undefined; `tb.branch.*` then returns a clear "hosted
   // mode" error instead of crashing session setup on a missing SUPABASE_URL.
+  //
+  // TB_BRANCH_SIGNING_SECRET is the dedicated HMAC secret shared with the
+  // tb-branch Edge Function. The service role key cannot serve as the signing
+  // secret: the hosted Edge runtime injects its own SUPABASE_SERVICE_ROLE_KEY
+  // value, which does not match the key this server holds.
   const branchSupabaseUrl = process.env.SUPABASE_URL;
   const branchServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  const branchSigningSecret = process.env.TB_BRANCH_SIGNING_SECRET;
+  if (branchSupabaseUrl && branchServiceKey && !branchSigningSecret) {
+    console.error(
+      "[branch] Supabase credentials present but TB_BRANCH_SIGNING_SECRET is not set; " +
+        "tb.branch.* is disabled. Set the same secret on this server and the " +
+        "tb-branch Edge Function (supabase secrets set TB_BRANCH_SIGNING_SECRET=...)."
+    );
+  }
   const branchHandler =
-    branchSupabaseUrl && branchServiceKey
+    branchSupabaseUrl && branchServiceKey && branchSigningSecret
       ? new BranchHandler({
           supabaseUrl: branchSupabaseUrl,
           serviceRoleKey: branchServiceKey,
+          signingSecret: branchSigningSecret,
           workspaceId: args.workspaceId ?? "default",
         })
       : undefined;

--- a/supabase/functions/tb-branch/index.ts
+++ b/supabase/functions/tb-branch/index.ts
@@ -121,9 +121,13 @@ async function parseBranchContext(url: URL): Promise<BranchContext> {
     throw new HttpError(401, "Invalid token");
   }
 
-  const secret = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  // Dedicated signing secret shared with the main MCP server. The hosted Edge
+  // runtime injects its own SUPABASE_SERVICE_ROLE_KEY value (not the dashboard
+  // key the server holds), so the service role key cannot verify server-minted
+  // tokens. Set via: supabase secrets set TB_BRANCH_SIGNING_SECRET=...
+  const secret = Deno.env.get("TB_BRANCH_SIGNING_SECRET");
   if (!secret) {
-    throw new HttpError(500, "Missing SUPABASE_SERVICE_ROLE_KEY");
+    throw new HttpError(500, "Missing TB_BRANCH_SIGNING_SECRET");
   }
 
   const expectedSignature = await signTokenSegment(payloadSegment, secret);


### PR DESCRIPTION
## Problem (SPEC-V1-INITIATIVE Phase 0.1)

Branch workers have never worked in the deployed configuration. The server signed worker tokens with its `SUPABASE_SERVICE_ROLE_KEY`; the `tb-branch` Edge Function verified against the runtime-injected `SUPABASE_SERVICE_ROLE_KEY`. On hosted Supabase those values differ — the Edge runtime injects a platform-managed value that matches neither the legacy `service_role` key nor the new `sb_secret` key (differentially verified against prod and staging: tokens signed with every dashboard-visible key are rejected). Every `tb.branch.spawn` worker URL returned 401 "Invalid token signature".

## Change

- Server mints with a dedicated `TB_BRANCH_SIGNING_SECRET` (`BranchHandlerDeps.signingSecret`); when Supabase creds are present but the secret is missing, `tb.branch.*` is disabled with an explicit error instead of minting unverifiable tokens.
- `tb-branch` Edge Function verifies with `TB_BRANCH_SIGNING_SECRET`.
- CI seeds `supabase/functions/.env` before `supabase start` so the local edge runtime shares the test secret.
- `.specs/SPEC-BRANCH-WORKERS.md` auth section updated in the same commit.

## Ops already applied (live)

- Secret set on prod + staging Supabase Edge runtimes (`supabase secrets set`).
- Mirrored to GCP Secret Manager as `tb-branch-signing-secret`; wired into Cloud Run revision `thoughtbox-mcp-00169-twj` (live now, read by the server once this PR's image deploys).
- `tb-branch` redeployed to prod (v3) and staging.

## Verification

- All 4 `branch-workers` tests pass against the local edge runtime (mint→verify loop, 401 without token, 5 concurrent branch thoughts).
- Prod `tb-branch` serves a full `tools/list` response for a token signed with the new secret; no-token and bad-token requests return 401.
- `tsc --noEmit`, oxlint, actionlint all clean.
- Claim `SPEC-V1-INITIATIVE:c1` completes end-to-end after merge, when Cloud Build deploys the image that mints with the new secret — I'll run the live `tb.branch.spawn` → worker round-trip then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)