### PR TITLE
feat(ci): add prod migration health check; document prod pipeline

### DIFF
--- a/.github/workflows/prod-migration-health.yml
+++ b/.github/workflows/prod-migration-health.yml
@@ -9,6 +9,9 @@
 #   1. fails if the prod default branch is not in a healthy terminal state
 #   2. fails if prod's applied migration versions drift from the files on main
 #
+# Both checks always run (continue-on-error + final gate), so a single run
+# reports both failure modes — they coexisted in the Phase 0.2 incident.
+#
 # Requires: SUPABASE_ACCESS_TOKEN repo secret (sbp_ personal access token,
 # already used by staging-deploy.yml).
 
@@ -33,44 +36,59 @@ jobs:
   check:
     name: Branch status + ledger drift
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           persist-credentials: false
 
-      - name: Wait for branching integration
-        # On push, the integration needs ~1-2 minutes to clone, apply, and
-        # report. Checking immediately would race it.
-        if: github.event_name == 'push'
-        run: sleep 180
-
       - name: Check prod default branch status
+        id: branch-status
+        continue-on-error: true
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+        # Polls instead of a fixed sleep: on push the integration needs about
+        # 1-2 minutes (queueing or a heavy migration can take longer), and
+        # intermediate statuses (e.g. RUNNING_MIGRATIONS) must not be treated
+        # as failures. Polling also guarantees the drift check below runs
+        # only after the integration reached a terminal state.
         run: |
           set -euo pipefail
-          status=$(curl -sf -H "Authorization: Bearer ${SUPABASE_ACCESS_TOKEN}" \
-            "https://api.supabase.com/v1/projects/${PROD_PROJECT_REF}/branches" \
-            | jq -r '.[] | select(.is_default) | .status')
-          echo "Prod default branch status: ${status}"
-          case "${status}" in
-            FUNCTIONS_DEPLOYED|MIGRATIONS_PASSED)
-              echo "Healthy." ;;
-            *)
-              echo "::error::Prod Supabase branch is unhealthy (${status})." \
-                "Migrations are NOT being delivered to prod." \
-                "Inspect branch-action logs in the Supabase dashboard and" \
-                "see SPEC-V1-INITIATIVE Phase 0.2 / 2 for the repair playbook."
-              exit 1 ;;
-          esac
+          deadline=$((SECONDS + 420))
+          while :; do
+            status=$(curl -sf --max-time 30 -H "Authorization: Bearer ${SUPABASE_ACCESS_TOKEN}" \
+              "https://api.supabase.com/v1/projects/${PROD_PROJECT_REF}/branches" \
+              | jq -r '.[] | select(.is_default) | .status')
+            echo "Prod default branch status: ${status}"
+            case "${status}" in
+              FUNCTIONS_DEPLOYED|MIGRATIONS_PASSED)
+                echo "Healthy."
+                exit 0 ;;
+              MIGRATIONS_FAILED|FUNCTIONS_FAILED)
+                echo "::error::Prod Supabase branch is unhealthy (${status})." \
+                  "Migrations are NOT being delivered to prod." \
+                  "Inspect branch-action logs in the Supabase dashboard and" \
+                  "see SPEC-V1-INITIATIVE Phase 0.2 / 2 for the repair playbook."
+                exit 1 ;;
+              *)
+                if [ "${SECONDS}" -ge "${deadline}" ]; then
+                  echo "::error::Prod branch still in non-terminal state (${status}) after 7 minutes."
+                  exit 1
+                fi
+                echo "Non-terminal state; retrying in 20s..."
+                sleep 20 ;;
+            esac
+          done
 
       - name: Check prod ledger vs migration files
+        id: ledger-drift
+        continue-on-error: true
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
         run: |
           set -euo pipefail
-          curl -sf -H "Authorization: Bearer ${SUPABASE_ACCESS_TOKEN}" \
+          curl -sf --max-time 30 -H "Authorization: Bearer ${SUPABASE_ACCESS_TOKEN}" \
             "https://api.supabase.com/v1/projects/${PROD_PROJECT_REF}/database/migrations" \
             | jq -r '.[].version' | sort > /tmp/prod-versions.txt
           find supabase/migrations -name '*.sql' \
@@ -84,3 +102,14 @@ jobs:
             cat /tmp/drift.txt
             exit 1
           fi
