### PR TITLE
fix(supabase): restore orphaned migration files applied to prod

### DIFF
--- a/supabase/migrations/20260513090000_allow_ulysses_validator_history_events.sql
+++ b/supabase/migrations/20260513090000_allow_ulysses_validator_history_events.sql
@@ -1,0 +1,18 @@
+-- Allow Ulysses validator audit events already emitted by the protocol handler.
+ALTER TABLE public.protocol_history
+  DROP CONSTRAINT IF EXISTS protocol_history_event_type_check;
+
+ALTER TABLE public.protocol_history
+  ADD CONSTRAINT protocol_history_event_type_check
+  CHECK (
+    event_type = ANY (
+      ARRAY[
+        'plan'::text,
+        'outcome'::text,
+        'reflect'::text,
+        'checkpoint'::text,
+        'final_validator_bound'::text,
+        'validator_tampering'::text
+      ]
+    )
+  );

--- a/supabase/migrations/20260608000001_protocol_workspace_defense_in_depth.sql
+++ b/supabase/migrations/20260608000001_protocol_workspace_defense_in_depth.sql
@@ -1,0 +1,91 @@
+-- Defense-in-depth tenant isolation for protocol-enforcement tables.
+--
+-- Background: protocol_sessions.workspace_id was text and mixed three eras of
+-- data: real tenant UUIDs (from 2026-04-23 on), pre-multi-tenancy NULLs, and
+-- dev project-name strings ("thoughtbox-staging", "thoughtbox-webpage-2026").
+-- The child tables (audits/history/scope/visas) had no workspace_id at all and
+-- relied solely on the session_id FK chain for isolation.
+--
+-- This migration removes the legacy/dev rows, normalizes workspace_id to uuid
+-- with a workspaces FK, and gives the child tables their own NOT NULL
+-- workspace_id (backfilled from the parent, kept in sync by a trigger).
+
+-- 1. Delete legacy/dev sessions (NULL, non-uuid, or not a real workspace).
+--    Children cascade via existing ON DELETE CASCADE FKs.
+DELETE FROM public.protocol_sessions ps
+WHERE ps.workspace_id IS NULL
+   OR ps.workspace_id !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+   OR NOT EXISTS (SELECT 1 FROM public.workspaces w WHERE w.id::text = ps.workspace_id);
+
+-- 2. Drop the workspace-scoped policy before altering the column type
+--    (a policy referencing the column blocks ALTER COLUMN TYPE).
+DROP POLICY IF EXISTS tenant_member_read ON public.protocol_sessions;
+
+-- 3. Normalize workspace_id to uuid + NOT NULL, and add the workspaces FK.
+ALTER TABLE public.protocol_sessions
+  ALTER COLUMN workspace_id TYPE uuid USING workspace_id::uuid,
+  ALTER COLUMN workspace_id SET NOT NULL;
+
+ALTER TABLE public.protocol_sessions
+  ADD CONSTRAINT protocol_sessions_workspace_id_fkey
+  FOREIGN KEY (workspace_id) REFERENCES public.workspaces(id) ON DELETE CASCADE;
+
+-- 4. Recreate the policy without the text cast (now uuid = uuid).
+CREATE POLICY tenant_member_read ON public.protocol_sessions
+  FOR SELECT TO authenticated
+  USING (
+    workspace_id IN (
+      SELECT wm.workspace_id FROM public.workspace_memberships wm
+      WHERE wm.user_id = auth.uid()
+    )
+  );
+
+-- 5. Add workspace_id to the child tables (nullable for backfill).
+ALTER TABLE public.protocol_audits  ADD COLUMN IF NOT EXISTS workspace_id uuid;
+ALTER TABLE public.protocol_history ADD COLUMN IF NOT EXISTS workspace_id uuid;
+ALTER TABLE public.protocol_scope   ADD COLUMN IF NOT EXISTS workspace_id uuid;
+ALTER TABLE public.protocol_visas   ADD COLUMN IF NOT EXISTS workspace_id uuid;
+
+-- 6. Backfill from the parent session.
+UPDATE public.protocol_audits  c SET workspace_id = s.workspace_id FROM public.protocol_sessions s WHERE s.id = c.session_id;
+UPDATE public.protocol_history c SET workspace_id = s.workspace_id FROM public.protocol_sessions s WHERE s.id = c.session_id;
+UPDATE public.protocol_scope   c SET workspace_id = s.workspace_id FROM public.protocol_sessions s WHERE s.id = c.session_id;
+UPDATE public.protocol_visas   c SET workspace_id = s.workspace_id FROM public.protocol_sessions s WHERE s.id = c.session_id;
+
+-- 7. Enforce NOT NULL + workspaces FK + index on each child table.
+ALTER TABLE public.protocol_audits  ALTER COLUMN workspace_id SET NOT NULL;
+ALTER TABLE public.protocol_audits  ADD CONSTRAINT protocol_audits_workspace_id_fkey  FOREIGN KEY (workspace_id) REFERENCES public.workspaces(id) ON DELETE CASCADE;
+CREATE INDEX IF NOT EXISTS idx_protocol_audits_workspace  ON public.protocol_audits(workspace_id);
+
+ALTER TABLE public.protocol_history ALTER COLUMN workspace_id SET NOT NULL;
+ALTER TABLE public.protocol_history ADD CONSTRAINT protocol_history_workspace_id_fkey FOREIGN KEY (workspace_id) REFERENCES public.workspaces(id) ON DELETE CASCADE;
+CREATE INDEX IF NOT EXISTS idx_protocol_history_workspace ON public.protocol_history(workspace_id);
+
+ALTER TABLE public.protocol_scope   ALTER COLUMN workspace_id SET NOT NULL;
+ALTER TABLE public.protocol_scope   ADD CONSTRAINT protocol_scope_workspace_id_fkey   FOREIGN KEY (workspace_id) REFERENCES public.workspaces(id) ON DELETE CASCADE;
+CREATE INDEX IF NOT EXISTS idx_protocol_scope_workspace   ON public.protocol_scope(workspace_id);
+
+ALTER TABLE public.protocol_visas   ALTER COLUMN workspace_id SET NOT NULL;
+ALTER TABLE public.protocol_visas   ADD CONSTRAINT protocol_visas_workspace_id_fkey   FOREIGN KEY (workspace_id) REFERENCES public.workspaces(id) ON DELETE CASCADE;
+CREATE INDEX IF NOT EXISTS idx_protocol_visas_workspace   ON public.protocol_visas(workspace_id);
+
+-- 8. Keep child workspace_id in sync with the parent session automatically,
+--    so app inserts cannot omit or mis-set it. Explicit values are respected.
+CREATE OR REPLACE FUNCTION public.set_protocol_child_workspace_id()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, public
+AS $$
+BEGIN
+  IF NEW.workspace_id IS NULL THEN
+    SELECT workspace_id INTO NEW.workspace_id
+    FROM public.protocol_sessions WHERE id = NEW.session_id;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_set_workspace_id BEFORE INSERT ON public.protocol_audits  FOR EACH ROW EXECUTE FUNCTION public.set_protocol_child_workspace_id();
+CREATE TRIGGER trg_set_workspace_id BEFORE INSERT ON public.protocol_history FOR EACH ROW EXECUTE FUNCTION public.set_protocol_child_workspace_id();
+CREATE TRIGGER trg_set_workspace_id BEFORE INSERT ON public.protocol_scope   FOR EACH ROW EXECUTE FUNCTION public.set_protocol_child_workspace_id();
+CREATE TRIGGER trg_set_workspace_id BEFORE INSERT ON public.protocol_visas   FOR EACH ROW EXECUTE FUNCTION public.set_protocol_child_workspace_id();


