### PR TITLE
fix(resources): serve gateway/operations catalog read handler

### DIFF
--- a/src/code-mode/__tests__/server-surface.test.ts
+++ b/src/code-mode/__tests__/server-surface.test.ts
@@ -56,6 +56,85 @@ describe("createMcpServer tool surface", () => {
     }
   });
 
+  it("lists and serves the gateway operations catalog resource", async () => {
+    const previousSupabaseUrl = process.env.SUPABASE_URL;
+    const previousSupabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    process.env.SUPABASE_URL = "https://example.supabase.co";
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "test-service-role-key";
+
+    const server = await createMcpServer({
+      storage: new InMemoryStorage(),
+      logger: silentLogger,
+    });
+    const client = new Client(
+      { name: "gateway-resource-test-client", version: "1.0.0" },
+      { capabilities: {} },
+    );
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+    try {
+      await server.connect(serverTransport);
+      await client.connect(clientTransport);
+
+      const { resources } = await client.listResources();
+      const listed = resources.find(
+        resource => resource.uri === "thoughtbox://gateway/operations",
+      );
+      expect(listed).toBeDefined();
+      expect(listed?.description).not.toContain("read_thoughts");
+
+      const { contents } = await client.readResource({
+        uri: "thoughtbox://gateway/operations",
+      });
+      expect(contents).toHaveLength(1);
+      expect(contents[0]?.mimeType).toBe("application/json");
+
+      const catalog = JSON.parse(contents[0]?.text as string) as {
+        version: string;
+        publicTools: Array<{ name: string }>;
+        operations: Record<string, Record<string, { title: string; description: string }>>;
+      };
+      expect(catalog.version).toBe("1.0.0");
+      expect(catalog.publicTools.map(tool => tool.name)).toEqual(
+        expect.arrayContaining(["thoughtbox_search", "thoughtbox_execute"]),
+      );
+      expect(Object.keys(catalog.operations)).toEqual(
+        expect.arrayContaining([
+          "thought",
+          "session",
+          "knowledge",
+          "notebook",
+          "theseus",
+          "ulysses",
+          "observability",
+          "branch",
+        ]),
+      );
+      expect(catalog.operations["thought"]?.["thoughtbox_thought"]?.description).toEqual(
+        expect.any(String),
+      );
+
+      const opDetail = await client.readResource({
+        uri: "thoughtbox://gateway/operations/thoughtbox_thought",
+      });
+      const op = JSON.parse(opDetail.contents[0]?.text as string) as {
+        module: string;
+        name: string;
+        title: string;
+      };
+      expect(op.module).toBe("thought");
+      expect(op.name).toBe("thoughtbox_thought");
+
+      await expect(
+        client.readResource({ uri: "thoughtbox://gateway/operations/no_such_op" }),
+      ).rejects.toThrow(/Unknown gateway operation/);
+    } finally {
+      await Promise.allSettled([client.close(), server.close()]);
+      restoreEnv("SUPABASE_URL", previousSupabaseUrl);
+      restoreEnv("SUPABASE_SERVICE_ROLE_KEY", previousSupabaseServiceKey);
+    }
+  });
+
   it("invokes the mock peer notebook pilot through the MCP client", async () => {
     const previousSupabaseUrl = process.env.SUPABASE_URL;
     const previousSupabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -1379,7 +1379,31 @@ mcp__thoughtbox__thoughtbox({
     })
   );
 
-
+  server.registerResource(
+    "gateway-operations",
+    "thoughtbox://gateway/operations",
+    {
+      description: "Complete catalog of operations available through the Code Mode gateway, grouped by tb SDK module (thought, session, knowledge, notebook, theseus, ulysses, observability, branch)",
+      mimeType: "application/json",
+    },
+    async (uri) => ({
+      contents: [
+        {
+          uri: uri.toString(),
+          mimeType: "application/json",
+          text: JSON.stringify(
+            {
+              version: "1.0.0",
+              publicTools: searchCatalog.publicTools,
+              operations: searchCatalog.operations,
+            },
+            null,
+            2
+          ),
+        },
+      ],
+    })
+  );
 
   server.registerResource(
     "init-operation",
@@ -1422,6 +1446,22 @@ mcp__thoughtbox__thoughtbox({
       const opDef = getHubOp(op as string);
       if (!opDef) throw new Error(`Unknown hub operation: ${op}`);
       return { contents: [{ uri: uri.href, mimeType: "application/json", text: JSON.stringify(opDef, null, 2) }] };
+    }
+  );
+
+  server.registerResource(
+    "gateway-operation",
+    new ResourceTemplate("thoughtbox://gateway/operations/{op}", { list: undefined }),
+    { description: "Individual operation schema from the Code Mode gateway catalog, looked up by name across tb SDK modules", mimeType: "application/json" },
+    async (uri, { op }) => {
+      const opName = op as string;
+      for (const [module, ops] of Object.entries(searchCatalog.operations)) {
+        const opDef = ops[opName];
+        if (opDef) {
+          return { contents: [{ uri: uri.href, mimeType: "application/json", text: JSON.stringify({ module, name: opName, ...opDef }, null, 2) }] };
+        }
+      }
+      throw new Error(`Unknown gateway operation: ${opName}`);
     }
   );
 
@@ -1737,7 +1777,7 @@ mcp__thoughtbox__thoughtbox({
       {
         uri: "thoughtbox://gateway/operations",
         name: "Gateway Operations Catalog",
-        description: "Complete catalog of gateway operations (thought, read_thoughts, get_structure, cipher, deep_analysis)",
+        description: "Complete catalog of operations available through the Code Mode gateway, grouped by tb SDK module (thought, session, knowledge, notebook, theseus, ulysses, observability, branch)",
         mimeType: "application/json",
       },
       {
@@ -1887,7 +1927,7 @@ mcp__thoughtbox__thoughtbox({
         {
           uriTemplate: "thoughtbox://gateway/operations/{op}",
           name: "Gateway Operation Detail",
-          description: "Individual gateway operation schema and examples",
+          description: "Individual operation schema from the Code Mode gateway catalog, looked up by name across tb SDK modules",
           mimeType: "application/json",
         },
         {


### PR DESCRIPTION
## What

`thoughtbox://gateway/operations` was advertised in the ListResources handler (and `thoughtbox://gateway/operations/{op}` in ListResourceTemplates), but no read handler served either URI — any client reading them got an error. SPEC-V1-INITIATIVE Phase 3.3 ("content exists; it is a missing wire").

## Changes

- `src/server-factory.ts`: register a static read handler for `thoughtbox://gateway/operations` returning JSON built from the existing Code Mode search catalog (`buildSearchCatalog()`): `version`, `publicTools`, and per-module `operations` (thought, session, knowledge, notebook, theseus, ulysses, observability, branch). Follows the same pattern as the session/init/knowledge/hub operations resources.
- Register a `thoughtbox://gateway/operations/{op}` template handler that resolves an operation name across catalog modules and returns its schema; unknown names throw.
- Fix the advertised descriptions: the old text promised `read_thoughts`, `get_structure`, `cipher`, and `deep_analysis`, which were removed along with the legacy gateway tool (`src/gateway/` no longer exists). Descriptions now state what is actually served; no operations were invented.
- `src/code-mode/__tests__/server-surface.test.ts`: new test asserting the resource is listed without the stale description, readable with parseable JSON matching the catalog, that per-op reads resolve (`thoughtbox_thought\` → module `thought`), and that unknown ops reject. Verified the test fails against the previous server-factory.ts.

## Tests

- `npx vitest run src/code-mode/__tests__/server-surface.test.ts` — 4 passed
- `npx tsc --noEmit` — clean
- `npx oxlint -c oxlint.json src/` — 0 warnings, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)