### PR TITLE
fix(notebook): derive real runbook verdicts; drop canned outputs

### DIFF
--- a/src/code-mode/sdk-types.ts
+++ b/src/code-mode/sdk-types.ts
@@ -85,8 +85,8 @@ interface TB {
     validate(args: { notebookId: string; cellId: string; observed: unknown; expectedSnapshotHash?: string }): Promise<unknown>;
     /** Persist the current notebook as a replayable artifact. */
     persist(args: { notebookId: string }): Promise<unknown>;
-    /** Start an evidence run; use sync for short checks and async for Cloud Run runner work. */
-    startRun(args: { notebookId: string; mode: "runbook" | "simulation" | "eval" | "failure_capsule" | "adr_evidence" | "skill_certification" | "scenario_factory" | "system_audit"; executionMode?: "sync" | "async"; inputs?: Record<string, unknown> }): Promise<unknown>;
+    /** Execute the notebook's cells and derive a verdict from real results. Only runbook mode is implemented; other modes return an explicit error. */
+    startRun(args: { notebookId: string; mode: "runbook" | "simulation" | "eval" | "failure_capsule" | "adr_evidence" | "skill_certification" | "scenario_factory" | "system_audit"; inputs?: Record<string, unknown> }): Promise<unknown>;
     getRun(args: { runId: string }): Promise<unknown>;
     listRuns(args?: { notebookId?: string }): Promise<unknown>;
     cancelRun(args: { runId: string; reason?: string }): Promise<unknown>;

--- a/src/notebook/__tests__/engine.test.ts
+++ b/src/notebook/__tests__/engine.test.ts
@@ -245,6 +245,33 @@ describe("Notebook Evidence Engine runs", () => {
     });
   });
 
+  it("marks the run failed when artifact persistence fails — never stuck running", async () => {
+    // Evidence artifacts store full cell output; an oversized one fails
+    // putArtifact and must transition the run to FailedRun, not leave it
+    // in RunningRun forever.
+    const runtime = new InMemoryNotebookEngineRuntime(async () => [
+      {
+        cellId: "huge",
+        cellType: "code",
+        filename: "huge.js",
+        status: "completed",
+        exitCode: 0,
+        output: "x".repeat(1_100_000),
+        error: "",
+      },
+    ]);
+
+    await expect(
+      Effect.runPromise(runtime.startRun({ notebookId: "nb_huge", mode: "runbook" })),
+    ).rejects.toThrow();
+
+    const runs = runtime.listRuns("nb_huge");
+    expect(runs).toHaveLength(1);
+    const failedRun = runs[0] as Extract<(typeof runs)[number], { _tag: "FailedRun" }>;
+    expect(failedRun.status).toBe("failed");
+    expect(failedRun.error).toContain("too large");
+  });
+
   it("fails a blank notebook — dependency install alone cannot pass", async () => {
     // New notebooks always carry a default package.json cell; a successful
     // pnpm install with no code cells must not look like a verified runbook.

--- a/src/notebook/__tests__/engine.test.ts
+++ b/src/notebook/__tests__/engine.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { Schema as S } from "effect";
+import { Effect, Schema as S } from "effect";
 import { NotebookHandler } from "../index.js";
+import { InMemoryNotebookEngineRuntime } from "../engine/runtime.js";
 import {
   BoundValidatorSchema,
   NotebookDocumentSchema,
@@ -100,14 +101,28 @@ describe("Notebook Evidence Engine domain", () => {
 
   it("handles run statuses exhaustively", () => {
     const run = S.decodeUnknownSync(NotebookRunSchema)({
-      _tag: "QueuedRun",
+      _tag: "RunningRun",
       runId: "run",
       notebookId: "nb",
       mode: "system_audit",
-      status: "queued",
+      status: "running",
       createdAt: "2026-04-30T00:00:00.000Z",
+      startedAt: "2026-04-30T00:00:00.000Z",
     });
-    expect(describeRunStatus(run)).toBe("queued");
+    expect(describeRunStatus(run)).toBe("running");
+  });
+
+  it("rejects queued runs — no external dispatcher exists", () => {
+    expect(() =>
+      S.decodeUnknownSync(NotebookRunSchema)({
+        _tag: "QueuedRun",
+        runId: "run",
+        notebookId: "nb",
+        mode: "runbook",
+        status: "queued",
+        createdAt: "2026-04-30T00:00:00.000Z",
+      }),
+    ).toThrow();
   });
 });
 
@@ -130,7 +145,107 @@ describe("Notebook Evidence Engine visibility", () => {
     ]);
   });
 
-  it("creates evidence templates and can start a sync evidence run", async () => {
+  it("marks only runbook as implemented; the rest are specified", () => {
+    const statuses = Object.fromEntries(
+      listNotebookModes().map((m) => [m.mode, m.runStatus]),
+    );
+    expect(statuses.runbook).toBe("implemented");
+    for (const [mode, status] of Object.entries(statuses)) {
+      if (mode !== "runbook") expect(status).toBe("specified");
+    }
+  });
+});
+
+describe("Notebook Evidence Engine runs", () => {
+  it("derives a passing runbook verdict from real cell execution", async () => {
+    const handler = new NotebookHandler();
+    await handler.init();
+
+    const created = await handler.handleCreateNotebook({
+      title: "Runbook pass",
+      language: "javascript",
+    });
+    await handler.handleAddCell({
+      notebookId: created.notebook.id,
+      cellType: "code",
+      filename: "step1.js",
+      content: 'console.log("step one ran");',
+    });
+
+    const runResult = await handler.handleStartRun({
+      notebookId: created.notebook.id,
+      mode: "runbook",
+    });
+
+    expect(runResult.run.status).toBe("completed");
+    const verdict = runResult.run.outputs[0];
+    expect(verdict._tag).toBe("RunbookVerdict");
+    expect(verdict.pass).toBe(true);
+    // Evidence covers the default package.json install cell plus step1.js.
+    const evidence = verdict.evidence as Array<Record<string, unknown>>;
+    expect(evidence).toHaveLength(2);
+    expect(evidence.every((cell) => cell.status === "completed")).toBe(true);
+    const step = evidence.find((cell) => cell.filename === "step1.js");
+    expect(String(step!.output)).toContain("step one ran");
+
+    const listed = await handler.handleListRuns({ notebookId: created.notebook.id });
+    expect(listed.runs).toHaveLength(1);
+  });
+
+  it("derives a failing runbook verdict and skips later cells", async () => {
+    const handler = new NotebookHandler();
+    await handler.init();
+
+    const created = await handler.handleCreateNotebook({
+      title: "Runbook fail",
+      language: "javascript",
+    });
+    await handler.handleAddCell({
+      notebookId: created.notebook.id,
+      cellType: "code",
+      filename: "boom.js",
+      content: 'console.error("deliberate failure"); process.exit(1);',
+    });
+    await handler.handleAddCell({
+      notebookId: created.notebook.id,
+      cellType: "code",
+      filename: "never.js",
+      content: 'console.log("should not run");',
+    });
+
+    const runResult = await handler.handleStartRun({
+      notebookId: created.notebook.id,
+      mode: "runbook",
+    });
+
+    expect(runResult.run.status).toBe("completed");
+    const verdict = runResult.run.outputs[0];
+    expect(verdict.pass).toBe(false);
+    expect(verdict.reason).toContain("boom.js");
+    // package.json install, then boom.js fails, then never.js is skipped.
+    const evidence = verdict.evidence as Array<Record<string, unknown>>;
+    expect(evidence).toHaveLength(3);
+    const boom = evidence.find((cell) => cell.filename === "boom.js");
+    expect(boom!.status).toBe("failed");
+    expect(boom!.exitCode).toBe(1);
+    const never = evidence.find((cell) => cell.filename === "never.js");
+    expect(never!.status).toBe("skipped");
+  });
+
+  it("fails a runbook with no executable cells — a verdict needs evidence", async () => {
+    const runtime = new InMemoryNotebookEngineRuntime(async () => []);
+    const result = await Effect.runPromise(
+      runtime.startRun({ notebookId: "nb_empty", mode: "runbook" }),
+    );
+
+    const run = result.run as Extract<typeof result.run, { _tag: "CompletedRun" }>;
+    expect(run.outputs[0]).toMatchObject({
+      pass: false,
+      reason: expect.stringContaining("no executable cells"),
+    });
+  });
+
+  it("rejects non-runbook modes with an explicit not-implemented error", async () => {
     const handler = new NotebookHandler();
     await handler.init();
 
@@ -140,17 +255,15 @@ describe("Notebook Evidence Engine visibility", () => {
       template: "evidence-eval-workbook",
     });
 
-    const runResult = await handler.handleStartRun({
-      notebookId: created.notebook.id,
-      mode: "eval",
-      executionMode: "sync",
-      inputs: { datasetName: "demo" },
-    });
-
-    expect(runResult.run.status).toBe("completed");
-    expect(runResult.run.outputs[0].mode).toBe("eval");
+    await expect(
+      handler.handleStartRun({
+        notebookId: created.notebook.id,
+        mode: "eval",
+        inputs: { datasetName: "demo" },
+      }),
+    ).rejects.toThrow(/not implemented/i);
 
     const listed = await handler.handleListRuns({ notebookId: created.notebook.id });
-    expect(listed.runs).toHaveLength(1);
+    expect(listed.runs).toHaveLength(0);
   });
 });

--- a/src/notebook/__tests__/engine.test.ts
+++ b/src/notebook/__tests__/engine.test.ts
@@ -245,6 +245,32 @@ describe("Notebook Evidence Engine runs", () => {
     });
   });
 
