### PR TITLE
fix(tools): purge live-surface references to unregistered tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,13 +83,12 @@ docs: Update README with loops documentation
 
 ## Agent Teams — Thoughtbox Integration
 
-When participating in an Agent Team, bootstrap Thoughtbox as your reasoning substrate:
+When participating in an Agent Team, bootstrap Thoughtbox as your reasoning substrate through the Code Mode surface (the only registered MCP tools are `thoughtbox_search`, `thoughtbox_execute`, and `thoughtbox_peer_notebook`):
 
-1. **Quick join** (single call): `thoughtbox_hub { operation: "quick_join", args: { name: "<your-role>", workspaceId: "<ID from spawn prompt>", profile: "<COORDINATOR|ARCHITECT|DEBUGGER|SECURITY|RESEARCHER|REVIEWER>" } }`
-2. **Load cipher**: `thoughtbox_gateway { operation: "cipher" }`
-3. **Begin work** — record decisions as thoughts, proposals as hub proposals
+1. **Load the cipher**: read the `thoughtbox://cipher` MCP resource (reasoning-pattern shorthand, includes the multi-agent extension).
+2. **Begin work** — record decisions as thoughts via `tb.thought` inside `thoughtbox_execute`.
 
-Spawn prompt templates for teammates are in `.claude/team-prompts/`.
+Hub coordination (workspaces, problems, proposals, channels) is implemented but not yet exposed over MCP: `tb.hub.*` arrives with SPEC-V1-INITIATIVE Phase 4.1. Until then the hub is reachable only via the local-mode HTTP surface (`POST /hub/api`), and the spawn-prompt templates in `.claude/team-prompts/` cannot be executed as written — they are rewritten in Phase 4.5.
 
 ### What to Record as Thoughts
 - Key decisions and their reasoning