+
+      - name: Fail if any check failed
+        if: steps.branch-status.outcome == 'failure' || steps.ledger-drift.outcome == 'failure'
+        env:
+          BRANCH_STATUS_OUTCOME: ${{ steps.branch-status.outcome }}
+          LEDGER_DRIFT_OUTCOME: ${{ steps.ledger-drift.outcome }}
+        run: |
+          echo "::error::Prod migration health failed:" \
+            "branch-status=${BRANCH_STATUS_OUTCOME}," \
+            "ledger-drift=${LEDGER_DRIFT_OUTCOME}"
+          exit 1

--- a/.github/workflows/prod-migration-health.yml
+++ b/.github/workflows/prod-migration-health.yml
@@ -1,0 +1,86 @@
+# Prod migration health (SPEC-V1-INITIATIVE:c5)
+#
+# The Supabase branching GitHub integration is the prod migration applier:
+# on every push to main it applies pending supabase/migrations/ files to the
+# production project and deploys Edge Functions. It once sat in
+# MIGRATIONS_FAILED for weeks without anyone noticing, silently blocking all
+# migration delivery to prod. This workflow makes that state loud:
+#
+#   1. fails if the prod default branch is not in a healthy terminal state
+#   2. fails if prod's applied migration versions drift from the files on main
+#
+# Requires: SUPABASE_ACCESS_TOKEN repo secret (sbp_ personal access token,
+# already used by staging-deploy.yml).
+
+name: Prod Migration Health
+
+on:
+  schedule:
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "supabase/migrations/**"
+
+permissions:
+  contents: read
+
+env:
+  PROD_PROJECT_REF: akjccuoncxlvrrtkvtno
+
+jobs:
+  check:
+    name: Branch status + ledger drift
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Wait for branching integration
+        # On push, the integration needs ~1-2 minutes to clone, apply, and
+        # report. Checking immediately would race it.
+        if: github.event_name == 'push'
+        run: sleep 180
+
+      - name: Check prod default branch status
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+        run: |
+          set -euo pipefail
+          status=$(curl -sf -H "Authorization: Bearer ${SUPABASE_ACCESS_TOKEN}" \
+            "https://api.supabase.com/v1/projects/${PROD_PROJECT_REF}/branches" \
+            | jq -r '.[] | select(.is_default) | .status')
+          echo "Prod default branch status: ${status}"
+          case "${status}" in
+            FUNCTIONS_DEPLOYED|MIGRATIONS_PASSED)
+              echo "Healthy." ;;
+            *)
+              echo "::error::Prod Supabase branch is unhealthy (${status})." \
+                "Migrations are NOT being delivered to prod." \
+                "Inspect branch-action logs in the Supabase dashboard and" \
+                "see SPEC-V1-INITIATIVE Phase 0.2 / 2 for the repair playbook."
+              exit 1 ;;
+          esac
+
+      - name: Check prod ledger vs migration files
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+        run: |
+          set -euo pipefail
+          curl -sf -H "Authorization: Bearer ${SUPABASE_ACCESS_TOKEN}" \
+            "https://api.supabase.com/v1/projects/${PROD_PROJECT_REF}/database/migrations" \
+            | jq -r '.[].version' | sort > /tmp/prod-versions.txt
+          find supabase/migrations -name '*.sql' \
+            | sed 's|.*/\([0-9]*\)_.*|\1|' | sort > /tmp/repo-versions.txt
+          if diff -u /tmp/prod-versions.txt /tmp/repo-versions.txt > /tmp/drift.txt; then
+            echo "No drift: $(wc -l < /tmp/repo-versions.txt | tr -d ' ') versions match."
+          else
+            echo "::error::Prod migration ledger has drifted from supabase/migrations/ on main."
+            echo "Lines starting with '-' are prod-only versions (file missing from repo);"
+            echo "lines starting with '+' are repo files not applied to prod."
+            cat /tmp/drift.txt
+            exit 1
+          fi

--- a/.specs/deployment/v1-initiative.md
+++ b/.specs/deployment/v1-initiative.md
@@ -25,10 +25,10 @@ claims:
     behavioral: false
     required_evidence: Terraform sets max_instance_count = 1 with a comment referencing c16.
   - id: c5
