### PR TITLE
fix(code-mode): clean error for tb.knowledge.* when knowledge init fails

### DIFF
--- a/src/code-mode/__tests__/execute-tool.test.ts
+++ b/src/code-mode/__tests__/execute-tool.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { ExecuteTool } from "../execute-tool.js";
+import { ExecuteTool, type ExecuteToolDeps } from "../execute-tool.js";
 import { ThoughtTool } from "../../thought/tool.js";
 import { SessionTool } from "../../sessions/tool.js";
 import { KnowledgeTool } from "../../knowledge/tool.js";
@@ -12,7 +12,7 @@ import { KnowledgeHandler, FileSystemKnowledgeStorage } from "../../knowledge/in
 import { NotebookHandler } from "../../notebook/index.js";
 import { InMemoryStorage } from "../../persistence/index.js";
 
-function createExecuteTool(): ExecuteTool {
+function createExecuteTool(overrides: Partial<ExecuteToolDeps> = {}): ExecuteTool {
   const storage = new InMemoryStorage();
   const thoughtHandler = new ThoughtHandler(true, storage);
   const sessionHandler = new SessionHandler({ storage, thoughtHandler });
@@ -28,6 +28,7 @@ function createExecuteTool(): ExecuteTool {
     theseusTool: new TheseusTool(protocolHandler),
     ulyssesTool: new UlyssesTool(protocolHandler),
     observabilityHandler: new ObservabilityGatewayHandler({ storage }),
+    ...overrides,
   });
 }
 
