### PR TITLE
fix(observability): honest errors and real health probes

### DIFF
--- a/src/observability/__tests__/gateway-handler.test.ts
+++ b/src/observability/__tests__/gateway-handler.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Unit tests for ObservabilityGatewayHandler.
+ *
+ * Verifies the honest-error contract (SPEC-V1-INITIATIVE:c6): operations
+ * either do the real thing or return an MCP error result — no soft success.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { ObservabilityGatewayHandler } from '../gateway-handler.js';
+import { InMemoryStorage } from '../../persistence/index.js';
+
+interface ToolResult {
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+}
+
+function parsePayload(result: ToolResult): Record<string, unknown> {
+  return JSON.parse(result.content[0].text);
+}
+
+describe('ObservabilityGatewayHandler', () => {
+  describe('OTEL operations without Supabase', () => {
+    it('session_timeline returns an error result when Supabase is not configured', async () => {
+      const handler = new ObservabilityGatewayHandler({ storage: new InMemoryStorage() });
+
+      const result = await handler.handle({
+        operation: 'session_timeline',
+        args: { sessionId: 'abc-123' },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(parsePayload(result).error).toBe('OTEL queries require Supabase configuration');
+    });
+
+    it('session_cost returns an error result when Supabase is not configured', async () => {
+      const handler = new ObservabilityGatewayHandler({ storage: new InMemoryStorage() });
+
+      const result = await handler.handle({
+        operation: 'session_cost',
+        args: { sessionId: 'abc-123' },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(parsePayload(result).error).toBe('OTEL queries require Supabase configuration');
+    });
+
+    it('session_timeline returns an error result when sessionId is missing', async () => {
+      const handler = new ObservabilityGatewayHandler({
+        storage: new InMemoryStorage(),
+        supabaseUrl: 'http://localhost:54321',
+        serviceRoleKey: 'test-service-role-key',
+      });
+
+      const result = await handler.handle({ operation: 'session_timeline' });
+
+      expect(result.isError).toBe(true);
+      expect(parsePayload(result).error).toBe('sessionId is required for session_timeline');
+    });
+  });
+
+  describe('health', () => {
+    it('reports thoughtbox healthy from a storage probe and supabase unknown when unconfigured', async () => {
+      const handler = new ObservabilityGatewayHandler({ storage: new InMemoryStorage() });
+
+      const result = await handler.handle({ operation: 'health' });
+
+      expect(result.isError).toBeUndefined();
+      const payload = parsePayload(result) as {
+        status: string;
+        services: Record<string, { status: string; error?: string }>;
+      };
+      expect(payload.services['thoughtbox'].status).toBe('healthy');
+      expect(payload.services['supabase'].status).toBe('unknown');
+      expect(payload.status).toBe('degraded');
+    });
+
+    it('reports thoughtbox unhealthy when the storage probe fails', async () => {
+      const storage = new InMemoryStorage();
+      vi.spyOn(storage, 'listSessions').mockRejectedValue(new Error('storage backend unavailable'));
+      const handler = new ObservabilityGatewayHandler({ storage });
+
+      const result = await handler.handle({ operation: 'health' });
+
+      const payload = parsePayload(result) as {
+        status: string;
+        services: Record<string, { status: string; error?: string }>;
+      };
+      expect(payload.services['thoughtbox'].status).toBe('unhealthy');
+      expect(payload.services['thoughtbox'].error).toBe('storage backend unavailable');
+      expect(payload.status).toBe('unhealthy');
+    });
+  });
+});

--- a/src/observability/gateway-handler.ts
+++ b/src/observability/gateway-handler.ts
@@ -96,7 +96,6 @@ export interface ObservabilityGatewayConfig {
   workspaceId?: string;
   supabaseUrl?: string;
   serviceRoleKey?: string;
-  thoughtboxUrl?: string;
 }
 
 // =============================================================================
@@ -104,13 +103,11 @@ export interface ObservabilityGatewayConfig {
 // =============================================================================
 
 export class ObservabilityGatewayHandler {
-  private readonly thoughtboxUrl: string;
   private readonly storage: ThoughtboxStorage;
   private readonly workspaceId: string;
   private readonly otelStorage: OtelEventStorage | null;
 
   constructor(config: ObservabilityGatewayConfig) {
-    this.thoughtboxUrl = config.thoughtboxUrl ?? 'http://thoughtbox:1731';
     this.storage = config.storage;
     this.workspaceId = config.workspaceId ?? '00000000-0000-4000-a000-000000000001';
 
@@ -170,7 +167,7 @@ export class ObservabilityGatewayHandler {
   }
 
   private async handleHealth(args: HealthArgs) {
-    return checkHealth(args, this.thoughtboxUrl, this.otelStorage);
+    return checkHealth(args, this.storage, this.otelStorage);
   }
 
   private async handleSessions(args: SessionsArgs) {
@@ -185,10 +182,10 @@ export class ObservabilityGatewayHandler {
     args: { sessionId?: string; limit?: number },
   ) {
     if (!this.otelStorage) {
-      return { error: 'OTEL queries require Supabase configuration' };
+      throw new Error('OTEL queries require Supabase configuration');
     }
     if (!args.sessionId) {
-      return { error: 'sessionId is required for session_timeline' };
+      throw new Error('sessionId is required for session_timeline');
     }
     return this.otelStorage.querySessionTimeline(
       this.workspaceId,
@@ -201,7 +198,7 @@ export class ObservabilityGatewayHandler {
     args: { sessionId?: string },
   ) {
     if (!this.otelStorage) {
-      return { error: 'OTEL queries require Supabase configuration' };
+      throw new Error('OTEL queries require Supabase configuration');
     }
     return this.otelStorage.querySessionCost(
       this.workspaceId,

--- a/src/observability/operations/health.ts
+++ b/src/observability/operations/health.ts
@@ -1,10 +1,13 @@
 /**
  * Health Check Operation
  *
- * Checks health of Thoughtbox and OTEL event storage.
+ * Probes the Thoughtbox storage backend and OTEL event storage and reports
+ * per-component status. Components that cannot be probed report `unknown` —
+ * never an unconditional `healthy`.
  */
 
 import type { OtelEventStorage } from '../../otel/otel-storage.js';
+import type { ThoughtboxStorage } from '../../persistence/types.js';
 
 export interface HealthArgs {
   services?: string[];
@@ -25,7 +28,7 @@ export interface HealthResult {
 
 export async function checkHealth(
   args: HealthArgs,
-  thoughtboxUrl: string,
+  storage: ThoughtboxStorage,
   otelStorage: OtelEventStorage | null,
 ): Promise<HealthResult> {
   const requestedServices = args.services ?? ['thoughtbox', 'supabase'];
@@ -35,9 +38,7 @@ export async function checkHealth(
     requestedServices.map(async (service) => {
       switch (service) {
         case 'thoughtbox':
-          // If responding to this request, the server is healthy.
-          // External URL checks fail from Cloud Run (no loopback route).
-          return { name: service, health: { status: 'healthy' as const } };
+          return { name: service, health: await checkThoughtboxStorage(storage) };
         case 'supabase':
           return { name: service, health: await checkOtelStorage(otelStorage) };
         default:
@@ -69,6 +70,20 @@ export async function checkHealth(
     timestamp: new Date().toISOString(),
     services,
   };
+}
+
+async function checkThoughtboxStorage(
+  storage: ThoughtboxStorage,
+): Promise<ServiceHealth> {
+  try {
+    await storage.listSessions({ limit: 1 });
+    return { status: 'healthy' };
+  } catch (err) {
+    return {
+      status: 'unhealthy',
+      error: err instanceof Error ? err.message : 'Storage probe failed',
+    };
+  }
 }
 
 async function checkOtelStorage(


### PR DESCRIPTION
Implements spec claim `SPEC-V1-INITIATIVE:c6` (Phase 3.1): observability operations either do the real thing or return an explicit error — no soft success.

## Changes

- `src/observability/gateway-handler.ts`: `session_timeline` and `session_cost` now throw when Supabase is not configured (and `session_timeline` when `sessionId` is missing). The handler's existing catch path converts these into MCP error results (`isError: true`), instead of the previous soft-success payload containing an `{ error }` object.
- `src/observability/operations/health.ts`: the `thoughtbox` component is now probed via a cheap `storage.listSessions({ limit: 1 })` read instead of being reported as unconditionally `healthy`. A failing probe reports `unhealthy` with the error message. Supabase reports `unknown` when not configured, and uses the existing `checkHealth()` query when it is.
- Removed the unused `thoughtboxUrl` config from `ObservabilityGatewayConfig` — no caller passed it and nothing read it after the health rewire.

## Tests

New `src/observability/__tests__/gateway-handler.test.ts` (5 tests):
- `session_timeline` / `session_cost` without Supabase return `isError: true` with the configuration error
- `session_timeline` without `sessionId` returns `isError: true`
- health reports `thoughtbox: healthy` from a real storage probe and `supabase: unknown` when unconfigured (overall `degraded`)
- health reports `thoughtbox: unhealthy` (overall `unhealthy`) when the storage probe rejects (boundary mocked with `vi.spyOn`)

Verified: `npx tsc --noEmit`, `npx oxlint -c oxlint.json src/` (0 warnings), `npx vitest run` on the new test file and `src/code-mode/__tests__/execute-tool.test.ts` (which constructs the handler) — all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)