--- a/src/code-mode/search-index.ts
+++ b/src/code-mode/search-index.ts
@@ -269,25 +269,19 @@ export function buildSearchCatalog(): SearchCatalog {
       {
         name: "test-thoughtbox",
         description:
-          "Behavioral tests for the thoughtbox thinking tool (15 tests covering forward/backward thinking, branching, revisions, linked structure)",
+          "Behavioral tests for tb.thought via thoughtbox_execute (15 tests covering forward/backward thinking, branching, revisions, linked structure)",
         args: [],
       },
       {
         name: "test-notebook",
         description:
-          "Behavioral tests for the notebook literate programming tool (8 tests covering creation, cells, execution, export)",
-        args: [],
-      },
-      {
-        name: "test-mental-models",
-        description:
-          "Behavioral tests for the mental_models structured reasoning tool (6 tests covering discovery, retrieval, capability graph)",
+          "Behavioral tests for tb.notebook via thoughtbox_execute (8 tests covering creation, cells, execution, export)",
         args: [],
       },
       {
         name: "test-memory",
         description:
-          "Behavioral tests for the thoughtbox_knowledge tool (12 tests covering entities, observations, relations, graph traversal, stats)",
+          "Behavioral tests for tb.knowledge via thoughtbox_execute (12 tests covering entities, observations, relations, graph traversal, stats)",
         args: [],
       },
       {
@@ -405,21 +399,14 @@ export function buildSearchCatalog(): SearchCatalog {
         name: "Behavioral Tests: Thoughtbox",
         uri: "thoughtbox://tests/thoughtbox",
         description:
-          "Behavioral tests for the thoughtbox thinking tool (15 tests covering forward/backward thinking, branching, revisions, linked structure)",
+          "Behavioral tests for tb.thought via thoughtbox_execute (15 tests covering forward/backward thinking, branching, revisions, linked structure)",
         mimeType: "text/markdown",
       },
       {
         name: "Behavioral Tests: Notebook",
         uri: "thoughtbox://tests/notebook",
         description:
-          "Behavioral tests for the notebook literate programming tool (8 tests covering creation, cells, execution, export)",
-        mimeType: "text/markdown",
-      },
-      {
-        name: "Behavioral Tests: Mental Models",
-        uri: "thoughtbox://tests/mental-models",
-        description:
-          "Behavioral tests for the mental_models structured reasoning tool (6 tests covering discovery, retrieval, capability graph)",
+          "Behavioral tests for tb.notebook via thoughtbox_execute (8 tests covering creation, cells, execution, export)",
         mimeType: "text/markdown",
       },
       {
@@ -432,7 +419,7 @@ export function buildSearchCatalog(): SearchCatalog {
         name: "Behavioral Tests: Memory",
         uri: "thoughtbox://tests/memory",
         description:
-          "Behavioral tests for the thoughtbox_knowledge tool (12 tests covering entities, observations, relations, graph traversal, stats)",
+          "Behavioral tests for tb.knowledge via thoughtbox_execute (12 tests covering entities, observations, relations, graph traversal, stats)",
         mimeType: "text/markdown",
       },
     ],

--- a/src/hub/__tests__/hub-task-store.test.ts
+++ b/src/hub/__tests__/hub-task-store.test.ts
@@ -26,7 +26,7 @@ describe('FileSystemTaskStore', () => {
     const task = await store.createTask(
       { ttl: 300000 },
       'req-1',
-      { method: 'tools/call', params: { name: 'thoughtbox_hub', arguments: {} } }
+      { method: 'tools/call', params: { name: 'thoughtbox_execute', arguments: {} } }
     );
 
     expect(task.taskId).toBeDefined();

--- a/src/hub/hub-handler.ts
+++ b/src/hub/hub-handler.ts
@@ -97,12 +97,12 @@ export function createHubHandler(
 
       // Stage 1+: agent must be registered
       if (!agentId) {
-        throw new Error("Register first. Call: thoughtbox_hub { operation: 'register', name: '...' }");
+        throw new Error("Register first via the hub 'register' operation with a name.");
       }
 
       const agent = await identity.getAgent(agentId);
       if (!agent) {
-        throw new Error("Register first. Call: thoughtbox_hub { operation: 'register', name: '...' }");
+        throw new Error("Register first via the hub 'register' operation with a name.");
       }
 
       // Stage 1: registered but may not need workspace
@@ -143,7 +143,7 @@ export function createHubHandler(
       if (requiredStage === 2) {
         const workspaceId = args.workspaceId as string;
         if (!workspaceId) {
-          throw new Error("Join a workspace first. Call: thoughtbox_hub { operation: 'join_workspace', workspaceId: '...' }");
+          throw new Error("Join a workspace first via the hub 'join_workspace' operation with a workspaceId.");
         }
 
         // Check workspace membership — distinguish "no workspace at all" from "wrong workspace"
@@ -153,7 +153,7 @@ export function createHubHandler(
           const allWorkspaces = await storage.listWorkspaces();
           const inAny = allWorkspaces.some(ws => ws.agents.some(a => a.agentId === agentId));
           if (!inAny) {
-            throw new Error("Join a workspace first. Call: thoughtbox_hub { operation: 'join_workspace', workspaceId: '...' }");
+            throw new Error("Join a workspace first via the hub 'join_workspace' operation with a workspaceId.");
           }
           throw new Error('Not a member of this workspace');
         }

--- a/src/init/renderers/markdown.ts
+++ b/src/init/renderers/markdown.ts
@@ -39,9 +39,9 @@ Choose how you'd like to begin:
 
 Thoughtbox helps you think through complex problems with structured reasoning tools:
 
-- **thoughtbox** — Step-by-step reasoning with branching and revision
-- **notebook** — Literate programming notebooks with executable code
-- **mental_models** — Structured reasoning frameworks
+- **thoughtbox_search** — Query the operation/prompt/resource catalog
+- **thoughtbox_execute** — Run JavaScript against the \`tb\` SDK (thoughts, sessions, knowledge, notebooks)
+- **thoughtbox_peer_notebook** — Seed artifacts and invoke the brokered claim-extractor peer
 
 The init flow helps you load relevant context from prior sessions before beginning new work.
 `;
@@ -60,7 +60,7 @@ You don't have any exported sessions yet. Start by creating a new reasoning sess
 
 - \`thoughtbox://init/new\` — Start new work
 
-Sessions are automatically exported when you complete a reasoning chain using the \`thoughtbox\` tool.
+Sessions are automatically exported when you complete a reasoning chain via \`tb.thought\` in the \`thoughtbox_execute\` tool.
 `,
       };
     }
@@ -220,10 +220,9 @@ ${sessionPreviews || '*No prior sessions with this aspect yet.*'}
 
 The following tools are now available for your work:
 
-- \`thoughtbox\` — Step-by-step reasoning with branching and revision
-- \`notebook\` — Literate programming notebooks with executable code
-- \`mental_models\` — Structured reasoning frameworks
-- \`export_reasoning_chain\` — Persist completed sessions
+- \`thoughtbox_search\` — Query the operation/prompt/resource catalog
+- \`thoughtbox_execute\` — Run JavaScript against the \`tb\` SDK (thoughts, sessions, knowledge, notebooks)
+- \`thoughtbox_peer_notebook\` — Seed artifacts and invoke the brokered claim-extractor peer
 
 ## Suggested Start
 
@@ -231,17 +230,18 @@ ${suggestions}
 
 ---
 
-**Ready to begin.** Start a new reasoning session with appropriate tags:
+**Ready to begin.** Start a new reasoning session with appropriate tags via \`thoughtbox_execute\`:
 
-\`\`\`json
-{
-  "thought": "Your first thought...",
-  "thoughtNumber": 1,
-  "totalThoughts": 5,
-  "nextThoughtNeeded": true,
-  "sessionTitle": "${taskName}: ${aspect}",
-  "sessionTags": ["project:${projectName}", "task:${taskName}", "aspect:${aspect}"]
-}
+\`\`\`javascript
+async () => tb.thought({
+  thought: "Your first thought...",
+  thoughtType: "reasoning",
+  thoughtNumber: 1,
+  totalThoughts: 5,
+  nextThoughtNeeded: true,
+  sessionTitle: "${taskName}: ${aspect}",
+  sessionTags: ["project:${projectName}", "task:${taskName}", "aspect:${aspect}"]
+})
 \`\`\`
 `;
 
@@ -296,7 +296,7 @@ Structured tags enable:
 
 ---
 
-**Begin when ready.** Use the \`thoughtbox\` tool with appropriate tags to start your reasoning session.
+**Begin when ready.** Call \`tb.thought\` via the \`thoughtbox_execute\` tool with appropriate tags to start your reasoning session.
 `;
 
     return { markdown };

--- a/src/knowledge/tool.ts
+++ b/src/knowledge/tool.ts
@@ -41,16 +41,6 @@ export const knowledgeToolInputSchema = z.object({
 
 export type KnowledgeToolInput = z.infer<typeof knowledgeToolInputSchema>;
 
-export const KNOWLEDGE_TOOL = {
-  name: "thoughtbox_knowledge",
-  description: "Knowledge graph operations for tracking entities, relationships, and temporal observations.",
-  inputSchema: knowledgeToolInputSchema,
-  annotations: {
-    audience: ["assistant"],
-    priority: 0.8,
-  },
-};
-
 export class KnowledgeTool {
   constructor(private handler: KnowledgeHandler) {}
 

--- a/src/prompts/contents/parallel-verification.ts
+++ b/src/prompts/contents/parallel-verification.ts
@@ -15,18 +15,18 @@ MAX_BRANCHES: $MAX_BRANCHES (default: 3)
 
 ## EXECUTE NOW
 
-You are being asked to use the \`mcp__thoughtbox__thoughtbox\` tool to work through the TASK using parallel verification. This is not documentation to read — this is a workflow to execute immediately.
+You are being asked to use the \`thoughtbox_execute\` tool — writing code that calls \`tb.thought\` — to work through the TASK using parallel verification. This is not documentation to read — this is a workflow to execute immediately.
 
 ### Phase 1: Branch (Thoughts 1-4)
 
-**DO THIS NOW:** Use thoughtbox to identify 2-4 distinct hypotheses about the TASK.
+**DO THIS NOW:** Use \`tb.thought\` to identify 2-4 distinct hypotheses about the TASK.
 
-1. Call thoughtbox with thought 1: State the problem/question clearly
-2. Call thoughtbox with thought 2: Generate hypothesis H1
-3. Call thoughtbox with thought 3: Generate hypothesis H2 (must be genuinely different from H1)
-4. Call thoughtbox with thought 4: Generate hypothesis H3 if needed
+1. Call \`tb.thought\` with thought 1: State the problem/question clearly
+2. Call \`tb.thought\` with thought 2: Generate hypothesis H1
+3. Call \`tb.thought\` with thought 3: Generate hypothesis H2 (must be genuinely different from H1)
+4. Call \`tb.thought\` with thought 4: Generate hypothesis H3 if needed
 
-Use thoughtbox branching parameters:
+Use \`tb.thought\` branching parameters:
 - \`branchFromThought: 1\`
 - \`branchId: "h1"\`, \`"h2"\`, \`"h3"\`
 
@@ -36,31 +36,31 @@ Use thoughtbox branching parameters:
 
 For each branch:
 1. **Factual Grounding**: Use search/retrieval tools (Grep, Read, WebSearch, MCP tools) to find concrete evidence
-2. **Contextual Reflection**: Call thoughtbox to evaluate: Does this hypothesis hold given the evidence?
+2. **Contextual Reflection**: Call \`tb.thought\` to evaluate: Does this hypothesis hold given the evidence?
 
 Document findings in each branch's thought chain.
 
 ### Phase 3: Cross-Verify (Thoughts 11-13)
 
-**DO THIS NOW:** Use thoughtbox to compare branches.
+**DO THIS NOW:** Use \`tb.thought\` to compare branches.
 
-Call thoughtbox with thoughts that explicitly compare:
+Call \`tb.thought\` with thoughts that explicitly compare:
 - H1 vs H2: Where do they agree? Contradict?
 - H1 vs H3: Where do they agree? Contradict?
 - H2 vs H3: Where do they agree? Contradict?
 
 ### Phase 4: Prune (Thought 14)
 
-**DO THIS NOW:** Use thoughtbox to eliminate hypotheses that:
+**DO THIS NOW:** Use \`tb.thought\` to eliminate hypotheses that:
 - Were contradicted by factual evidence
 - Are logically inconsistent
 - Are strictly dominated by another hypothesis
 
-Call thoughtbox with \`isRevision: true\` to mark pruned branches.
+Call \`tb.thought\` with \`isRevision: true\` to mark pruned branches.
 
 ### Phase 5: Converge (Thought 15)
 
-**DO THIS NOW:** Use thoughtbox with \`nextThoughtNeeded: false\` to:
+**DO THIS NOW:** Use \`tb.thought\` with \`nextThoughtNeeded: false\` to:
 1. Select the surviving hypothesis (or synthesize compatible survivors)
 2. State your confidence level (high/medium/low)
 3. Provide the rationale for your conclusion
@@ -68,12 +68,18 @@ Call thoughtbox with \`isRevision: true\` to mark pruned branches.
 
 ## Begin Execution
 
-Start Phase 1 NOW. Call \`mcp__thoughtbox__thoughtbox\` with:
-- thought: "Analyzing task: [restate TASK]. Identifying distinct hypotheses..."
-- thoughtNumber: 1
-- totalThoughts: 15
-- nextThoughtNeeded: true
-- sessionTitle: "Parallel Verification: [TASK summary]"
+Start Phase 1 NOW. Call \`thoughtbox_execute\` with code:
+
+\`\`\`javascript
+async () => tb.thought({
+  thought: "Analyzing task: [restate TASK]. Identifying distinct hypotheses...",
+  thoughtType: "reasoning",
+  thoughtNumber: 1,
+  totalThoughts: 15,
+  nextThoughtNeeded: true,
+  sessionTitle: "Parallel Verification: [TASK summary]"
+})
+\`\`\`
 `;
 
 /**

--- a/src/resources/behavioral-tests-content.ts
+++ b/src/resources/behavioral-tests-content.ts
@@ -1,23 +1,30 @@
 /**
- * Behavioral test specifications for Thoughtbox MCP tools.
+ * Behavioral test specifications for the Thoughtbox Code Mode surface.
  * Served as both prompts (slash commands) and resources (URIs).
+ *
+ * Every call goes through the `thoughtbox_execute` tool: write JavaScript
+ * against the `tb` SDK (e.g. `async () => tb.thought({ ... })`).
  */
 
 export const BEHAVIORAL_TESTS = {
   thoughtbox: {
     name: "test-thoughtbox",
     uri: "thoughtbox://tests/thoughtbox",
-    description: "Behavioral tests for the thoughtbox thinking tool (15 tests covering forward/backward thinking, branching, revisions, linked structure)",
-    content: `# Thoughtbox Tool - Behavioral Tests
+    description: "Behavioral tests for tb.thought via thoughtbox_execute (15 tests covering forward/backward thinking, branching, revisions, linked structure)",
+    content: `# tb.thought - Behavioral Tests
 
-Workflows for Claude to execute when verifying the thoughtbox thinking tool functions correctly.
+Workflows for Claude to execute when verifying structured reasoning works correctly.
+
+**Surface:** All calls go through the \`thoughtbox_execute\` tool. Write code against the
+\`tb\` SDK, e.g. \`async () => tb.thought({ thought: "...", thoughtType: "reasoning", thoughtNumber: 1, totalThoughts: 3, nextThoughtNeeded: true })\`.
+Every \`tb.thought\` call requires a \`thoughtType\` (use \`"reasoning"\` unless a test says otherwise).
 
 ## Test 1: Basic Forward Thinking Flow
 
 **Goal:** Verify sequential thought progression works.
 
 **Steps:**
-1. Call \`thoughtbox\` with thought 1 of 3, nextThoughtNeeded: true
+1. Call \`tb.thought\` with thought 1 of 3, nextThoughtNeeded: true
 2. Verify response includes thoughtNumber, totalThoughts, nextThoughtNeeded
 3. Call thought 2 of 3
 4. Call thought 3 of 3 with nextThoughtNeeded: false
@@ -41,7 +48,7 @@ Workflows for Claude to execute when verifying the thoughtbox thinking tool func
 **Expected:**
 - Session auto-creates at first thought (thought 5), not waiting for thought 1
 - \`sessionId\` returned in response from first call
-- Tool accepts backward progression without error
+- \`tb.thought\` accepts backward progression without error
 
 ---
 
@@ -94,7 +101,7 @@ Workflows for Claude to execute when verifying the thoughtbox thinking tool func
 1. Start with thought 1 of 5
 2. At thought 4, realize more needed - set totalThoughts to 10
 3. Continue to thought 10
-4. Verify tool accepts the adjustment
+4. Verify \`tb.thought\` accepts the adjustment
 
 **Expected:** Flexible estimation, not rigid planning
 
@@ -105,7 +112,7 @@ Workflows for Claude to execute when verifying the thoughtbox thinking tool func
 **Goal:** Verify input validation.
 
 **Steps:**
-1. Call without required field (thought) - should error
+1. Call \`tb.thought\` without required field (thought) - should error
 2. Call without thoughtNumber - should error
 3. Call with thoughtNumber > totalThoughts - should auto-adjust totalThoughts
 4. Call with invalid types - should error with clear message
@@ -120,7 +127,7 @@ Workflows for Claude to execute when verifying the thoughtbox thinking tool func
 
 **Steps:**
 1. Create thoughts 1, 2, 3 sequentially with nextThoughtNeeded: true
-2. Call session export tool to export session
+2. Call \`tb.session.export(sessionId, "json")\` to export the session
 3. Verify thoughts are stored correctly
 
 **Expected:**
@@ -138,7 +145,7 @@ Workflows for Claude to execute when verifying the thoughtbox thinking tool func
 1. Create thoughts 1-3 on main chain
 2. Create thought 4 with \`branchFromThought: 3\`, \`branchId: "option-a"\`
 3. Create thought 5 with \`branchFromThought: 3\`, \`branchId: "option-b"\`
-4. Export session and examine node 3
+4. Export the session via \`tb.session.export(sessionId, "json")\` and examine node 3
 
 **Expected:**
 - Node 3 has \`next: ["{sessionId}:4", "{sessionId}:5"]\` (two children)
@@ -154,7 +161,7 @@ Workflows for Claude to execute when verifying the thoughtbox thinking tool func
 **Steps:**
 1. Create thoughts 1-3
 2. Create thought 4 with \`isRevision: true\`, \`revisesThought: 2\`
-3. Export session
+3. Export the session via \`tb.session.export(sessionId, "json")\`
 
 **Expected:**
 - Node 4 has \`revisesNode: "{sessionId}:2"\`
@@ -164,7 +171,7 @@ Workflows for Claude to execute when verifying the thoughtbox thinking tool func
 
 ## Test 11: Auto-Export on Session Close
 
-**Goal:** Verify session automatically exports to filesystem when complete.
+**Goal:** Verify session automatically exports to storage when complete.
 
 **Steps:**
 1. Create thoughts 1-3 with \`nextThoughtNeeded: true\`
@@ -177,13 +184,13 @@ Workflows for Claude to execute when verifying the thoughtbox thinking tool func
 
 ---
 
-## Test 12: Manual Export Tool
+## Test 12: Manual Export
 
-**Goal:** Verify \`export_reasoning_chain\` tool exports without closing session.
+**Goal:** Verify \`tb.session.export\` exports without closing the session.
 
 **Steps:**
 1. Create thoughts 1-3 with \`nextThoughtNeeded: true\` (session still open)
-2. Call \`export_reasoning_chain\` tool
+2. Call \`tb.session.export(sessionId)\`
 3. Create thought 4 (should work - session still active)
 
 **Expected:** Export without closing session
@@ -197,7 +204,7 @@ Workflows for Claude to execute when verifying the thoughtbox thinking tool func
 **Steps:**
 1. Create thought 1, capture sessionId from response
 2. Create thoughts 2-3
-3. Export session and verify thoughts have consistent structure
+3. Export the session and verify thoughts have consistent structure
 
 **Expected:**
 - Session ID returned with each thought response
@@ -214,7 +221,7 @@ Workflows for Claude to execute when verifying the thoughtbox thinking tool func
 **Steps:**
 1. Start at thought 5 of 5
 2. Create thoughts 4, 3, 2, 1 in sequence
-3. Export session
+3. Export the session
 
 **Expected:** Chain flows 5←4←3←2←1 by creation order
 
@@ -229,7 +236,7 @@ Workflows for Claude to execute when verifying the thoughtbox thinking tool func
 2. Create thought 5 of 10 (skipping 2-4)
 3. Create thought 8 of 10 (skipping 6-7)
 4. Create thought 10 of 10
-5. Export session
+5. Export the session
 
 **Expected:** Chain is contiguous (1←5←8←10) despite thought number gaps
 `
@@ -238,19 +245,22 @@ Workflows for Claude to execute when verifying the thoughtbox thinking tool func
   notebook: {
     name: "test-notebook",
     uri: "thoughtbox://tests/notebook",
-    description: "Behavioral tests for the notebook literate programming tool (8 tests covering creation, cells, execution, export)",
-    content: `# Notebook Toolhost - Behavioral Tests
+    description: "Behavioral tests for tb.notebook via thoughtbox_execute (8 tests covering creation, cells, execution, export)",
+    content: `# tb.notebook - Behavioral Tests
 
-Workflows for Claude to execute when verifying the notebook toolhost functions correctly.
+Workflows for Claude to execute when verifying the notebook module functions correctly.
+
+**Surface:** All calls go through the \`thoughtbox_execute\` tool. Write code against the
+\`tb.notebook\` module, e.g. \`async () => tb.notebook.create({ title: "Test", language: "typescript" })\`.
 
 ## Test 1: Create and List Flow
 
 **Goal:** Verify notebook creation and discovery.
 
 **Steps:**
-1. Call \`notebook\` with operation \`create\`, args: { title: "Test Notebook", language: "typescript" }
+1. Call \`tb.notebook.create({ title: "Test Notebook", language: "typescript" })\`
 2. Verify response includes notebookId, title, language, cells array
-3. Call operation \`list\`
+3. Call \`tb.notebook.list()\`
 4. Verify created notebook appears in list with correct metadata
 
 **Expected:** Notebook created with unique ID, discoverable via list
@@ -263,10 +273,10 @@ Workflows for Claude to execute when verifying the notebook toolhost functions c
 
 **Steps:**
 1. Create a notebook
-2. Add title cell: operation \`add_cell\`, cellType: "title", content: "My Analysis"
+2. Add title cell: \`tb.notebook.addCell({ notebookId, cellType: "title", content: "My Analysis" })\`
 3. Add markdown cell: cellType: "markdown", content: "## Introduction..."
 4. Add code cell: cellType: "code", content: "console.log('hello')", filename: "hello.ts"
-5. Call operation \`list_cells\` with notebookId
+5. Call \`tb.notebook.listCells({ notebookId })\`
 6. Verify all three cells present with correct types
 
 **Expected:** All cell types work, retrievable by ID
@@ -280,7 +290,7 @@ Workflows for Claude to execute when verifying the notebook toolhost functions c
 **Steps:**
 1. Create notebook with language: "typescript"
 2. Add code cell: \`const x = 1 + 1; console.log(x);\`
-3. Call operation \`run_cell\` with notebookId and cellId
+3. Call \`tb.notebook.runCell({ notebookId, cellId })\`
 4. Verify output contains "2"
 5. Verify cell status is "completed"
 
@@ -294,8 +304,8 @@ Workflows for Claude to execute when verifying the notebook toolhost functions c
 
 **Steps:**
 1. Create notebook with a code cell
-2. Call operation \`update_cell\` with new content
-3. Call \`get_cell\` to verify content changed
+2. Call \`tb.notebook.updateCell({ notebookId, cellId, content })\` with new content
+3. Call \`tb.notebook.getCell({ notebookId, cellId })\` to verify content changed
 4. Run the updated cell
 5. Verify new output reflects updated code
 
@@ -309,9 +319,9 @@ Workflows for Claude to execute when verifying the notebook toolhost functions c
 
 **Steps:**
 1. Create notebook with title, markdown, and code cells
-2. Call operation \`export\` with notebookId
+2. Call \`tb.notebook.export({ notebookId })\`
 3. Verify response includes content in .src.md format
-4. Call operation \`load\` with the exported content string
+4. Call \`tb.notebook.load({ content })\` with the exported content string
 5. Verify loaded notebook has same cells as original
 
 **Expected:** Lossless roundtrip through .src.md format
@@ -323,7 +333,7 @@ Workflows for Claude to execute when verifying the notebook toolhost functions c
 **Goal:** Verify template instantiation.
 
 **Steps:**
-1. Call \`create\` with template: "sequential-feynman", title: "React Hooks"
+1. Call \`tb.notebook.create({ template: "sequential-feynman", title: "React Hooks", language: "typescript" })\`
 2. Verify notebook created with pre-populated cells
 3. Cells should include scaffolded structure from template
 
@@ -338,7 +348,7 @@ Workflows for Claude to execute when verifying the notebook toolhost functions c
 **Steps:**
 1. Create notebook
 2. Add package.json cell or update existing with dependencies
-3. Call operation \`install_deps\` with notebookId
+3. Call \`tb.notebook.installDeps({ notebookId })\`
 4. Verify installation completes
 5. Add code cell that uses installed dependency
 6. Run cell, verify it works
@@ -352,126 +362,26 @@ Workflows for Claude to execute when verifying the notebook toolhost functions c
 **Goal:** Verify graceful error handling.
 
 **Steps:**
-1. Call \`run_cell\` with nonexistent notebookId - should error
-2. Call \`get_cell\` with invalid cellId - should error
-3. Call \`add_cell\` with invalid cellType - should error
+1. Call \`tb.notebook.runCell\` with nonexistent notebookId - should error
+2. Call \`tb.notebook.getCell\` with invalid cellId - should error
+3. Call \`tb.notebook.addCell\` with invalid cellType - should error
 4. Run code cell with syntax error - should show error in output
 
 **Expected:** Clear errors, failed cells have error info
 `
   },
 
-  mentalModels: {
-    name: "test-mental-models",
-    uri: "thoughtbox://tests/mental-models",
-    description: "Behavioral tests for the mental_models structured reasoning tool (6 tests covering discovery, retrieval, capability graph)",
-    content: `# Mental Models Toolhost - Behavioral Tests
-
-Workflows for Claude to execute when verifying the mental_models toolhost functions correctly.
-
-## Test 1: Discovery Flow
-
-**Goal:** Verify an agent can discover what's available.
-
-**Steps:**
-1. Call \`mental_models\` with operation \`list_tags\`
-2. Verify response contains 9 tags with descriptions
-3. Pick a tag (e.g., "debugging") and call \`list_models\` with that tag filter
-4. Verify only models with that tag are returned
-
-**Expected:** Agent can navigate from tags → filtered models
-
----
-
-## Test 2: Model Retrieval Flow
-
-**Goal:** Verify an agent can retrieve and use a mental model.
-
-**Steps:**
-1. Call \`mental_models\` with operation \`get_model\`, model \`five-whys\`
-2. Verify response contains:
-   - Name and title
-   - Tags array
-   - Content with "# Five Whys" heading
-   - "## When to Use" section
-   - "## Process" section with numbered steps
-3. Content should be process scaffolding (HOW to think), not analysis
-
-**Expected:** Full prompt content suitable for guiding reasoning
-
----
-
-## Test 3: Error Handling Flow
-
-**Goal:** Verify graceful error handling.
-
-**Steps:**
-1. Call \`get_model\` without a model name - should error with available models list
-2. Call \`get_model\` with invalid model name - should error with available models list
-3. Call \`list_models\` with invalid tag - should error with available tags list
-4. Call unknown operation - should error with available operations list
-
-**Expected:** All errors include guidance on valid options
-
----
-
-## Test 4: Capability Graph Flow
-
-**Goal:** Verify capability graph can initialize knowledge graph.
-
-**Steps:**
-1. Call \`mental_models\` with operation \`get_capability_graph\`
-2. Verify response contains:
-   - \`entities\` array with thoughtbox_server, tools, tags, and models
-   - \`relations\` array with provides, contains, tagged_with relationships
-   - \`usage\` object with step-by-step instructions
-3. Optionally: Use returned data with \`memory_create_entities\` and \`memory_create_relations\`
-
-**Expected:** Structured data ready for knowledge graph initialization
-
----
-
-## Test 5: Tag Coverage Flow
-
-**Goal:** Verify tag taxonomy covers use cases.
-
-**Steps:**
-1. Call \`list_tags\` to see all categories
-2. For each tag, call \`list_models\` with that tag
-3. Verify each tag has at least one model
-4. Verify model descriptions match tag intent
-
-**Expected:** Complete coverage - no orphan tags or miscategorized models
-
----
-
-## Test 6: Content Quality Flow
-
-**Goal:** Verify mental model content follows "infrastructure not intelligence" principle.
-
-**Steps:**
-1. Retrieve several models (rubber-duck, pre-mortem, inversion)
-2. For each, verify content:
-   - Has clear process steps (numbered or bulleted)
-   - Explains WHEN to use
-   - Provides examples of APPLICATION
-   - Lists anti-patterns or common mistakes
-   - Does NOT perform reasoning or draw conclusions
-
-**Expected:** Process scaffolds, not analysis
-`
-  },
-
   memory: {
     name: "test-memory",
     uri: "thoughtbox://tests/memory",
-    description: "Behavioral tests for the thoughtbox_knowledge tool (12 tests covering entities, observations, relations, graph traversal, stats)",
+    description: "Behavioral tests for tb.knowledge via thoughtbox_execute (12 tests covering entities, observations, relations, graph traversal, stats)",
     content: `# Knowledge Graph - Behavioral Tests
 
-Workflows for verifying the \`thoughtbox_knowledge\` tool functions correctly.
+Workflows for verifying the \`tb.knowledge\` module functions correctly.
 
-**Tool:** \`thoughtbox_knowledge\`
-**Operations:** \`knowledge_create_entity\`, \`knowledge_get_entity\`, \`knowledge_list_entities\`, \`knowledge_add_observation\`, \`knowledge_create_relation\`, \`knowledge_query_graph\`, \`knowledge_stats\`
+**Surface:** All calls go through the \`thoughtbox_execute\` tool. Write code against the
+\`tb.knowledge\` module, e.g. \`async () => tb.knowledge.createEntity({ name: "...", type: "Concept", label: "..." })\`.
+**Operations:** \`createEntity\`, \`getEntity\`, \`listEntities\`, \`addObservation\`, \`createRelation\`, \`queryGraph\`, \`stats\`
 **Entity types:** Insight, Concept, Workflow, Decision, Agent
 **Relation types:** RELATES_TO, BUILDS_ON, CONTRADICTS, EXTRACTED_FROM, APPLIED_IN, LEARNED_BY, DEPENDS_ON, SUPERSEDES, MERGED_FROM
 
@@ -482,8 +392,7 @@ Workflows for verifying the \`thoughtbox_knowledge\` tool functions correctly.
 **Goal:** Verify entity creation with name, type, and label.
 
 **Steps:**
-1. Call \`thoughtbox_knowledge\` with:
-   \`{ operation: "knowledge_create_entity", name: "test-entity-001", type: "Concept", label: "Test Entity" }\`
+1. Call \`tb.knowledge.createEntity({ name: "test-entity-001", type: "Concept", label: "Test Entity" })\`
 2. Verify response includes:
    - \`entity_id\` (UUID)
    - \`name\` matches \`"test-entity-001"\`
@@ -500,7 +409,7 @@ Workflows for verifying the \`thoughtbox_knowledge\` tool functions correctly.
 
 **Steps:**
 1. Create an entity, capture the \`entity_id\`
-2. Call \`{ operation: "knowledge_get_entity", entity_id: "<id>" }\`
+2. Call \`tb.knowledge.getEntity("<id>")\`
 3. Verify response includes all entity fields:
    - \`id\`, \`name\`, \`type\`, \`label\`
    - \`created_at\`, \`updated_at\`
@@ -518,9 +427,9 @@ Workflows for verifying the \`thoughtbox_knowledge\` tool functions correctly.
 
 **Steps:**
 1. Create 2+ entities with different types (Concept, Insight, Decision)
-2. Call \`{ operation: "knowledge_list_entities" }\`
+2. Call \`tb.knowledge.listEntities()\`
 3. Verify \`count\` >= 2, \`entities\` array present
-4. Call \`{ operation: "knowledge_list_entities", types: ["Concept"] }\`
+4. Call \`tb.knowledge.listEntities({ types: ["Concept"] })\`
 5. Verify only Concept entities returned
 6. Call with \`name_pattern: "test-entity"\`
 7. Verify only matching entities returned
@@ -535,15 +444,15 @@ Workflows for verifying the \`thoughtbox_knowledge\` tool functions correctly.
 
 **Steps:**
 1. Create an entity, capture \`entity_id\`
-2. Call \`{ operation: "knowledge_add_observation", entity_id: "<id>", content: "This entity was tested" }\`
+2. Call \`tb.knowledge.addObservation({ entity_id: "<id>", content: "This entity was tested" })\`
 3. Verify response includes:
    - \`observation_id\` (UUID)
    - \`entity_id\` matches
    - \`added_at\` (timestamp)
-4. Call \`knowledge_get_entity\` with the entity ID
+4. Call \`tb.knowledge.getEntity\` with the entity ID
 5. Verify the observation appears in the entity's observations array
 
-**Expected:** Observation attached to entity, retrievable via get_entity
+**Expected:** Observation attached to entity, retrievable via getEntity
 
 ---
 
@@ -553,7 +462,7 @@ Workflows for verifying the \`thoughtbox_knowledge\` tool functions correctly.
 
 **Steps:**
 1. Create entity A (type: Concept) and entity B (type: Insight)
-2. Call \`{ operation: "knowledge_create_relation", from_id: "<B-id>", to_id: "<A-id>", relation_type: "BUILDS_ON" }\`
+2. Call \`tb.knowledge.createRelation({ from_id: "<B-id>", to_id: "<A-id>", relation_type: "BUILDS_ON" })\`
 3. Verify response includes:
    - \`relation_id\` (UUID)
    - \`from_id\` matches entity B
@@ -571,7 +480,7 @@ Workflows for verifying the \`thoughtbox_knowledge\` tool functions correctly.
 
 **Steps:**
 1. Create entities A and B with a BUILDS_ON relation (A → B)
-2. Call \`{ operation: "knowledge_query_graph", start_entity_id: "<A-id>" }\`
+2. Call \`tb.knowledge.queryGraph({ start_entity_id: "<A-id>" })\`
 3. Verify response includes:
    - \`entity_count\` >= 2
    - \`relation_count\` >= 1
@@ -588,7 +497,7 @@ Workflows for verifying the \`thoughtbox_knowledge\` tool functions correctly.
 
 **Steps:**
 1. Create entities A, B, C with relations A→B→C
-2. Call \`{ operation: "knowledge_query_graph", start_entity_id: "<A-id>", max_depth: 1 }\`
+2. Call \`tb.knowledge.queryGraph({ start_entity_id: "<A-id>", max_depth: 1 })\`
 3. Verify only A and B returned (not C)
 4. Call with \`max_depth: 2\`
 5. Verify A, B, and C all returned
@@ -605,7 +514,7 @@ Workflows for verifying the \`thoughtbox_knowledge\` tool functions correctly.
 1. Create entities A, B, C
 2. Create relation A → B type BUILDS_ON
 3. Create relation A → C type CONTRADICTS
-4. Call \`{ operation: "knowledge_query_graph", start_entity_id: "<A-id>", relation_types: ["BUILDS_ON"] }\`
+4. Call \`tb.knowledge.queryGraph({ start_entity_id: "<A-id>", relation_types: ["BUILDS_ON"] })\`
 5. Verify B is in results but C is NOT
 6. Call with \`relation_types: ["CONTRADICTS"]\`
 7. Verify C is in results but B is NOT
@@ -619,10 +528,10 @@ Workflows for verifying the \`thoughtbox_knowledge\` tool functions correctly.
 **Goal:** Verify knowledge graph statistics.
 
 **Steps:**
-1. Call \`{ operation: "knowledge_stats" }\`
+1. Call \`tb.knowledge.stats()\`
 2. Verify response includes entity count and relation count
 3. Create a new entity
-4. Call \`knowledge_stats\` again
+4. Call \`tb.knowledge.stats()\` again
 5. Verify entity count increased by 1
 
 **Expected:** Accurate counts reflecting current graph state
@@ -634,16 +543,16 @@ Workflows for verifying the \`thoughtbox_knowledge\` tool functions correctly.
 **Goal:** Verify clear errors for invalid operations.
 
 **Steps:**
-1. Call \`knowledge_create_entity\` without required \`name\` field — should error
-2. Call \`knowledge_get_entity\` with nonexistent \`entity_id\` — should error "not found"
-3. Call \`knowledge_create_relation\` with nonexistent \`from_id\` — should error
-4. Call \`knowledge_add_observation\` with nonexistent \`entity_id\` — should error
+1. Call \`tb.knowledge.createEntity\` without required \`name\` field — should error
+2. Call \`tb.knowledge.getEntity\` with nonexistent \`entity_id\` — should error "not found"
+3. Call \`tb.knowledge.createRelation\` with nonexistent \`from_id\` — should error
+4. Call \`tb.knowledge.addObservation\` with nonexistent \`entity_id\` — should error
 
 **Expected:** Each error is specific, actionable, and non-destructive
 
 ---
 
-## Test 11: UNIQUE Collision on create_entity
+## Test 11: UNIQUE Collision on createEntity
 
 **Goal:** Verify duplicate entity name+type returns existing entity.
 
@@ -651,7 +560,7 @@ Workflows for verifying the \`thoughtbox_knowledge\` tool functions correctly.
 1. Create entity with name "collision-test", type "Concept", label "First"
 2. Create entity with same name "collision-test", type "Concept", label "Second"
 3. Verify second call returns the SAME entity_id as the first
-4. Use \`knowledge_add_observation\` to add corroborating evidence to the existing entity
+4. Use \`tb.knowledge.addObservation\` to add corroborating evidence to the existing entity
 
 **Expected:** No error on collision; existing entity returned for deduplication
 
@@ -663,9 +572,9 @@ Workflows for verifying the \`thoughtbox_knowledge\` tool functions correctly.
 
 **Steps:**
 1. **Create entities:**
-   - Entity A: \`{ operation: "knowledge_create_entity", name: "arch-patterns", type: "Concept", label: "Architecture Patterns" }\`
-   - Entity B: \`{ operation: "knowledge_create_entity", name: "microservices-insight", type: "Insight", label: "Microservices Trade-offs" }\`
-   - Entity C: \`{ operation: "knowledge_create_entity", name: "monolith-decision", type: "Decision", label: "Stay Monolith" }\`
+   - Entity A: \`tb.knowledge.createEntity({ name: "arch-patterns", type: "Concept", label: "Architecture Patterns" })\`
+   - Entity B: \`tb.knowledge.createEntity({ name: "microservices-insight", type: "Insight", label: "Microservices Trade-offs" })\`
+   - Entity C: \`tb.knowledge.createEntity({ name: "monolith-decision", type: "Decision", label: "Stay Monolith" })\`
 2. **Add observations:**
    - On A: \`"Common patterns include microservices, monolith, serverless"\`
    - On B: \`"Microservices add network complexity but improve team autonomy"\`
@@ -679,118 +588,10 @@ Workflows for verifying the \`thoughtbox_knowledge\` tool functions correctly.
    - From C, max_depth: 1: verify only B found
 5. **Verify stats:** entity_count >= 3, relation_count >= 3
 6. **Verify consistency:**
-   - \`knowledge_get_entity\` for each verifies observations attached
-   - \`knowledge_list_entities\` with types: ["Decision"] returns only C
+   - \`tb.knowledge.getEntity\` for each verifies observations attached
+   - \`tb.knowledge.listEntities({ types: ["Decision"] })\` returns only C
 
 **Expected:** Complete lifecycle — create, observe, link, traverse, query, stats all consistent
 `
-  },
-  hub: {
-    name: "test-hub",
-    uri: "thoughtbox://tests/hub",
-    description: "Behavioral tests for the Hub multi-agent collaboration tool (6 tests covering identity registry, shared sessions, proposal review, and cross-agent workflows)",
-    content: `# Hub Tool - Behavioral Tests
-
-Workflows for verifying Hub multi-agent collaboration, with focus on the
-connection-scoped identity registry that allows multiple agents to share
-a single MCP session while maintaining distinct identities.
-
-## Test 1: Multi-Agent Registration in Shared Session
-
-**Goal:** Verify two agents can register in the same MCP session and keep distinct identities.
-
-**Steps:**
-1. Call \`thoughtbox_hub\` with operation \`register\`, name: "coordinator"
-2. Note the returned agentId (call it coordId)
-3. Call \`register\` again with name: "auditor"
-4. Note the returned agentId (call it auditorId)
-5. Call \`whoami\` with agentId: coordId
-6. Call \`whoami\` with agentId: auditorId
-
-**Expected:**
-- coordId !== auditorId
-- Each whoami returns the correct agent's identity
-- First register becomes the session default
-
----
-
-## Test 2: Per-Call Identity Override
-
-**Goal:** Verify agents identify themselves per-call via agentId.
-
-**Steps:**
-1. Register "alice" and "bob" in the same session
-2. Alice creates a workspace (default identity or explicit agentId)
-3. Bob joins via \`join_workspace\` with agentId: bobId, workspaceId: ...
-4. Bob creates a problem with agentId: bobId, workspaceId: ..., title: ..., description: ...
-5. Alice posts a message with agentId: aliceId, workspaceId: ..., problemId: ..., content: ...
-
-**Expected:** Each operation attributed to the correct agent
-
----
-
-## Test 3: Cross-Agent Proposal Review (The Core Bug)
-
-**Goal:** Verify the exact scenario that was broken — proposal review across agents sharing a session.
-
-**Steps:**
-1. Register "coordinator" and "auditor" in the same session
-2. Coordinator creates workspace and problem
-3. Auditor joins, claims problem, and creates a proposal
-4. Coordinator reviews the proposal with agentId: coordId, ..., verdict: "approve"
-5. Coordinator merges the proposal
-
-**Expected:**
-- Review succeeds (no self-review error)
-- Merge succeeds (coordinator is recognized as coordinator, not auditor)
-- Problem status becomes "resolved"
-- Proposal status becomes "merged"
-
----
-
-## Test 4: Unregistered Agent ID Rejection
-
-**Goal:** Verify the anti-spoofing guard rejects unknown agentIds.
-
-**Steps:**
-1. Register "alice" in a session
-2. Call \`whoami\` with agentId: "fake-agent-id"
-
-**Expected:** Error: "Agent fake-agent-id not registered in this session. Call register first."
-
----
-
-## Test 5: quick_join Identity Registration
-
-**Goal:** Verify quick_join adds the agent to the session identity registry.
-
-**Steps:**
-1. Register "coordinator", create a workspace
-2. Call \`quick_join\` with name: "debugger", workspaceId: ...
-3. Call \`whoami\` with agentId: debuggerAgentId
-4. Debugger creates a problem using its own agentId
-
-**Expected:**
-- quick_join returns a distinct agentId
-- Debugger can use its agentId in subsequent calls
-- Operations are attributed to the debugger, not the coordinator
-
----
-
-## Test 6: Env-Var Agent Coexistence
-
-**Goal:** Verify env-var-resolved agents coexist with dynamically registered agents.
-
-**Steps:**
-1. Create handler with envAgentId and envAgentName set
-2. Verify env agent can call \`whoami\` without explicit register
-3. Register a second agent ("sub-agent") in the same session
-4. Sub-agent calls operations with agentId: subAgentId
-5. Env agent calls operations with agentId: envAgentId
-
-**Expected:** Both agents operate independently, neither overwrites the other
-`
   }
 } as const;
-
-export type BehavioralTestKey = keyof typeof BEHAVIORAL_TESTS;

--- a/src/resources/evolution-check-content.ts
+++ b/src/resources/evolution-check-content.ts
@@ -77,15 +77,15 @@ A thought should NOT be updated if:
 
 \`\`\`typescript
 // Retrieve prior thoughts (you do this, not sub-agent)
-const sessionResult = await mcp__thoughtbox__session({
-  operation: "get",
-  args: { sessionId: "<YOUR_SESSION_ID>" }
-});
+// Via the thoughtbox_execute tool:
+async () => {
+  const sessionResult = await tb.session.get("<YOUR_SESSION_ID>");
 
-// Extract thought content for sub-agent
-const priorThoughts = sessionResult.thoughts
-  .map((t, i) => \`S\${i+1}: \${t.thought}\`)
-  .join("\\n");
+  // Extract thought content for sub-agent
+  return sessionResult.thoughts
+    .map((t, i) => \`S\${i + 1}: \${t.thought}\`)
+    .join("\\n");
+}
 \`\`\`
 
 ### Step 2: Spawn Evolution Checker
@@ -105,8 +105,10 @@ const priorThoughts = sessionResult.thoughts
 For each thought marked UPDATE:
 
 \`\`\`typescript
-await mcp__thoughtbox__thoughtbox({
+// Via the thoughtbox_execute tool:
+async () => tb.thought({
   thought: "REVISED: [Original thought content] — Context updated: [How new insight relates]",
+  thoughtType: "reasoning",
   thoughtNumber: [original thought number],
   totalThoughts: [current total],
   nextThoughtNeeded: false,
@@ -194,7 +196,7 @@ Key differences from paper:
 
 - \`thoughtbox://cipher\` — Token-efficient notation system
 - \`subagent-summarize\` — Context isolation for session retrieval
-- \`thoughtbox_session\` with operation \`get\` — Direct session retrieval
-- \`thoughtbox_thought\` with \`isRevision: true\` — Apply revisions
+- \`tb.session.get(sessionId)\` via \`thoughtbox_execute\` — Direct session retrieval
+- \`tb.thought\` with \`isRevision: true\` via \`thoughtbox_execute\` — Apply revisions
 - A-Mem paper: https://arxiv.org/abs/2502.12110
 `;

--- a/src/resources/patterns-cookbook-content.ts
+++ b/src/resources/patterns-cookbook-content.ts
@@ -262,13 +262,14 @@ The guide is also automatically provided:
 
 ## Accessing Thoughtbox
 
-### Direct Tool Access
+### Code Mode Access
 
-The standard way to use thoughtbox (when the tool is visible):
+Call \`tb.thought\` through the \`thoughtbox_execute\` tool:
 
 \`\`\`javascript
-mcp__thoughtbox__thoughtbox({
+async () => tb.thought({
   thought: "Your reasoning step",
+  thoughtType: "reasoning",
   thoughtNumber: 1,
   totalThoughts: 10,
   nextThoughtNeeded: true

--- a/src/resources/server-architecture-content.ts
+++ b/src/resources/server-architecture-content.ts
@@ -13,16 +13,21 @@ export const SERVER_ARCHITECTURE_GUIDE = `<!-- srcbook:{"language":"typescript",
 
 ## Introduction
 
-Thoughtbox is an MCP (Model Context Protocol) server that provides cognitive enhancement tools for LLM agents. All tools are available immediately at connection start. No staged unlocking is required.
+Thoughtbox is an MCP (Model Context Protocol) server that provides cognitive enhancement tools for LLM agents using Code Mode. Three tools are registered:
 
-1. **thoughtbox_session** - Session management and persistence
-2. **thoughtbox_thought** - Step-by-step reasoning with branching, revision, and semantic types
-3. **thoughtbox_notebook** - Literate programming notebooks
-4. **thoughtbox_knowledge** - Knowledge graph (entities, relations, observations)
-5. **thoughtbox_theseus** - Friction-gated refactoring protocol
-6. **thoughtbox_ulysses** - Surprise-gated debugging protocol
-7. **thoughtbox_operations** - Discover operation schemas for any tool
-8. **observability_gateway** - Metrics, health, alerts
+1. **thoughtbox_search** - Write JavaScript to query the operation/prompt/resource catalog
+2. **thoughtbox_execute** - Write JavaScript against the \`tb\` SDK to chain operations
+3. **thoughtbox_peer_notebook** - Seed artifacts and invoke the brokered claim-extractor peer
+
+The \`tb\` SDK inside \`thoughtbox_execute\` exposes the domain modules:
+
+- **tb.thought** - Step-by-step reasoning with branching, revision, and semantic types
+- **tb.session** - Session management and persistence
+- **tb.notebook** - Literate programming notebooks
+- **tb.knowledge** - Knowledge graph (entities, relations, observations)
+- **tb.theseus** - Friction-gated refactoring protocol
+- **tb.ulysses** - Surprise-gated debugging protocol
+- **tb.observability** - Metrics, health, alerts
 
 This notebook explores the architecture, implementation patterns, and design decisions behind the Thoughtbox server.
 
@@ -66,8 +71,8 @@ The server consists of several interconnected components:
 
 ### Key Design Patterns
 
-1. **Toolhost Pattern**: Each domain is a single tool with operation dispatch (e.g., \`thoughtbox_session\`, \`thoughtbox_thought\`)
-2. **Direct Tool Access**: All tools available immediately at connection start — no gateway or init ceremony
+1. **Code Mode**: One execute tool hosts the whole \`tb\` SDK — the LLM writes code that chains operations instead of making many tool calls
+2. **Search + Execute**: \`thoughtbox_search\` discovers operations; \`thoughtbox_execute\` runs them
 3. **Resource Embedding**: Responses include contextual documentation as embedded resources
 4. **Streamable HTTP**: Single transport via Express with per-session server instances
 5. **Lazy Initialization**: Resources created on-demand, not at startup
@@ -76,39 +81,26 @@ The server consists of several interconnected components:
 
 ## Tool Surface
 
-All tools are available immediately at connection start. Each tool is a domain-specific toolhost with operation dispatch.
+Three tools are registered at connection start. Domain functionality lives in the \`tb\` SDK modules inside \`thoughtbox_execute\`.
 
 ### Tool Examples
 
 ###### tool-usage.ts
 
 \`\`\`typescript
-// Example: Using Thoughtbox tools directly
+// Example: code passed to the thoughtbox_execute tool
 
 // Structured reasoning
-const thought = {
-  tool: 'thoughtbox_thought',
-  args: {
-    operation: 'thought',
-    args: {
-      thought: 'Analyzing the problem',
-      thoughtNumber: 1,
-      totalThoughts: 5,
-      nextThoughtNeeded: true
-    }
-  }
-};
+async () => tb.thought({
+  thought: 'Analyzing the problem',
+  thoughtType: 'reasoning',
+  thoughtNumber: 1,
+  totalThoughts: 5,
+  nextThoughtNeeded: true
+});
 
 // Session management
-const sessions = {
-  tool: 'thoughtbox_session',
-  args: {
-    operation: 'list'
-  }
-};
-
-console.log('Thought:', JSON.stringify(thought, null, 2));
-console.log('Sessions:', JSON.stringify(sessions, null, 2));
+async () => tb.session.list();
 \`\`\`
 
 ## Project Scoping
@@ -242,16 +234,19 @@ interface MCPToolResponse {
   isError?: boolean;
 }
 
-// Example: thoughtbox tool call
+// Example: thoughtbox_execute tool call running tb.thought
 const exampleRequest: MCPToolRequest = {
   method: 'tools/call',
   params: {
-    name: 'thoughtbox',
+    name: 'thoughtbox_execute',
     arguments: {
-      thought: 'Analyzing the problem structure',
-      thoughtNumber: 1,
-      totalThoughts: 5,
-      nextThoughtNeeded: true
+      code: \`async () => tb.thought({
+        thought: 'Analyzing the problem structure',
+        thoughtType: 'reasoning',
+        thoughtNumber: 1,
+        totalThoughts: 5,
+        nextThoughtNeeded: true
+      })\`
     }
   }
 };
@@ -286,9 +281,9 @@ const exampleResponse: MCPToolResponse = {
 console.log('\\nMCP Response:', JSON.stringify(exampleResponse, null, 2));
 \`\`\`
 
-## The thoughtbox Tool
+## The tb.thought Module
 
-The \`thoughtbox\` tool implements a flexible sequential thinking framework. Key features:
+\`tb.thought\` implements a flexible sequential thinking framework. Key features:
 
 ### Parameters
 - **thought**: The current reasoning step
@@ -364,13 +359,12 @@ console.log('\\nRevision:', revision);
 console.log('\\nWith Guide:', withGuide);
 \`\`\`
 
-## The Notebook Toolhost Pattern
+## The tb.notebook Module
 
-Instead of exposing 10 separate MCP tools (\`notebook_create\`, \`notebook_list\`, etc.), Thoughtbox uses a **toolhost pattern**:
+Instead of exposing 10 separate MCP tools (\`notebook_create\`, \`notebook_list\`, etc.), Thoughtbox groups notebook functionality into the \`tb.notebook\` SDK module inside \`thoughtbox_execute\`:
 
-- **Single Tool**: \`notebook(operation, args)\`
-- **Operation Dispatch**: The \`operation\` parameter routes to specific handlers
-- **Cleaner Interface**: Clients see 1 tool instead of 10
+- **Single Surface**: \`tb.notebook.<operation>(args)\`
+- **Cleaner Interface**: Clients see 3 registered tools total, not one per operation
 - **Easier Maintenance**: Add operations without changing MCP tool registration
 
 ### Available Operations
@@ -378,18 +372,18 @@ Instead of exposing 10 separate MCP tools (\`notebook_create\`, \`notebook_list\
 **Notebook Management**
 - \`create\`: Create new notebook
 - \`list\`: List all notebooks
-- \`load\`: Load from .src.md file
-- \`export\`: Save to .src.md file
+- \`load\`: Load from .src.md content
+- \`export\`: Save to .src.md format
 
 **Cell Operations**
-- \`add_cell\`: Add title/markdown/code cell
-- \`update_cell\`: Modify cell content
-- \`list_cells\`: List all cells
-- \`get_cell\`: Get cell details
+- \`addCell\`: Add title/markdown/code cell
+- \`updateCell\`: Modify cell content
+- \`listCells\`: List all cells
+- \`getCell\`: Get cell details
 
 **Execution**
-- \`run_cell\`: Execute code cell
-- \`install_deps\`: Install pnpm dependencies
+- \`runCell\`: Execute code cell
+- \`installDeps\`: Install pnpm dependencies
 
 ### Operation Catalog Resource
 

--- a/src/resources/session-analysis-guide-content.ts
+++ b/src/resources/session-analysis-guide-content.ts
@@ -18,7 +18,7 @@ You have received structural metrics for a reasoning session. To perform qualita
 
 ## Step 1: Review Session Content
 
-Use the \`thoughtbox_session\` tool with operation \`get\` to retrieve the full session with all thoughts if you haven't already.
+Call \`tb.session.get("<session-id>")\` via the \`thoughtbox_execute\` tool to retrieve the full session with all thoughts if you haven't already.
 
 ## Step 2: Identify Key Moments
 
@@ -39,26 +39,25 @@ For each key moment identified, consider:
 
 ## Step 4: Extract Learnings
 
-Use the \`session\` tool with operation \`extract_learnings\` and your identified key moments:
+Call \`tb.session.extractLearnings\` via \`thoughtbox_execute\` with your identified key moments:
 
-\`\`\`json
-{
-  "sessionId": "<session-id>",
-  "keyMoments": [
+\`\`\`javascript
+async () => tb.session.extractLearnings("<session-id>", {
+  keyMoments: [
     {
-      "thoughtNumber": 5,
-      "type": "decision",
-      "significance": 8,
-      "summary": "Chose hybrid approach over pure options"
+      thoughtNumber: 5,
+      type: "decision",
+      significance: 8,
+      summary: "Chose hybrid approach over pure options"
     }
   ],
-  "targetTypes": ["pattern", "anti-pattern", "signal"]
-}
+  targetTypes: ["pattern", "anti-pattern", "signal"]
+})
 \`\`\`
 
 ## Step 5: Generate Artifacts
 
-The extract_learnings tool will generate:
+The extractLearnings operation will generate:
 - **Patterns**: From decisions and insights (for DGM experiments)
 - **Anti-patterns**: From revisions (what didn't work)
 - **Signals**: Session-level success/failure metrics
@@ -96,7 +95,7 @@ When scanning thoughts, look for these signals:
 
 ## Writing Effective Learnings
 
-When providing key moments to \`extract_learnings\`:
+When providing key moments to \`tb.session.extractLearnings\`:
 
 1. **Be specific**: Include the exact thought number
 2. **Rate significance**: 1-10 scale helps prioritize

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -682,7 +682,7 @@ You MUST now spawn a sub-agent using the Task tool to fulfill this request. This
   "tool": "Task",
   "subagent_type": "general-purpose",
   "description": "${request ? request.slice(0, 50) : "Query Thoughtbox sessions"}",
-  "prompt": "${request ? `Task: ${request}` : "Retrieve and summarize Thoughtbox session data."}\\n\\nSteps:\\n1. Call mcp__thoughtbox__thoughtbox_session with appropriate operation:\\n   - 'list' to see available sessions\\n   - 'get' with sessionId to retrieve specific session\\n   - 'search' with query to find relevant sessions\\n2. Process the data according to the request\\n\\nReturn ONLY your findings/summary. Do not include raw thought content."
+  "prompt": "${request ? `Task: ${request}` : "Retrieve and summarize Thoughtbox session data."}\\n\\nSteps:\\n1. Call mcp__thoughtbox__thoughtbox_execute with code using the tb SDK:\\n   - async () => tb.session.list() to see available sessions\\n   - async () => tb.session.get('<SESSION_ID>') to retrieve a specific session\\n   - async () => tb.session.search('<QUERY>') to find relevant sessions\\n2. Process the data according to the request\\n\\nReturn ONLY your findings/summary. Do not include raw thought content."
 }
 \`\`\`
 
@@ -749,8 +749,10 @@ Spawn a Haiku sub-agent to evaluate which prior thoughts should be updated based
 For each thought marked UPDATE, use:
 
 \`\`\`typescript
-mcp__thoughtbox__thoughtbox({
+// Via the thoughtbox_execute tool:
+async () => tb.thought({
   thought: "[REVISED content with new context]",
+  thoughtType: "reasoning",
   thoughtNumber: [N],
   totalThoughts: [total],
   nextThoughtNeeded: false,
@@ -810,21 +812,6 @@ mcp__thoughtbox__thoughtbox({
         {
           role: "user" as const,
           content: { type: "text" as const, text: BEHAVIORAL_TESTS.notebook.content },
-        },
-      ],
-    })
-  );
-
-  server.registerPrompt(
-    "test-mental-models",
-    {
-      description: BEHAVIORAL_TESTS.mentalModels.description,
-    },
-    async () => ({
-      messages: [
-        {
-          role: "user" as const,
-          content: { type: "text" as const, text: BEHAVIORAL_TESTS.mentalModels.content },
         },
       ],
     })
@@ -1268,24 +1255,6 @@ mcp__thoughtbox__thoughtbox({
   );
 
   server.registerResource(
-    "test-mental-models",
-    BEHAVIORAL_TESTS.mentalModels.uri,
-    {
-      description: BEHAVIORAL_TESTS.mentalModels.description,
-      mimeType: "text/markdown",
-    },
-    async (uri) => ({
-      contents: [
-        {
-          uri: uri.toString(),
-          mimeType: "text/markdown",
-          text: BEHAVIORAL_TESTS.mentalModels.content,
-        },
-      ],
-    })
-  );
-
-  server.registerResource(
     "test-memory",
     BEHAVIORAL_TESTS.memory.uri,
     {
@@ -1465,7 +1434,7 @@ mcp__thoughtbox__thoughtbox({
       return {
         uri: "thoughtbox://init",
         mimeType: "text/markdown",
-        text: `# Thoughtbox Init\n\nSession index not available. You can start using tools directly.\n\n## Available Tools\n\n- \`thoughtbox\` — Step-by-step reasoning\n- \`thoughtbox_cipher\` — Token-efficient notation system\n- \`session\` — Manage/retrieve/analyze reasoning sessions\n- \`notebook\` — Literate programming notebooks`,
+        text: `# Thoughtbox Init\n\nSession index not available. You can start using tools directly.\n\n## Available Tools\n\n- \`thoughtbox_search\` — Query the operation/prompt/resource catalog\n- \`thoughtbox_execute\` — Run JavaScript against the \`tb\` SDK (thoughts, sessions, knowledge, notebooks)\n- \`thoughtbox_peer_notebook\` — Seed artifacts and invoke the brokered claim-extractor peer`,
       };
     }
     return initHandler.handle(params);

--- a/src/thought-handler.ts
+++ b/src/thought-handler.ts
@@ -1092,7 +1092,7 @@ export class ThoughtHandler {
                     branches: Object.keys(this.branches),
                     thoughtHistoryLength: this.thoughtHistory.length,
                     sessionId: this.currentSessionId,
-                    warning: `Auto-export failed: ${exportError}. Session remains open to prevent data loss. You can manually export using the export_reasoning_chain tool.`,
+                    warning: `Auto-export failed: ${exportError}. Session remains open to prevent data loss. You can manually export via tb.session.export(sessionId) in thoughtbox_execute.`,
                     ...(critiqueResult && { critique: critiqueResult }),
                   },
                   null,


### PR DESCRIPTION
## Summary

Implements SPEC-V1-INITIATIVE:c7 (Phase 3.4): no live surface (search catalog, init renderer, behavioral tests, prompts, resources) references the `mental_models` tool or any other unregistered tool name. The registered MCP tools are `thoughtbox_search`, `thoughtbox_execute`, and `thoughtbox_peer_notebook`; all domain operations flow through the `tb.*` SDK inside `thoughtbox_execute`.

## Changes

- `src/resources/behavioral-tests-content.ts` — removed the `mental_models` suite (no implementation exists in src/) and the hub suite (hub is real but unexposed; `tb.hub.*` lands in a later phase). Rewrote the thoughtbox/notebook/memory suites to call `tb.thought`, `tb.notebook`, and `tb.knowledge` via `thoughtbox_execute`, preserving test semantics.
- `src/server-factory.ts` — removed the `test-mental-models` prompt and resource registrations; updated the subagent-summarize prompt header from `mcp__thoughtbox__thoughtbox_session` to `tb.session` via `thoughtbox_execute`; updated the evolution-check revision example to `tb.thought`; replaced the init fallback tool list (`thoughtbox`, `thoughtbox_cipher`, `session`, `notebook`) with the real three-tool surface.
- `src/code-mode/search-index.ts` — removed `test-mental-models` prompt and resource catalog entries; updated remaining test descriptions to the `tb.*` surface.
- `src/init/renderers/markdown.ts` — replaced `thoughtbox`/`notebook`/`mental_models`/`export_reasoning_chain` tool lists and the session-start JSON example with the Code Mode surface.
- `src/resources/evolution-check-content.ts`, `src/prompts/contents/parallel-verification.ts`, `src/resources/patterns-cookbook-content.ts`, `src/resources/session-analysis-guide-content.ts`, `src/resources/server-architecture-content.ts` — rewrote ghost tool-call instructions (`mcp__thoughtbox__thoughtbox`, `mcp__thoughtbox__session`, `thoughtbox_session`, `thoughtbox_knowledge`, notebook operation dispatch) to `tb.*` code examples.
- `src/knowledge/tool.ts` — deleted the unreferenced `KNOWLEDGE_TOOL` constant carrying the `thoughtbox_knowledge` name.
- `src/hub/hub-handler.ts` — error messages now name hub operations instead of the unregistered `thoughtbox_hub` tool (test assertions match on preserved prefixes).
- `src/hub/__tests__/hub-task-store.test.ts` — synthetic request uses a registered tool name.
- `src/thought-handler.ts` — auto-export failure warning points at `tb.session.export` instead of `export_reasoning_chain`.

## Verification

- `rg -n "mental_models|thoughtbox_knowledge|thoughtbox_cipher" src/` returns no hits
- `rg -n "thoughtbox_hub" src/` returns no hits
- `npx tsc --noEmit` clean
- `npx oxlint -c oxlint.json src/` clean (0 warnings)
- Tests: hub-task-store, hub-handler, hub-tool-wiring, wiring-integration, search-tool, execute-tool, server-surface, architecture, thought-attribution, e2e-workflow — all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)