@@ -145,6 +146,23 @@ describe("thoughtbox_execute", () => {
     const output = JSON.parse(result.content[0].text);
     expect(output.result).toBeNull();
     expect(output.error).toContain("hosted mode");
+  });
+
+  it("tb.knowledge.* returns a clean error when knowledge init failed", async () => {
+    // Mirrors server-factory behavior: knowledge storage init threw, so
+    // knowledgeTool is undefined and the captured failure reason is threaded in.
+    const tool = createExecuteTool({
+      knowledgeTool: undefined,
+      knowledgeUnavailableReason: "EACCES: permission denied, mkdir '/data/knowledge'",
+    });
+    const result = await tool.handle({
+      code: `async () => { return await tb.knowledge.stats(); }`,
+    });
+    const output = JSON.parse(result.content[0].text);
+    expect(output.result).toBeNull();
+    expect(output.error).toBe(
+      "knowledge unavailable: EACCES: permission denied, mkdir '/data/knowledge'",
+    );
   });
 
   it("can call tb.thought()", async () => {

--- a/src/code-mode/execute-tool.ts
+++ b/src/code-mode/execute-tool.ts
@@ -37,7 +37,14 @@ export type ExecuteToolInput = z.infer<typeof executeToolInputSchema>;
 export interface ExecuteToolDeps {
   thoughtTool: ThoughtTool;
   sessionTool: SessionTool;
-  knowledgeTool: KnowledgeTool;
+  /**
+   * Undefined when knowledge storage failed to initialize at server creation.
+   * `tb.knowledge.*` then returns a clean error (carrying
+   * `knowledgeUnavailableReason`) instead of crashing.
+   */
+  knowledgeTool?: KnowledgeTool;
+  /** Captured knowledge storage init failure, surfaced in the tb.knowledge.* error. */
+  knowledgeUnavailableReason?: string;
   notebookTool: NotebookTool;
   theseusTool: TheseusTool;
   ulyssesTool: UlyssesTool;
@@ -141,6 +148,15 @@ function buildTbObject(deps: ExecuteToolDeps, ctx: TbContext): Record<string, un
   const { thoughtTool, sessionTool, knowledgeTool, notebookTool,
           theseusTool, ulyssesTool, observabilityHandler, branchHandler } = deps;
 
+  const requireKnowledgeTool = (): KnowledgeTool => {
+    if (!knowledgeTool) {
+      throw new Error(
+        `knowledge unavailable: ${deps.knowledgeUnavailableReason ?? "knowledge storage failed to initialize"}`,
+      );
+    }
+    return knowledgeTool;
+  };
+
   const requireBranchHandler = (): BranchHandler => {
     if (!branchHandler) {
       throw new Error(
@@ -186,31 +202,31 @@ function buildTbObject(deps: ExecuteToolDeps, ctx: TbContext): Record<string, un
 
     knowledge: {
       createEntity: async (args: Record<string, unknown>) =>
-        normalizeEntityResult(unwrapToolResult(await knowledgeTool.handle({
+        normalizeEntityResult(unwrapToolResult(await requireKnowledgeTool().handle({
           operation: "knowledge_create_entity", ...args,
         } as KnowledgeToolInput))),
       getEntity: async (entityId: string) =>
-        normalizeEntityResult(unwrapToolResult(await knowledgeTool.handle({
+        normalizeEntityResult(unwrapToolResult(await requireKnowledgeTool().handle({
           operation: "knowledge_get_entity", entity_id: entityId,
         } as KnowledgeToolInput))),
       listEntities: async (args?: Record<string, unknown>) =>
-        unwrapToolResult(await knowledgeTool.handle({
+        unwrapToolResult(await requireKnowledgeTool().handle({
           operation: "knowledge_list_entities", ...args,
         } as KnowledgeToolInput)),
       addObservation: async (args: { entity_id: string; content: string; source_session?: string; added_by?: string }) =>
-        unwrapToolResult(await knowledgeTool.handle({
+        unwrapToolResult(await requireKnowledgeTool().handle({
           operation: "knowledge_add_observation", ...args,
         } as KnowledgeToolInput)),
       createRelation: async (args: { from_id: string; to_id: string; relation_type: string; properties?: Record<string, unknown> }) =>
-        unwrapToolResult(await knowledgeTool.handle({
+        unwrapToolResult(await requireKnowledgeTool().handle({
           operation: "knowledge_create_relation", ...args,
         } as KnowledgeToolInput)),
       queryGraph: async (args: { start_entity_id: string; max_depth?: number; relation_types?: string[] }) =>
-        unwrapToolResult(await knowledgeTool.handle({
+        unwrapToolResult(await requireKnowledgeTool().handle({
           operation: "knowledge_query_graph", ...args,
         } as KnowledgeToolInput)),
       stats: async () =>
-        unwrapToolResult(await knowledgeTool.handle({
+        unwrapToolResult(await requireKnowledgeTool().handle({
           operation: "knowledge_stats",
         } as KnowledgeToolInput)),
     },

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -332,6 +332,7 @@ Use \`console.log()\` for debugging — output captured in response logs.`;
   // Otherwise fall back to FileSystemKnowledgeStorage.
   let knowledgeHandler: KnowledgeHandler | undefined;
   let knowledgeStorage: import('./knowledge/types.js').KnowledgeStorage | undefined;
+  let knowledgeInitError: string | undefined;
   if (args.knowledgeStorage) {
     knowledgeStorage = args.knowledgeStorage;
     knowledgeHandler = new KnowledgeHandler(knowledgeStorage);
@@ -343,8 +344,10 @@ Use \`console.log()\` for debugging — output captured in response logs.`;
       knowledgeStorage = fsKnowledge;
       knowledgeHandler = new KnowledgeHandler(knowledgeStorage);
     } catch (knowledgeError) {
+      knowledgeInitError =
+        knowledgeError instanceof Error ? knowledgeError.message : String(knowledgeError);
       logger.warn(
-        `Knowledge storage unavailable, continuing without it: ${knowledgeError instanceof Error ? knowledgeError.message : String(knowledgeError)}`
+        `Knowledge storage unavailable, continuing without it: ${knowledgeInitError}`
       );
     }
   }
@@ -410,7 +413,9 @@ Use \`console.log()\` for debugging — output captured in response logs.`;
   // Tool Registration (all tools enabled at startup)
   // =============================================================================
 
-  const knowledgeTool = new KnowledgeTool(knowledgeHandler!);
+  // Undefined when knowledge init failed above; tb.knowledge.* then returns
+  // a clean "knowledge unavailable" error from ExecuteTool instead of crashing.
+  const knowledgeTool = knowledgeHandler ? new KnowledgeTool(knowledgeHandler) : undefined;
   const sessionTool = new SessionTool(sessionHandler);
   const thoughtTool = new ThoughtTool(thoughtHandler);
   const notebookTool = new NotebookTool(notebookHandler);
@@ -592,6 +597,7 @@ Use \`console.log()\` for debugging — output captured in response logs.`;
     thoughtTool,
     sessionTool,
     knowledgeTool,
+    knowledgeUnavailableReason: knowledgeInitError,
     notebookTool,
     theseusTool,
     ulyssesTool,


### PR DESCRIPTION
## What

Eliminates a latent crash in `tb.knowledge.*` (SPEC-V1-INITIATIVE:c8, Phase 3.2).

In `src/server-factory.ts`, knowledge storage init failure was caught and logged ("continuing without it"), but `KnowledgeTool` was then constructed with a non-null assertion on the undefined handler. Any subsequent `tb.knowledge.*` call crashed at runtime.

## Changes

- `src/server-factory.ts`: capture the init failure message (`knowledgeInitError`) at the catch site; construct `knowledgeTool` only when the handler exists (no non-null assertion); pass `knowledgeUnavailableReason` into `ExecuteTool`.
- `src/code-mode/execute-tool.ts`: `knowledgeTool` is now optional in `ExecuteToolDeps`, alongside a new `knowledgeUnavailableReason` field. A `requireKnowledgeTool()` guard (same pattern as `requireBranchHandler()`) throws `knowledge unavailable: <captured init failure reason>`, which the sandbox surfaces as a clean error in the result envelope instead of crashing.
- `src/code-mode/__tests__/execute-tool.test.ts`: `createExecuteTool` accepts dep overrides; new test forces a missing knowledge tool with a captured reason and asserts `tb.knowledge.stats()` returns `error: "knowledge unavailable: ..."` with `result: null`.

## Verification

- `npx tsc --noEmit` — clean
- `npx oxlint -c oxlint.json src/` — 0 warnings, 0 errors
- `npx vitest run src/code-mode/__tests__/execute-tool.test.ts` — 20/20 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)