+  it("fails a blank notebook — dependency install alone cannot pass", async () => {
+    // New notebooks always carry a default package.json cell; a successful
+    // pnpm install with no code cells must not look like a verified runbook.
+    const handler = new NotebookHandler();
+    await handler.init();
+
+    const created = await handler.handleCreateNotebook({
+      title: "Runbook blank",
+      language: "javascript",
+    });
+
+    const runResult = await handler.handleStartRun({
+      notebookId: created.notebook.id,
+      mode: "runbook",
+    });
+
+    expect(runResult.run.status).toBe("completed");
+    const verdict = runResult.run.outputs[0];
+    expect(verdict.pass).toBe(false);
+    expect(verdict.reason).toContain("no code cells executed");
+    const evidence = verdict.evidence as Array<Record<string, unknown>>;
+    expect(evidence).toHaveLength(1);
+    expect(evidence[0]!.cellType).toBe("package.json");
+    expect(evidence[0]!.status).toBe("completed");
+  });
+
   it("rejects non-runbook modes with an explicit not-implemented error", async () => {
     const handler = new NotebookHandler();
     await handler.init();

--- a/src/notebook/engine/domain.ts
+++ b/src/notebook/engine/domain.ts
@@ -265,21 +265,9 @@ const RunBaseSchema = {
 export const NotebookRunSchema = S.Union(
   S.Struct({
     ...RunBaseSchema,
-    _tag: S.Literal("QueuedRun"),
-    status: S.Literal("queued"),
-  }),
-  S.Struct({
-    ...RunBaseSchema,
     _tag: S.Literal("RunningRun"),
     status: S.Literal("running"),
     startedAt: S.String,
-  }),
-  S.Struct({
-    ...RunBaseSchema,
-    _tag: S.Literal("InputRequiredRun"),
-    status: S.Literal("input_required"),
-    startedAt: S.String,
-    prompt: S.String,
   }),
   S.Struct({
     ...RunBaseSchema,
@@ -349,6 +337,16 @@ export class StoreUnavailable extends Data.TaggedError("StoreUnavailable")<{
   readonly store: string;
   readonly reason: string;
 }> {}
+export class NotebookModeNotImplemented extends Data.TaggedError(
+  "NotebookModeNotImplemented",
+)<{
+  readonly mode: string;
+  readonly reason: string;
+}> {
+  override get message(): string {
+    return this.reason;
+  }
+}
 
 export type NotebookEngineError =
   | InvalidNotebookShape
@@ -357,7 +355,8 @@ export type NotebookEngineError =
   | RunnerTimeout
   | SandboxDenied
   | ArtifactTooLarge
-  | StoreUnavailable;
+  | StoreUnavailable
+  | NotebookModeNotImplemented;
 
 export interface NotebookStore {
   readonly save: (notebook: NotebookPersistence) => Promise<void>;
@@ -403,9 +402,7 @@ export class SandboxExecutorService extends Context.Tag("SandboxExecutor")<
 export function describeRunStatus(run: NotebookRun): string {
   return Match.value(run).pipe(
     Match.tagsExhaustive({
-      QueuedRun: () => "queued",
       RunningRun: () => "running",
-      InputRequiredRun: () => "input_required",
       CompletedRun: (r) => `completed:${r.outputs.length}`,
       FailedRun: (r) => `failed:${r.error}`,
       CancelledRun: (r) => `cancelled:${r.reason}`,

--- a/src/notebook/engine/registry.ts
+++ b/src/notebook/engine/registry.ts
@@ -2,6 +2,13 @@ import type { NotebookMode } from "./domain.js";
 
 export interface NotebookModeDescriptor {
   mode: NotebookMode;
+  /**
+   * "implemented": notebook_start_run executes cells and derives a real
+   * verdict. "specified": the mode is designed (schema, templates, docs)
+   * but start_run rejects it with an explicit not-implemented error; use
+   * notebook_run_cell and notebook_validate for cell-level evidence.
+   */
+  runStatus: "implemented" | "specified";
   title: string;
   whenToUse: string;
   requiredInputs: string[];
@@ -13,6 +20,7 @@ export interface NotebookModeDescriptor {
 export const NOTEBOOK_MODE_REGISTRY: Record<NotebookMode, NotebookModeDescriptor> = {
   runbook: {
     mode: "runbook",
+    runStatus: "implemented",
     title: "Functional Skill Runbook",
     whenToUse:
       "Use when an agent workflow should be reusable, stepwise, and gated by deterministic validators.",
@@ -21,11 +29,12 @@ export const NOTEBOOK_MODE_REGISTRY: Record<NotebookMode, NotebookModeDescriptor
     templates: ["evidence-runbook"],
     exampleSequence: [
       { operation: "notebook_create", args: { title: "Runbook", language: "typescript", template: "evidence-runbook" } },
-      { operation: "notebook_start_run", args: { notebookId: "<id>", mode: "runbook", executionMode: "sync" } },
+      { operation: "notebook_start_run", args: { notebookId: "<id>", mode: "runbook" } },
     ],
   },
   simulation: {
     mode: "simulation",
+    runStatus: "specified",
     title: "Monte Carlo Simulation Notebook",
     whenToUse:
       "Use when stochastic or parameterized experiments should influence reasoning with repeatable seeds and aggregates.",
@@ -34,11 +43,12 @@ export const NOTEBOOK_MODE_REGISTRY: Record<NotebookMode, NotebookModeDescriptor
     templates: ["evidence-simulation"],
     exampleSequence: [
       { operation: "notebook_create", args: { title: "Simulation", language: "typescript", template: "evidence-simulation" } },
-      { operation: "notebook_start_run", args: { notebookId: "<id>", mode: "simulation", inputs: { runs: 1000, seed: "demo" } } },
+      { operation: "notebook_run_cell", args: { notebookId: "<id>", cellId: "<cellId>" } },
     ],
   },
   eval: {
     mode: "eval",
+    runStatus: "specified",
     title: "Executable Evaluation Workbook",
     whenToUse:
       "Use when a model, tool, claim, or workflow needs a scored executable evaluation rather than narrative judgment.",
@@ -47,11 +57,12 @@ export const NOTEBOOK_MODE_REGISTRY: Record<NotebookMode, NotebookModeDescriptor
     templates: ["evidence-eval-workbook"],
     exampleSequence: [
       { operation: "notebook_create", args: { title: "Eval Workbook", language: "typescript", template: "evidence-eval-workbook" } },
-      { operation: "notebook_start_run", args: { notebookId: "<id>", mode: "eval", executionMode: "sync" } },
+      { operation: "notebook_validate", args: { notebookId: "<id>", cellId: "<validatorCellId>" } },
     ],
   },
   failure_capsule: {
     mode: "failure_capsule",
+    runStatus: "specified",
     title: "Failure Capsule / Debugging Lab",
     whenToUse:
       "Use when a bug, production incident, or agent failure should become replayable and regression-testable.",
@@ -60,11 +71,12 @@ export const NOTEBOOK_MODE_REGISTRY: Record<NotebookMode, NotebookModeDescriptor
     templates: ["evidence-failure-capsule"],
     exampleSequence: [
       { operation: "notebook_create", args: { title: "Failure Capsule", language: "typescript", template: "evidence-failure-capsule" } },
-      { operation: "notebook_start_run", args: { notebookId: "<id>", mode: "failure_capsule", executionMode: "sync" } },
+      { operation: "notebook_validate", args: { notebookId: "<id>", cellId: "<validatorCellId>" } },
     ],
   },
   adr_evidence: {
     mode: "adr_evidence",
+    runStatus: "specified",
     title: "Executable ADR Evidence Pack",
     whenToUse:
       "Use when an architectural hypothesis needs executable evidence attached to the ADR lifecycle.",
@@ -73,11 +85,12 @@ export const NOTEBOOK_MODE_REGISTRY: Record<NotebookMode, NotebookModeDescriptor
     templates: ["evidence-adr-pack"],
     exampleSequence: [
       { operation: "notebook_create", args: { title: "ADR Evidence", language: "typescript", template: "evidence-adr-pack" } },
-      { operation: "notebook_start_run", args: { notebookId: "<id>", mode: "adr_evidence", executionMode: "sync" } },
+      { operation: "notebook_validate", args: { notebookId: "<id>", cellId: "<validatorCellId>" } },
     ],
   },
   skill_certification: {
     mode: "skill_certification",
+    runStatus: "specified",
     title: "Skill Certification Harness",
     whenToUse:
       "Use when a reusable skill needs positive, adversarial, and negative-control proof obligations.",
@@ -86,11 +99,12 @@ export const NOTEBOOK_MODE_REGISTRY: Record<NotebookMode, NotebookModeDescriptor
     templates: ["evidence-skill-certification"],
     exampleSequence: [
       { operation: "notebook_create", args: { title: "Skill Certification", language: "typescript", template: "evidence-skill-certification" } },
-      { operation: "notebook_start_run", args: { notebookId: "<id>", mode: "skill_certification", executionMode: "sync" } },
+      { operation: "notebook_validate", args: { notebookId: "<id>", cellId: "<validatorCellId>" } },
     ],
   },
   scenario_factory: {
     mode: "scenario_factory",
+    runStatus: "specified",
     title: "Dataset And Scenario Factory",
     whenToUse:
       "Use when tests or evals need parameterized, schema-validated generated scenarios.",
@@ -99,11 +113,12 @@ export const NOTEBOOK_MODE_REGISTRY: Record<NotebookMode, NotebookModeDescriptor
     templates: ["evidence-scenario-factory"],
     exampleSequence: [
       { operation: "notebook_create", args: { title: "Scenario Factory", language: "typescript", template: "evidence-scenario-factory" } },
-      { operation: "notebook_start_run", args: { notebookId: "<id>", mode: "scenario_factory", executionMode: "sync" } },
+      { operation: "notebook_validate", args: { notebookId: "<id>", cellId: "<validatorCellId>" } },
     ],
   },
   system_audit: {
     mode: "system_audit",
+    runStatus: "specified",
     title: "Living System Audit",
     whenToUse:
       "Use when repo, protocol, or infrastructure invariants should be checked repeatedly and reported as issue-ready findings.",
@@ -112,7 +127,7 @@ export const NOTEBOOK_MODE_REGISTRY: Record<NotebookMode, NotebookModeDescriptor
     templates: ["evidence-system-audit"],
     exampleSequence: [
       { operation: "notebook_create", args: { title: "System Audit", language: "typescript", template: "evidence-system-audit" } },
-      { operation: "notebook_start_run", args: { notebookId: "<id>", mode: "system_audit", executionMode: "sync" } },
+      { operation: "notebook_validate", args: { notebookId: "<id>", cellId: "<validatorCellId>" } },
     ],
   },
 };
@@ -132,8 +147,8 @@ export function getNotebookCapabilitiesJson(): string {
       description:
         "Notebook Evidence Engine capabilities: executable, replayable notebooks with prose, code, validators, structured outputs, and durable run artifacts.",
       lowLevelPredicatePrimitive: "notebook_validate",
-      durableOrchestration:
-        "Supabase run records are the durable state machine; long compute belongs in the Cloud Run runner.",
+      execution:
+        "Runs execute synchronously in-process through real cell subprocesses. Only runbook mode derives a verdict today; modes marked specified reject notebook_start_run.",
       observatoryScope:
         "Observatory integration is out of scope. Outputs are local-first notebook exports and run artifacts.",
       modes: listNotebookModes(),
@@ -149,7 +164,7 @@ export function getNotebookCapabilitiesMarkdown(): string {
       const sequence = mode.exampleSequence
         .map((step) => `  - \`${step.operation}\` ${JSON.stringify(step.args)}`)
         .join("\n");
-      return `### ${mode.title}\n\n**Mode:** \`${mode.mode}\`\n\n**When to use:** ${mode.whenToUse}\n\n**Required inputs:** ${mode.requiredInputs.join(", ")}\n\n**Expected outputs:** ${mode.expectedOutputs.join(", ")}\n\n**Templates:** ${mode.templates.map((t) => `\`${t}\``).join(", ")}\n\n**Example sequence:**\n${sequence}`;
+      return `### ${mode.title}\n\n**Mode:** \`${mode.mode}\` (${mode.runStatus})\n\n**When to use:** ${mode.whenToUse}\n\n**Required inputs:** ${mode.requiredInputs.join(", ")}\n\n**Expected outputs:** ${mode.expectedOutputs.join(", ")}\n\n**Templates:** ${mode.templates.map((t) => `\`${t}\``).join(", ")}\n\n**Example sequence:**\n${sequence}`;
     })
     .join("\n\n");
 
@@ -157,9 +172,9 @@ export function getNotebookCapabilitiesMarkdown(): string {
 
 Thoughtbox notebooks are an evidence engine: executable Markdown artifacts that combine prose, code, deterministic validators, structured outputs, and replayable runs.
 
-Use \`notebook_validate\` as the low-level predicate primitive. Use \`notebook_start_run\` when a full notebook mode should produce artifacts, scorecards, simulation summaries, audit findings, or certification results.
+Use \`notebook_validate\` as the low-level predicate primitive. Use \`notebook_start_run\` to execute a runbook's cells and derive a pass/fail verdict from the real results. Modes marked **specified** below are designed but not yet runnable through \`notebook_start_run\` — it rejects them explicitly; use \`notebook_run_cell\` and \`notebook_validate\` for cell-level evidence in those modes.
 
-Long-running execution should be coordinated through persisted run records and a Cloud Run runner. Observatory integration is intentionally out of scope.
+Runs execute synchronously in-process. Observatory integration is intentionally out of scope.
 
 ${modeDocs}
 `;

--- a/src/notebook/engine/runtime.ts
+++ b/src/notebook/engine/runtime.ts
@@ -99,7 +99,7 @@ export class InMemoryNotebookEngineRuntime {
             mode: parsedMode,
             reason:
               `Verdict derivation for mode "${parsedMode}" is not implemented; ` +
-              `only "runbook" runs execute today. Use notebook_execute_cell ` +
+              `only "runbook" runs execute today. Use notebook_run_cell ` +
               `and notebook_validate for cell-level evidence in other modes.`,
           }),
         );
@@ -119,15 +119,38 @@ export class InMemoryNotebookEngineRuntime {
       };
       this.runs.set(runId, running);
 
-      const evidence = yield* Effect.tryPromise({
-        try: () => this.executeNotebook(input.notebookId),
-        catch: (cause) =>
-          new InvalidNotebookShape({
-            reason: `Notebook execution failed: ${cause instanceof Error ? cause.message : String(cause)}`,
-          }),
-      }).pipe(
-        Effect.tapError(() =>
+      // Everything between marking the run running and marking it completed
+      // shares one error handler: any failure (execution or artifact
+      // persistence) must transition the run to FailedRun — a run may never
+      // be left in RunningRun forever.
+      const runBody = Effect.gen(this, function* () {
+        const evidence = yield* Effect.tryPromise({
+          try: () => this.executeNotebook(input.notebookId),
+          catch: (cause) =>
+            new InvalidNotebookShape({
+              reason: `Notebook execution failed: ${cause instanceof Error ? cause.message : String(cause)}`,
+            }),
+        });
+        const inputsArtifact = yield* this.putArtifact(
+          `${runId}-inputs.json`,
+          "application/json",
+          JSON.stringify(input.inputs ?? {}, null, 2),
+        );
+        const evidenceArtifact = yield* this.putArtifact(
+          `${runId}-cell-results.json`,
+          "application/json",
+          JSON.stringify(evidence, null, 2),
+        );
+        return { evidence, inputsArtifact, evidenceArtifact };
+      });
+
+      const { evidence, inputsArtifact, evidenceArtifact } = yield* runBody.pipe(
+        Effect.tapError((error) =>
           Effect.sync(() => {
+            const detail =
+              error._tag === "ArtifactTooLarge"
+                ? `run artifact too large: ${error.sizeBytes} bytes (max ${error.maxBytes})`
+                : error.reason;
             const failed: NotebookRun = {
               _tag: "FailedRun",
               runId,
@@ -137,22 +160,11 @@ export class InMemoryNotebookEngineRuntime {
               createdAt,
               startedAt,
               completedAt: new Date().toISOString(),
-              error: "notebook execution failed before producing a verdict",
+              error: detail,
             };
             this.runs.set(runId, failed);
           }),
         ),
-      );
-
-      const inputsArtifact = yield* this.putArtifact(
-        `${runId}-inputs.json`,
-        "application/json",
-        JSON.stringify(input.inputs ?? {}, null, 2),
-      );
-      const evidenceArtifact = yield* this.putArtifact(
-        `${runId}-cell-results.json`,
-        "application/json",
-        JSON.stringify(evidence, null, 2),
       );
 
       const completedAt = new Date().toISOString();

--- a/src/notebook/engine/runtime.ts
+++ b/src/notebook/engine/runtime.ts
@@ -230,12 +230,16 @@ export class InMemoryNotebookEngineRuntime {
 
 /**
  * Derive the runbook verdict from real per-cell execution results.
- * An empty runbook cannot pass: a verdict must rest on at least one
- * executed cell.
+ * A passing verdict must rest on at least one completed code cell:
+ * dependency installation (package.json cells) is recorded as evidence
+ * but cannot verify a runbook by itself, so blank notebooks — which
+ * always carry a default package.json cell — cannot pass.
  */
 function buildRunbookVerdict(evidence: CellExecutionEvidence[]): NotebookOutput {
   const failed = evidence.filter((cell) => cell.status === "failed");
-  const completed = evidence.filter((cell) => cell.status === "completed");
+  const completedCode = evidence.filter(
+    (cell) => cell.status === "completed" && cell.cellType === "code",
+  );
 
   let pass: boolean;
   let reason: string;
@@ -248,9 +252,13 @@ function buildRunbookVerdict(evidence: CellExecutionEvidence[]): NotebookOutput 
     reason =
       `cell ${first.cellId} (${first.filename}) failed with exit code ` +
       `${first.exitCode ?? "none"}: ${truncate(first.error || first.output)}`;
+  } else if (completedCode.length === 0) {
+    pass = false;
+    reason =
+      "no code cells executed; dependency install alone does not verify a runbook";
   } else {
     pass = true;
-    reason = `all ${completed.length} executable cells completed`;
+    reason = `all executable cells completed (${completedCode.length} code)`;
   }
 
   return {

--- a/src/notebook/engine/runtime.ts
+++ b/src/notebook/engine/runtime.ts
@@ -8,17 +8,18 @@ import type {
 import {
   ArtifactTooLarge,
   InvalidNotebookShape,
+  NotebookModeNotImplemented,
   NotebookModeSchema,
   describeRunStatus,
 } from "./domain.js";
 import { getNotebookMode } from "./registry.js";
 
 const MAX_ARTIFACT_BYTES = 1_000_000;
+const MAX_EVIDENCE_OUTPUT_CHARS = 2_000;
 
 export interface StartNotebookRunInput {
   notebookId: string;
   mode: NotebookMode;
-  executionMode?: "sync" | "async";
   inputs?: Record<string, unknown>;
 }
 
@@ -27,9 +28,35 @@ export interface NotebookRunRuntimeResult {
   message: string;
 }
 
+/**
+ * Per-cell result of a real notebook execution, as reported by the
+ * NotebookCellExecutor. `skipped` means an earlier cell failed and this
+ * cell was never run.
+ */
+export interface CellExecutionEvidence {
+  cellId: string;
+  cellType: "code" | "package.json";
+  filename: string;
+  status: "completed" | "failed" | "skipped";
+  exitCode: number | null;
+  output: string;
+  error: string;
+}
+
+/**
+ * Executes a notebook's executable cells in document order and reports
+ * per-cell evidence. Implemented by NotebookHandler over the real
+ * NotebookStateManager subprocess execution path.
+ */
+export type NotebookCellExecutor = (
+  notebookId: string,
+) => Promise<CellExecutionEvidence[]>;
+
 export class InMemoryNotebookEngineRuntime {
   private runs = new Map<string, NotebookRun>();
   private artifacts = new Map<string, { ref: ArtifactRef; content: string }>();
+
+  constructor(private readonly executeNotebook: NotebookCellExecutor) {}
 
   persistNotebook(notebookId: string, content: string) {
     return Effect.gen(this, function* () {
@@ -58,10 +85,6 @@ export class InMemoryNotebookEngineRuntime {
         );
       }
 
-      const createdAt = new Date().toISOString();
-      const runId = `nbr_${Math.random().toString(36).slice(2, 12)}`;
-      const executionMode = input.executionMode ?? "sync";
-
       const parsedMode = yield* Effect.try({
         try: () => S.decodeUnknownSync(NotebookModeSchema)(input.mode),
         catch: () =>
@@ -70,23 +93,20 @@ export class InMemoryNotebookEngineRuntime {
           }),
       });
 
-      if (executionMode === "async") {
-        const queued: NotebookRun = {
-          _tag: "QueuedRun",
-          runId,
-          notebookId: input.notebookId,
-          mode: parsedMode,
-          status: "queued",
-          createdAt,
-        };
-        this.runs.set(runId, queued);
-        return {
-          run: queued,
-          message:
-            "Run queued for external notebook runner. Supabase/Cloud Run worker dispatch is the durable v1 boundary.",
-        } satisfies NotebookRunRuntimeResult;
+      if (parsedMode !== "runbook") {
+        return yield* Effect.fail(
+          new NotebookModeNotImplemented({
+            mode: parsedMode,
+            reason:
+              `Verdict derivation for mode "${parsedMode}" is not implemented; ` +
+              `only "runbook" runs execute today. Use notebook_execute_cell ` +
+              `and notebook_validate for cell-level evidence in other modes.`,
+          }),
+        );
       }
 
+      const createdAt = new Date().toISOString();
+      const runId = `nbr_${Math.random().toString(36).slice(2, 12)}`;
       const startedAt = new Date().toISOString();
       const running: NotebookRun = {
         _tag: "RunningRun",
@@ -99,10 +119,40 @@ export class InMemoryNotebookEngineRuntime {
       };
       this.runs.set(runId, running);
 
-      const artifact = yield* this.putArtifact(
+      const evidence = yield* Effect.tryPromise({
+        try: () => this.executeNotebook(input.notebookId),
+        catch: (cause) =>
+          new InvalidNotebookShape({
+            reason: `Notebook execution failed: ${cause instanceof Error ? cause.message : String(cause)}`,
+          }),
+      }).pipe(
+        Effect.tapError(() =>
+          Effect.sync(() => {
+            const failed: NotebookRun = {
+              _tag: "FailedRun",
+              runId,
+              notebookId: input.notebookId,
+              mode: parsedMode,
+              status: "failed",
+              createdAt,
+              startedAt,
+              completedAt: new Date().toISOString(),
+              error: "notebook execution failed before producing a verdict",
+            };
+            this.runs.set(runId, failed);
+          }),
+        ),
+      );
+
+      const inputsArtifact = yield* this.putArtifact(
         `${runId}-inputs.json`,
         "application/json",
         JSON.stringify(input.inputs ?? {}, null, 2),
+      );
+      const evidenceArtifact = yield* this.putArtifact(
+        `${runId}-cell-results.json`,
+        "application/json",
+        JSON.stringify(evidence, null, 2),
       );
 
       const completedAt = new Date().toISOString();
@@ -115,8 +165,8 @@ export class InMemoryNotebookEngineRuntime {
         createdAt,
         startedAt,
         completedAt,
-        outputs: [buildModeOutput(parsedMode, input.inputs ?? {}, artifact)],
-        artifacts: [artifact],
+        outputs: [buildRunbookVerdict(evidence)],
+        artifacts: [inputsArtifact, evidenceArtifact],
       };
       this.runs.set(runId, completed);
 
@@ -178,74 +228,49 @@ export class InMemoryNotebookEngineRuntime {
   }
 }
 
-function buildModeOutput(
-  mode: NotebookMode,
-  inputs: Record<string, unknown>,
-  artifact: ArtifactRef,
-): NotebookOutput {
-  switch (mode) {
-    case "runbook":
-      return {
-        _tag: "RunbookVerdict",
-        mode,
-        pass: true,
-        reason: "runbook substrate smoke run completed",
-        evidence: inputs,
-      };
-    case "simulation":
-      return {
-        _tag: "SimulationSummary",
-        mode,
-        runs: typeof inputs.runs === "number" ? inputs.runs : 0,
-        seed: typeof inputs.seed === "string" ? inputs.seed : "unseeded",
-        summary: { status: "simulation substrate smoke run" },
-        samples: artifact,
-      };
-    case "eval":
-      return {
-        _tag: "EvalScorecard",
-        mode,
-        score: 1,
-        metrics: { status: "eval substrate smoke run" },
-      };
-    case "failure_capsule":
-      return {
-        _tag: "FailureCapsuleResult",
-        mode,
-        reproduced: false,
-        fixed: false,
-        regressionArtifact: artifact,
-      };
-    case "adr_evidence":
-      return {
-        _tag: "AdrEvidenceResult",
-        mode,
-        outcome: "inconclusive",
-        evidence: { status: "adr evidence substrate smoke run" },
-      };
-    case "skill_certification":
-      return {
-        _tag: "SkillCertificationResult",
-        mode,
-        certified: false,
-        cases: { status: "skill certification substrate smoke run" },
-      };
-    case "scenario_factory":
-      return {
-        _tag: "ScenarioFactoryResult",
-        mode,
-        generated: typeof inputs.count === "number" ? inputs.count : 0,
-        artifact,
-      };
-    case "system_audit":
-      return {
-        _tag: "SystemAuditResult",
-        mode,
-        findings: [{ status: "system audit substrate smoke run" }],
-      };
-    default: {
-      const exhaustive: never = mode;
-      return exhaustive;
-    }
+/**
+ * Derive the runbook verdict from real per-cell execution results.
+ * An empty runbook cannot pass: a verdict must rest on at least one
+ * executed cell.
+ */
+function buildRunbookVerdict(evidence: CellExecutionEvidence[]): NotebookOutput {
+  const failed = evidence.filter((cell) => cell.status === "failed");
+  const completed = evidence.filter((cell) => cell.status === "completed");
+
+  let pass: boolean;
+  let reason: string;
+  if (evidence.length === 0) {
+    pass = false;
+    reason = "runbook has no executable cells; nothing was verified";
+  } else if (failed.length > 0) {
+    pass = false;
+    const first = failed[0]!;
+    reason =
+      `cell ${first.cellId} (${first.filename}) failed with exit code ` +
+      `${first.exitCode ?? "none"}: ${truncate(first.error || first.output)}`;
+  } else {
+    pass = true;
+    reason = `all ${completed.length} executable cells completed`;
   }
+
+  return {
+    _tag: "RunbookVerdict",
+    mode: "runbook",
+    pass,
+    reason,
+    evidence: evidence.map((cell) => ({
+      cellId: cell.cellId,
+      cellType: cell.cellType,
+      filename: cell.filename,
+      status: cell.status,
+      exitCode: cell.exitCode,
+      output: truncate(cell.output),
+      error: truncate(cell.error),
+    })),
+  };
+}
+
+function truncate(text: string): string {
+  if (text.length <= MAX_EVIDENCE_OUTPUT_CHARS) return text;
+  return `${text.slice(0, MAX_EVIDENCE_OUTPUT_CHARS)}… [truncated]`;
 }

--- a/src/notebook/index.ts
+++ b/src/notebook/index.ts
@@ -49,12 +49,12 @@ export class NotebookHandler {
       throw new Error(`Notebook ${notebookId} not found`);
     }
     const executable = notebook.cells.filter(
-      (cell: Cell) => cell.type === "code" || cell.type === "package.json",
+      (cell: Cell): cell is Extract<Cell, { type: "code" | "package.json" }> =>
+        cell.type === "code" || cell.type === "package.json",
     );
     const evidence: CellExecutionEvidence[] = [];
     let failed = false;
     for (const cell of executable) {
-      if (cell.type !== "code" && cell.type !== "package.json") continue;
       if (failed) {
         evidence.push({
           cellId: cell.id,

--- a/src/notebook/index.ts
+++ b/src/notebook/index.ts
@@ -3,7 +3,10 @@ import { NotebookStateManager } from "./state.js";
 import type { Cell, CodeLanguage } from "./types.js";
 import { randomid } from "./types.js";
 import { ValidatorService } from "./validator.js";
-import { InMemoryNotebookEngineRuntime } from "./engine/runtime.js";
+import {
+  InMemoryNotebookEngineRuntime,
+  type CellExecutionEvidence,
+} from "./engine/runtime.js";
 import { getNotebookCapabilitiesJson } from "./engine/registry.js";
 import {
   NOTEBOOK_OPERATIONS,
@@ -28,7 +31,55 @@ export class NotebookHandler {
   constructor(tempDir?: string) {
     this.stateManager = new NotebookStateManager(tempDir);
     this.validatorService = new ValidatorService(this.stateManager);
-    this.engineRuntime = new InMemoryNotebookEngineRuntime();
+    this.engineRuntime = new InMemoryNotebookEngineRuntime((notebookId) =>
+      this.executeAllCells(notebookId),
+    );
+  }
+
+  /**
+   * Execute every executable cell (package.json installs and code cells) in
+   * document order through the real subprocess execution path, stopping at
+   * the first failure; remaining executable cells are reported as skipped.
+   */
+  private async executeAllCells(
+    notebookId: string,
+  ): Promise<CellExecutionEvidence[]> {
+    const notebook = this.stateManager.getNotebook(notebookId);
+    if (!notebook) {
+      throw new Error(`Notebook ${notebookId} not found`);
+    }
+    const executable = notebook.cells.filter(
+      (cell: Cell) => cell.type === "code" || cell.type === "package.json",
+    );
+    const evidence: CellExecutionEvidence[] = [];
+    let failed = false;
+    for (const cell of executable) {
+      if (cell.type !== "code" && cell.type !== "package.json") continue;
+      if (failed) {
+        evidence.push({
+          cellId: cell.id,
+          cellType: cell.type,
+          filename: cell.filename,
+          status: "skipped",
+          exitCode: null,
+          output: "",
+          error: "",
+        });
+        continue;
+      }
+      const result = await this.stateManager.executeCell(notebookId, cell.id);
+      evidence.push({
+        cellId: cell.id,
+        cellType: cell.type,
+        filename: cell.filename,
+        status: result.success ? "completed" : "failed",
+        exitCode: result.exitCode,
+        output: result.stdout,
+        error: result.stderr,
+      });
+      if (!result.success) failed = true;
+    }
+    return evidence;
   }
 
   /**
@@ -467,19 +518,12 @@ export class NotebookHandler {
    * Handle notebook_start_run tool call.
    */
   async handleStartRun(args: any): Promise<any> {
-    const { notebookId, mode, executionMode, inputs } = args;
+    const { notebookId, mode, inputs } = args;
     if (!notebookId || typeof notebookId !== "string") {
       throw new Error("notebookId is required and must be a string");
     }
     if (!mode || typeof mode !== "string") {
       throw new Error("mode is required and must be a string");
-    }
-    if (
-      executionMode !== undefined &&
-      executionMode !== "sync" &&
-      executionMode !== "async"
-    ) {
-      throw new Error('executionMode must be "sync" or "async" if provided');
     }
     if (inputs !== undefined && (typeof inputs !== "object" || inputs === null || Array.isArray(inputs))) {
       throw new Error("inputs must be an object if provided");
@@ -493,7 +537,6 @@ export class NotebookHandler {
         this.engineRuntime.startRun({
           notebookId,
           mode: mode as any,
-          executionMode,
           inputs,
         }),
       ),

--- a/src/notebook/operations.ts
+++ b/src/notebook/operations.ts
@@ -306,7 +306,7 @@ When 'expectedSnapshotHash' is provided, the operation refuses to run if the cel
   {
     name: "notebook_start_run",
     title: "Start Notebook Evidence Run",
-    description: "Start a Notebook Evidence Engine run for one of the supported modes. Short sync runs complete in-process; async runs create a queued run record for the Cloud Run runner boundary.",
+    description: "Execute a notebook's cells in-process and derive a verdict from the real results. Only runbook mode is implemented; other modes return an explicit not-implemented error. See thoughtbox://notebook/capabilities.",
     category: "evidence-engine",
     inputSchema: {
       type: "object",
@@ -315,25 +315,18 @@ When 'expectedSnapshotHash' is provided, the operation refuses to run if the cel
         mode: {
           type: "string",
           enum: listNotebookModes().map((mode) => mode.mode),
-          description: "Evidence engine mode. See thoughtbox://notebook/capabilities.",
-        },
-        executionMode: {
-          type: "string",
-          enum: ["sync", "async"],
-          description: "sync for short local/server checks; async for long Cloud Run runner work",
+          description: "Evidence engine mode. Only runbook executes today; see thoughtbox://notebook/capabilities for per-mode status.",
         },
         inputs: {
           type: "object",
-          description: "Mode-specific JSON inputs",
+          description: "Mode-specific JSON inputs (recorded as a run artifact)",
         },
       },
       required: ["notebookId", "mode"],
     },
     example: {
       notebookId: "abc123",
-      mode: "eval",
-      executionMode: "sync",
-      inputs: { datasetName: "thoughtbox_notebook_verification" },
+      mode: "runbook",
     },
   },
   {
@@ -366,7 +359,7 @@ When 'expectedSnapshotHash' is provided, the operation refuses to run if the cel
   {
     name: "notebook_cancel_run",
     title: "Cancel Notebook Evidence Run",
-    description: "Cancel a queued/running notebook evidence run.",
+    description: "Cancel a running notebook evidence run.",
     category: "evidence-engine",
     inputSchema: {
       type: "object",

--- a/src/notebook/tool.ts
+++ b/src/notebook/tool.ts
@@ -42,7 +42,6 @@ export const notebookToolInputSchema = z.object({
     "scenario_factory",
     "system_audit",
   ]).optional().describe("Notebook Evidence Engine mode (notebook_start_run)"),
-  executionMode: z.enum(["sync", "async"]).optional().describe("Execution mode for notebook_start_run"),
   inputs: z.record(z.unknown()).optional().describe("Mode-specific JSON inputs for notebook_start_run"),
   runId: z.string().optional().describe("Notebook run ID"),
   artifactId: z.string().optional().describe("Notebook artifact ID"),


### PR DESCRIPTION
## What (SPEC-V1-INITIATIVE Phase 3.6, claim c9)

The Evidence Engine was the deepest "pretending to work" finding in the audit: every sync `notebook_start_run` returned fabricated verdicts (`pass: true`, `score: 1`, audit findings of `"smoke run"`) without executing anything, and async runs queued into a void — no dispatcher exists.

### Changes

- **Real execution**: `notebook_start_run` now executes the notebook's executable cells (package.json installs + code cells, document order, stop on first failure) through the existing real subprocess path (`NotebookStateManager.executeCell`), injected into the engine runtime as a `NotebookCellExecutor`.
- **Real verdicts**: the runbook verdict is derived from actual results — pass only when every cell completed; per-cell evidence (status, exit code, truncated output) on the verdict plus a full `cell-results.json` run artifact. An empty runbook cannot pass.
- **Explicit refusal instead of fiction**: the other seven modes return `NotebookModeNotImplemented` (with a message pointing at `notebook_run_cell`/`notebook_validate` for cell-level evidence). The mode registry and `thoughtbox://notebook/capabilities` now carry per-mode `runStatus: implemented | specified`, so the catalog advertises only what runs.
- **Deleted, not deprecated**: the async/queued branch, the `executionMode` parameter (tool schema, operations catalog, `TB_SDK_TYPES`), and the `QueuedRun`/`InputRequiredRun` domain states nothing could produce.

### Verification

- New tests execute real subprocesses: a runbook designed to fail yields `pass: false` with the failing cell named in the reason and later cells reported `skipped` — c9's required evidence. Plus passing-verdict, empty-evidence, non-runbook-rejection, and queued-run schema-rejection tests.
- `vitest run src/notebook/ src/code-mode/`: 53/53 passing. `tsc --noEmit` and oxlint clean. `rg executionMode|QueuedRun src/` → only the intentional schema-rejection test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)