### PR DESCRIPTION
## Problem (SPEC-V1-INITIATIVE Phase 0.2)

Prod's Supabase branching integration fails on **every push to main** with `Remote migration versions not found in local migrations directory` (verified in branch-action logs), leaving the default branch in `MIGRATIONS_FAILED` and blocking all migration delivery to prod — including `20260602214044`, which is applied on staging but missing from prod.

Prod's ledger references three versions with no file on main:
- `20260513090000` — ulysses validator migration, applied to prod from `fix/ulysses-fixes` (never merged)
- `20260608045925` / `20260608050836` — the tenant-isolation RLS pair, applied via a Supabase branch merge under re-stamped versions (repo files: `20260607000001` on main, `20260608000001` on PR #354)

## Change

Restores two migration files verbatim from their source branches: `20260513090000_allow_ulysses_validator_history_events.sql` and `20260608000001_protocol_workspace_defense_in_depth.sql`. Both schema changes are **already applied** to prod (and the latter to staging), so this PR changes no database state — it only lets the integration's file↔ledger matching succeed. When PR #354 rebases onto this, its migration file diff disappears; its code changes are untouched.

Staging deploy uses `db push --include-all`, so the out-of-order ulysses file applies cleanly to staging (parity improvement — prod already has it).

## After merge (documented one-off ledger repair, then automated)

1. `supabase migration repair` on prod: `20260608045925`→reverted, `20260607000001`→applied; `20260608050836`→reverted, `20260608000001`→applied
2. One-off apply of pending `20260602214044` to prod (Phase 2's gated promotion pipeline will own this path going forward)
3. Next push to main → branching integration goes green → SPEC-V1-INITIATIVE:c2 evidence

🤖 Generated with [Claude Code](https://claude.com/claude-code)