### PR TITLE
fix(eval): regression check skipped is not passed when unconfigured

### DIFF
--- a/.specs/deployment/v1-initiative.md
+++ b/.specs/deployment/v1-initiative.md
@@ -160,7 +160,7 @@ Each numbered item is one unit of work: one branch, one PR, conventional commits
 - **3.2** Knowledge init failure → clean unavailable error, not `knowledgeHandler!` crash (`src/server-factory.ts:413`). → **c8**
 - **3.3** Register a read handler for `thoughtbox://gateway/operations` (content exists; it is a missing wire).
 - **3.4** Purge `mental_models` and all stale tool names from search catalog, init renderer, behavioral tests, prompts. → **c7**
-- **3.5** `runRegressionCheck` returns explicit skipped/failed when LangSmith unconfigured (or is deleted, per 0.4 decision).
+- **3.5** `runRegressionCheck` returns explicit skipped + non-passing (`RegressionCheckResult` with `passed: false, skipped: true`) when LangSmith is unconfigured or the experiment yields no result. The LangSmith stack stays per the 0.4 decision (2026-06-10; live in production). Done.
 - **3.6 Evidence Engine** (`src/notebook/engine/runtime.ts`): sync runs execute referenced notebook cells through the real notebook runtime and derive verdicts from actual outputs, or return an explicit unsupported error. Delete the async branch that queues to a nonexistent dispatcher. Rewrite tests to assert real verdict derivation (a failing runbook must yield `pass: false`). → **c9**
 
 ### Phase 4 — Hub: expose, persist, deliver

--- a/src/evaluation/__tests__/regression-check.test.ts
+++ b/src/evaluation/__tests__/regression-check.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Regression-gate honesty tests (SPEC-V1-INITIATIVE Phase 3.5).
+ *
+ * A gate must never pass by being disabled: when LangSmith is unconfigured
+ * (or the experiment yields no result), runRegressionCheck must report
+ * skipped=true and passed=false so callers can distinguish "gate ran and
+ * passed" from "gate did not run".
+ */
+import { describe, it, expect } from "vitest";
+import { ExperimentRunner } from "../experiment-runner.js";
+import type { LangSmithConfig } from "../types.js";
+
+function createConfig(): LangSmithConfig {
+  return {
+    apiKey: "test-key",
+    apiUrl: "https://api.smith.langchain.com",
+    project: "test-project",
+  };
+}
+
+type MockRow = {
+  example: { id: string; inputs: Record<string, unknown> };
+  evaluationResults: { results: Array<{ key: string; score: number }> };
+};
+
+function createMockEvaluate(rows: MockRow[]) {
+  return async () => {
+    let index = 0;
+    return {
+      experimentName: "test-experiment-001",
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+      async next() {
+        if (index < rows.length) {
+          return { value: rows[index++], done: false };
+        }
+        return { value: undefined, done: true };
+      },
+    };
+  };
+}
+
+describe("runRegressionCheck gate honesty", () => {
+  it("reports skipped and NOT passed when LangSmith is unconfigured", async () => {
+    const runner = new ExperimentRunner(null);
+    const check = await runner.runRegressionCheck("regression-ds", async (input) => input);
+
+    expect(check.passed).toBe(false);
+    expect(check.skipped).toBe(true);
+    expect(check.scores).toEqual({});
+    expect(check.failedEvaluators).toEqual([]);
+    expect(check.details).toContain("not configured");
+    expect(check.details).toContain("not passed");
+  });
+
+  it("reports skipped and NOT passed when the experiment produces no result", async () => {
+    const failingEvaluate = async () => {
+      throw new Error("LangSmith API unavailable");
+    };
+    const runner = new ExperimentRunner(createConfig(), undefined, failingEvaluate as never);
+    const check = await runner.runRegressionCheck("regression-ds", async (input) => input);
+
+    expect(check.passed).toBe(false);
+    expect(check.skipped).toBe(true);
+    expect(check.details).toContain("no result");
+  });
+
+  it("passes with skipped=false when evaluators meet thresholds", async () => {
+    const mockEvaluate = createMockEvaluate([
+      {
+        example: { id: "ex-1", inputs: {} },
+        evaluationResults: {
+          results: [
+            { key: "sessionQuality", score: 0.9 },
+            { key: "reasoningCoherence", score: 0.8 },
+          ],
+        },
+      },
+    ]);
+    const runner = new ExperimentRunner(createConfig(), undefined, mockEvaluate as never);
+    const check = await runner.runRegressionCheck("regression-ds", async (input) => input);
+
+    expect(check.passed).toBe(true);
+    expect(check.skipped).toBe(false);
+    expect(check.failedEvaluators).toEqual([]);
+  });
+
+  it("fails with skipped=false when an evaluator is below threshold", async () => {
+    const mockEvaluate = createMockEvaluate([
+      {
+        example: { id: "ex-1", inputs: {} },
+        evaluationResults: {
+          results: [
+            { key: "sessionQuality", score: 0.2 },
+            { key: "reasoningCoherence", score: 0.9 },
+          ],
+        },
+      },
+    ]);
+    const runner = new ExperimentRunner(createConfig(), undefined, mockEvaluate as never);
+    const check = await runner.runRegressionCheck("regression-ds", async (input) => input);
+
+    expect(check.passed).toBe(false);
+    expect(check.skipped).toBe(false);
+    expect(check.failedEvaluators).toContain("sessionQuality");
+  });
+});