-    statement: A staging-to-prod Supabase migration pipeline exists — PRs apply migrations to staging; merge to main applies them to production through a gated GitHub Actions workflow; no migrations reach prod outside this path.
+    statement: A staging-to-prod Supabase migration pipeline exists — PRs apply migrations to staging; merging to main (the gate is PR review) applies them to production via the Supabase branching integration; CI monitors prod branch health and ledger-vs-files drift and fails loudly; no migrations reach prod outside this path.
     type: governance
     behavioral: true
-    required_evidence: A migration merged via PR appears in the prod ledger via the workflow run, with the approval gate exercised.
+    required_evidence: A migration merged via PR appears in the prod ledger via a green branching-integration run, and the prod-migration-health workflow passes (and demonstrably fails on injected drift or an unhealthy branch).
   - id: c6
     statement: Observability operations return isError on missing configuration instead of soft success, and the health operation reports per-component status from real probes.
     type: behavioral
@@ -144,7 +144,15 @@ Each numbered item is one unit of work: one branch, one PR, conventional commits
 
 ### Phase 2 — Supabase staging → prod pipeline
 
-- **2.1 Prod promotion workflow.** Keep `staging-deploy.yml` (PR → staging). Add `prod-deploy.yml`: on merge to main touching `supabase/migrations/**`, apply to prod via `supabase db push` against `akjccuoncxlvrrtkvtno` using a GitHub Environment with required approval. Document that local checkouts stay linked to staging by design. Add a drift check job (prod ledger vs repo) to CI so re-stamping regressions surface immediately. → **c5**
+> Amended 2026-06-10 after Phase 0.2: discovery showed the Supabase branching
+> GitHub integration already applies migrations and deploys Edge Functions to
+> prod on every push to main (confirmed by a green run once the ledger was
+> repaired). A second applier (`prod-deploy.yml`) would double-apply, so the
+> pipeline is documented rather than rebuilt, and the missing piece — loud
+> failure detection — is added instead.
+
+- **2.1 The pipeline (existing, now documented).** PR touching `supabase/migrations/**` → `staging-deploy.yml` applies to staging (`db push --include-all`) → PR review/merge is the gate → on push to main, the Supabase branching integration applies pending migrations to prod and deploys Edge Functions from the repo. Local checkouts stay linked to staging by design; nothing applies to prod from a laptop. → **c5**
+- **2.2 Prod migration health workflow.** `.github/workflows/prod-migration-health.yml` (daily schedule + post-merge + manual): fails loudly when the prod default branch is not healthy (the silent-MIGRATIONS_FAILED failure mode of Phase 0.2) or when prod's applied versions drift from the migration files on main (the re-stamping failure mode). Uses the Management API with the existing `SUPABASE_ACCESS_TOKEN` secret. → **c5**
 
 ### Phase 3 — Honesty fixes (small independent PRs)
 


### PR DESCRIPTION
## What (SPEC-V1-INITIATIVE Phase 2)

Phase 0.2 discovery changed this phase's design: the **Supabase branching GitHub integration is already the prod migration applier** — on every push to main it applies pending `supabase/migrations/` files to prod and deploys Edge Functions (confirmed by the first green run after the ledger repair: "All migrations are up to date" + both functions deployed; prod default branch is now `FUNCTIONS_DEPLOYED`). The originally planned `prod-deploy.yml` applier would double-apply against the same ledger, so it's dropped.

What was actually missing is **loud failure detection** — the integration sat in `MIGRATIONS_FAILED` for weeks, silently blocking all migration delivery to prod.

### Changes

- **`.github/workflows/prod-migration-health.yml`** (daily cron + push-to-main on migrations + manual): two checks via the Supabase Management API using the existing `SUPABASE_ACCESS_TOKEN` secret —
  1. prod default branch status must be healthy (catches the Phase 0.2 silent-failure mode)
  2. prod applied versions must exactly match migration files on main (catches the re-stamping drift mode)
- **SPEC-V1-INITIATIVE** Phase 2 + claim c5 amended to document the real pipeline: PR → `staging-deploy` applies to staging → PR review/merge is the gate → branching integration applies to prod. Local checkouts stay linked to staging; nothing applies to prod from a laptop.

### Verification

- Both check scripts dry-run green against live prod with identical commands: status `FUNCTIONS_DEPLOYED`, drift `23/23 versions match`.
- actionlint + zizmor clean; spec frontmatter validates against `.schemas/spec-v1.json`.
- Negative paths are plain `exit 1` on bad status / non-empty diff; can be demonstrated post-merge via `workflow_dispatch` against an injected mismatch if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)