--- a/src/evaluation/experiment-runner.ts
+++ b/src/evaluation/experiment-runner.ts
@@ -26,6 +26,7 @@ import type {
   LangSmithConfig,
   RunExperimentOptions,
   ExperimentRunResult,
+  RegressionCheckResult,
   EvaluatorName,
 } from "./types.js";
 import { getEvaluator, getAllEvaluators } from "./evaluators/index.js";
@@ -204,18 +205,16 @@ export class ExperimentRunner {
   /**
    * Run a regression check suitable for gatekeeper integration.
    *
-   * Runs all evaluators and returns a simple pass/fail with details.
+   * Runs all evaluators and returns pass/fail with details. When the check
+   * cannot run (LangSmith unconfigured, or the experiment produced no
+   * result), the check is reported as skipped AND not passed — a disabled
+   * gate must never read as a passing gate.
    */
   async runRegressionCheck(
     datasetName: string,
     target: RunExperimentOptions["target"],
     thresholds?: Record<string, number>,
-  ): Promise<{
-    passed: boolean;
-    scores: Record<string, number>;
-    failedEvaluators: string[];
-    details: string;
-  }> {
+  ): Promise<RegressionCheckResult> {
     const defaultThresholds: Record<string, number> = {
       sessionQuality: 0.5,
       memoryQuality: 0.4,
@@ -233,10 +232,13 @@ export class ExperimentRunner {
 
     if (!result) {
       return {
-        passed: true,
+        passed: false,
+        skipped: true,
         scores: {},
         failedEvaluators: [],
-        details: "LangSmith not configured — regression check skipped",
+        details: this.isEnabled()
+          ? "Experiment produced no result — regression check skipped, not passed"
+          : "LangSmith not configured — regression check skipped, not passed",
       };
     }
 
@@ -250,6 +252,7 @@ export class ExperimentRunner {
 
     return {
       passed: failedEvaluators.length === 0,
+      skipped: false,
       scores: result.aggregateScores,
       failedEvaluators,
       details: failedEvaluators.length === 0

--- a/src/evaluation/index.ts
+++ b/src/evaluation/index.ts
@@ -36,6 +36,7 @@ export type {
   EvaluatorName,
   RunExperimentOptions,
   ExperimentRunResult,
+  RegressionCheckResult,
   MemoryDesignArchiveEntry,
   MonitoringAlert,
   AlertSeverity,

--- a/src/evaluation/types.ts
+++ b/src/evaluation/types.ts
@@ -176,6 +176,27 @@ export interface ExperimentRunResult {
   timestamp: string;
 }
 
+/**
+ * Result of a regression check gate.
+ *
+ * A skipped check is never a passed check: when the experiment cannot run
+ * (LangSmith unconfigured, or the run produced no results), `passed` is
+ * false and `skipped` is true so callers can distinguish "gate ran and
+ * passed" from "gate did not run".
+ */
+export interface RegressionCheckResult {
+  /** True only when the experiment ran and all evaluators met thresholds */
+  passed: boolean;
+  /** True when the check did not run (unconfigured or no results) */
+  skipped: boolean;
+  /** Aggregate scores keyed by evaluator name (empty when skipped) */
+  scores: Record<string, number>;
+  /** Evaluators that scored below their threshold */
+  failedEvaluators: string[];
+  /** Human-readable explanation of the outcome */
+  details: string;
+}
+
 // =============================================================================
 // DGM Archive Types (Layer 4 → DGM bridge)
 // =============================================================================

--- a/tests/unit/experiment-runner.test.ts
+++ b/tests/unit/experiment-runner.test.ts
@@ -244,6 +244,7 @@ async function runTests() {
     const check = await runner.runRegressionCheck("regression-ds", async (input) => input);
 
     assertEqual(check.passed, true, "Should pass above thresholds");
+    assertEqual(check.skipped, false, "Should not be skipped when experiment ran");
     assertEqual(check.failedEvaluators.length, 0, "No failed evaluators");
     assert(check.details.includes("passed"), "Details should say passed");
   });
@@ -265,8 +266,20 @@ async function runTests() {
     const check = await runner.runRegressionCheck("regression-ds", async (input) => input);
 
     assertEqual(check.passed, false, "Should fail below thresholds");
+    assertEqual(check.skipped, false, "Should not be skipped when experiment ran");
     assert(check.failedEvaluators.includes("sessionQuality"), "sessionQuality should fail");
     assert(!check.failedEvaluators.includes("reasoningCoherence"), "reasoningCoherence should pass");
+  });
+
+  await test("runRegressionCheck on unconfigured runner is skipped and NOT passed", async () => {
+    const runner = new ExperimentRunner(null);
+    const check = await runner.runRegressionCheck("regression-ds", async (input) => input);
+
+    assertEqual(check.passed, false, "A skipped gate must not report passed");
+    assertEqual(check.skipped, true, "Should be marked skipped when LangSmith unconfigured");
+    assertEqual(check.failedEvaluators.length, 0, "No evaluators ran");
+    assertEqual(Object.keys(check.scores).length, 0, "No scores when skipped");
+    assert(check.details.includes("not configured"), "Details should explain why it was skipped");
   });
 
   await test("shared client is reused across instances", async () => {


### PR DESCRIPTION
## What

`ExperimentRunner.runRegressionCheck` returned `passed: true` with details "regression check skipped" when LangSmith was unconfigured — a disabled gate reporting itself as passing. This PR makes the skip explicit and non-passing.

## Changes

- `src/evaluation/types.ts`: new `RegressionCheckResult` interface with a required (non-optional) `skipped: boolean` field, exported from `src/evaluation/index.ts`.
- `src/evaluation/experiment-runner.ts`: `runRegressionCheck` now returns `{ passed: false, skipped: true }` when LangSmith is unconfigured, and also when a configured run produces no result (the `safe()` error path), with details distinguishing the two. Real runs return `skipped: false` with the existing pass/fail logic.
- `src/evaluation/__tests__/regression-check.test.ts` (new, vitest): asserts skipped-is-not-passed for the unconfigured and no-result paths, and `skipped: false` for real pass and fail runs.
- `tests/unit/experiment-runner.test.ts` (tsx script): adds the unconfigured case and `skipped: false` assertions to the existing pass/fail tests. No prior test asserted `passed: true` on the unconfigured path, so none was corrected or deleted — coverage was added.
- `.specs/deployment/v1-initiative.md`: Phase 3.5 line updated to record the implemented contract and the 0.4 decision (LangSmith stack stays; live in production, 2026-06-10).

## Scope notes

- `runRegressionCheck` has no production call sites (verified by repo-wide search); the contract change breaks no callers.
- The evaluation module is untouched otherwise — this changes only the gate's result contract.

## Verification

- `npx tsc --noEmit` clean
- `npx oxlint -c oxlint.json src/` clean
- `npx vitest run src/evaluation/__tests__/regression-check.test.ts` — 4 passed
- `npx tsx tests/unit/experiment-runner.test.ts` — 14 passed

SPEC-V1-INITIATIVE Phase 3.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)