### PR TITLE
feat(code-mode): expose tb.hub namespace and real hub thought store

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ When participating in an Agent Team, bootstrap Thoughtbox as your reasoning subs
 1. **Load the cipher**: read the `thoughtbox://cipher` MCP resource (reasoning-pattern shorthand, includes the multi-agent extension).
 2. **Begin work** — record decisions as thoughts via `tb.thought` inside `thoughtbox_execute`.
 
-Hub coordination (workspaces, problems, proposals, channels) is implemented but not yet exposed over MCP: `tb.hub.*` arrives with SPEC-V1-INITIATIVE Phase 4.1. Until then the hub is reachable only via the local-mode HTTP surface (`POST /hub/api`), and the spawn-prompt templates in `.claude/team-prompts/` cannot be executed as written — they are rewritten in Phase 4.5.
+Hub coordination (workspaces, problems, proposals, channels) is exposed over MCP as `tb.hub.*` inside `thoughtbox_execute` (SPEC-V1-INITIATIVE Phase 4.1). Call `tb.hub.register({ name })` or `tb.hub.quickJoin({ name, workspaceId })` once — the returned agentId is then implicit for the rest of the session. The local-mode HTTP surface (`POST /hub/api`) remains for non-MCP clients. The spawn-prompt templates in `.claude/team-prompts/` still use the legacy `thoughtbox_hub` syntax — they are rewritten in Phase 4.5.
 
 ### What to Record as Thoughts
 - Key decisions and their reasoning

--- a/src/code-mode/__tests__/execute-tool.test.ts
+++ b/src/code-mode/__tests__/execute-tool.test.ts
@@ -17,6 +17,7 @@ import { InMemoryStorage } from "../../persistence/index.js";
 import { createFileSystemHubStorage } from "../../hub/hub-storage-fs.js";
 import { createHubToolHandler } from "../../hub/hub-tool-handler.js";
 import { createThoughtStoreAdapter } from "../../hub/thought-store-adapter.js";
+import { createHubHandler } from "../../hub/hub-handler.js";
 
 function createHarness(overrides: Partial<ExecuteToolDeps> = {}) {
   const storage = new InMemoryStorage();
@@ -449,5 +450,107 @@ describe("thoughtbox_execute tb.hub", () => {
     const output = JSON.parse(result.content[0].text);
     expect(output.result).toBeNull();
     expect(output.error).toContain("not registered in this session");
+  });
+
+  it("merges across surfaces when the hub thought store is shared", async () => {
+    // A workspace's mainSession is created through the hub thought store.
+    // The /hub/api surface and every MCP session each hold their own
+    // ThoughtboxStorage instance; only a SHARED hub thought store
+    // (server-factory's hubThoughtStore) lets a merge initiated on one
+    // surface find a mainSession created on another. Coordinator identity
+    // is session-bound in tb.hub, so the cross-surface merge goes through
+    // the registry-less hub handler (the /hub/api path) with an explicit
+    // coordinator agentId.
+    const hubDir = await mkdtemp(join(tmpdir(), "tb-hub-xsurface-"));
+    tempHubDirs.push(hubDir);
+    const hubStorage = createFileSystemHubStorage(hubDir);
+    const sharedHubThoughtStorage = new InMemoryStorage();
+    const sharedThoughtStore = createThoughtStoreAdapter(sharedHubThoughtStorage);
+
+    const sessionHandler = createHubToolHandler({
+      hubStorage,
+      thoughtStore: sharedThoughtStore,
+    });
+    const sessionTool = createExecuteTool({
+      hubDispatcher: { handle: (input) => sessionHandler.handle(input, "session-a") },
+    });
+
+    const setup = await sessionTool.handle({
+      code: `async () => {
+        const coordinator = await tb.hub.register({ name: "Coordinator" });
+        const ws = await tb.hub.createWorkspace({
+          name: "Cross-surface Workspace",
+          description: "created via tb.hub",
+        });
+        const reviewer = await tb.hub.register({ name: "Reviewer" });
+        await tb.hub.joinWorkspace({ workspaceId: ws.workspaceId, agentId: reviewer.agentId });
+        const prop = await tb.hub.createProposal({
+          workspaceId: ws.workspaceId,
+          title: "Cross-surface merge",
+          description: "merge from a different surface",
+          sourceBranch: "coordinator/cross-surface",
+        });
+        await tb.hub.reviewProposal({
+          workspaceId: ws.workspaceId,
+          proposalId: prop.proposalId,
+          verdict: "approve",
+          reasoning: "ok",
+          agentId: reviewer.agentId,
+        });
+        return { coordinator, ws, prop };
+      }`,
+    });
+    const setupOut = JSON.parse(setup.content[0].text);
+    expect(setupOut.error).toBeUndefined();
+    const { coordinator, ws, prop } = setupOut.result;
+
+    // Second surface sharing the thought store (post-fix /hub/api wiring):
+    const sharedSurface = createHubHandler(hubStorage, sharedThoughtStore, () => {});
+    const merged = await sharedSurface.handle(coordinator.agentId, "merge_proposal", {
+      workspaceId: ws.workspaceId,
+      proposalId: prop.proposalId,
+      mergeMessage: "Merged from the hub API surface",
+    });
+    expect((merged as { proposal: { status: string } }).proposal.status).toBe("merged");
+    const thoughts = await sharedHubThoughtStorage.getThoughts(ws.mainSessionId);
+    expect(thoughts.some((t) => t.thought === "Merged from the hub API surface")).toBe(true);
+
+    // Control (pre-fix wiring): a surface with its own thought storage has
+    // never seen the workspace mainSession, so the same merge fails on a
+    // fresh approved proposal.
+    const isolatedSurface = createHubHandler(
+      hubStorage,
+      createThoughtStoreAdapter(new InMemoryStorage()),
+      () => {},
+    );
+    const propB = await sessionTool.handle({
+      code: `async () => {
+        const prop = await tb.hub.createProposal({
+          workspaceId: "${ws.workspaceId}",
+          title: "Doomed merge",
+          description: "isolated thought store cannot see mainSession",
+          sourceBranch: "coordinator/doomed",
+        });
+        const reviewer = await tb.hub.register({ name: "Reviewer3" });
+        await tb.hub.joinWorkspace({ workspaceId: "${ws.workspaceId}", agentId: reviewer.agentId });
+        await tb.hub.reviewProposal({
+          workspaceId: "${ws.workspaceId}",
+          proposalId: prop.proposalId,
+          verdict: "approve",
+          reasoning: "ok",
+          agentId: reviewer.agentId,
+        });
+        return prop;
+      }`,
+    });
+    const propBOut = JSON.parse(propB.content[0].text);
+    expect(propBOut.error).toBeUndefined();
+    await expect(
+      isolatedSurface.handle(coordinator.agentId, "merge_proposal", {
+        workspaceId: ws.workspaceId,
+        proposalId: propBOut.result.proposalId,
+        mergeMessage: "should not persist",
+      }),
+    ).rejects.toThrow(/not found/);
   });
 });

--- a/src/code-mode/__tests__/execute-tool.test.ts
+++ b/src/code-mode/__tests__/execute-tool.test.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterAll } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { ExecuteTool, type ExecuteToolDeps } from "../execute-tool.js";
 import { ThoughtTool } from "../../thought/tool.js";
 import { SessionTool } from "../../sessions/tool.js";
@@ -11,8 +14,11 @@ import { SessionHandler } from "../../sessions/index.js";
 import { KnowledgeHandler, FileSystemKnowledgeStorage } from "../../knowledge/index.js";
 import { NotebookHandler } from "../../notebook/index.js";
 import { InMemoryStorage } from "../../persistence/index.js";
+import { createFileSystemHubStorage } from "../../hub/hub-storage-fs.js";
+import { createHubToolHandler } from "../../hub/hub-tool-handler.js";
+import { createThoughtStoreAdapter } from "../../hub/thought-store-adapter.js";
 
-function createExecuteTool(overrides: Partial<ExecuteToolDeps> = {}): ExecuteTool {
+function createHarness(overrides: Partial<ExecuteToolDeps> = {}) {
   const storage = new InMemoryStorage();
   const thoughtHandler = new ThoughtHandler(true, storage);
   const sessionHandler = new SessionHandler({ storage, thoughtHandler });
@@ -20,7 +26,7 @@ function createExecuteTool(overrides: Partial<ExecuteToolDeps> = {}): ExecuteToo
   const notebookHandler = new NotebookHandler();
   const protocolHandler = new InMemoryProtocolHandler();
 
-  return new ExecuteTool({
+  const tool = new ExecuteTool({
     thoughtTool: new ThoughtTool(thoughtHandler),
     sessionTool: new SessionTool(sessionHandler),
     knowledgeTool: new KnowledgeTool(knowledgeHandler),
@@ -30,6 +36,53 @@ function createExecuteTool(overrides: Partial<ExecuteToolDeps> = {}): ExecuteToo
     observabilityHandler: new ObservabilityGatewayHandler({ storage }),
     ...overrides,
   });
+
+  return { tool, storage };
+}
+
+function createExecuteTool(overrides: Partial<ExecuteToolDeps> = {}): ExecuteTool {
+  return createHarness(overrides).tool;
+}
+
+const tempHubDirs: string[] = [];
+
+afterAll(async () => {
+  for (const dir of tempHubDirs) {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+async function createHubHarness() {
+  const hubDir = await mkdtemp(join(tmpdir(), "tb-hub-execute-"));
+  tempHubDirs.push(hubDir);
+
+  const storage = new InMemoryStorage();
+  const thoughtHandler = new ThoughtHandler(true, storage);
+  const sessionHandler = new SessionHandler({ storage, thoughtHandler });
+  const knowledgeHandler = new KnowledgeHandler(new FileSystemKnowledgeStorage({}));
+  const notebookHandler = new NotebookHandler();
+  const protocolHandler = new InMemoryProtocolHandler();
+
+  const hubStorage = createFileSystemHubStorage(hubDir);
+  const hubToolHandler = createHubToolHandler({
+    hubStorage,
+    thoughtStore: createThoughtStoreAdapter(storage),
+  });
+
+  const tool = new ExecuteTool({
+    thoughtTool: new ThoughtTool(thoughtHandler),
+    sessionTool: new SessionTool(sessionHandler),
+    knowledgeTool: new KnowledgeTool(knowledgeHandler),
+    notebookTool: new NotebookTool(notebookHandler),
+    theseusTool: new TheseusTool(protocolHandler),
+    ulyssesTool: new UlyssesTool(protocolHandler),
+    observabilityHandler: new ObservabilityGatewayHandler({ storage }),
+    hubDispatcher: {
+      handle: (input) => hubToolHandler.handle(input, "execute-test-session"),
+    },
+  });
+
+  return { tool, storage };
 }
 
 describe("thoughtbox_execute", () => {
@@ -108,13 +161,16 @@ describe("thoughtbox_execute", () => {
     expect(output.result).toBe("undefined");
   });
 
-  it("tb.hub is not available", async () => {
+  it("tb.hub.* errors cleanly when no hub dispatcher is wired", async () => {
+    // createExecuteTool() omits hubDispatcher (defensive: server started
+    // without hub storage).
     const tool = createExecuteTool();
     const result = await tool.handle({
-      code: `async () => { return typeof tb.hub; }`,
+      code: `async () => { return await tb.hub.listWorkspaces(); }`,
     });
     const output = JSON.parse(result.content[0].text);
-    expect(output.result).toBe("undefined");
+    expect(output.result).toBeNull();
+    expect(output.error).toContain("Hub operations are unavailable");
   });
 
   it("tb.init is not available", async () => {
@@ -274,5 +330,124 @@ describe("thoughtbox_execute", () => {
     });
     const output = JSON.parse(result.content[0].text);
     expect(output.error).toBeDefined();
+  });
+});
+
+describe("thoughtbox_execute tb.hub", () => {
+  it("register makes the agentId implicit for subsequent calls", async () => {
+    const { tool } = await createHubHarness();
+    const result = await tool.handle({
+      code: `async () => {
+        const reg = await tb.hub.register({ name: "Coordinator", profile: "MANAGER" });
+        const who = await tb.hub.whoami();
+        return { reg, who };
+      }`,
+    });
+    const output = JSON.parse(result.content[0].text);
+    expect(output.error).toBeUndefined();
+    expect(output.result.reg.agentId).toBeDefined();
+    expect(output.result.who.agentId).toBe(output.result.reg.agentId);
+    expect(output.result.who.name).toBe("Coordinator");
+  });
+
+  it("runs the workspace/problem/channel flow against FS hub storage", async () => {
+    const { tool } = await createHubHarness();
+    const result = await tool.handle({
+      code: `async () => {
+        await tb.hub.register({ name: "Coordinator" });
+        const ws = await tb.hub.createWorkspace({
+          name: "Phase 4 Workspace",
+          description: "tb.hub namespace test",
+        });
+        const prob = await tb.hub.createProblem({
+          workspaceId: ws.workspaceId,
+          title: "Expose hub over Code Mode",
+          description: "Map operations under tb.hub",
+        });
+        await tb.hub.postMessage({
+          workspaceId: ws.workspaceId,
+          problemId: prob.problemId,
+          content: "starting work",
+        });
+        const channel = await tb.hub.readChannel({
+          workspaceId: ws.workspaceId,
+          problemId: prob.problemId,
+        });
+        const workspaces = await tb.hub.listWorkspaces();
+        return { ws, prob, channel, workspaces };
+      }`,
+    });
+    const output = JSON.parse(result.content[0].text);
+    expect(output.error).toBeUndefined();
+    expect(output.result.ws.workspaceId).toBeDefined();
+    expect(output.result.prob.problemId).toBeDefined();
+    const messages = output.result.channel.messages;
+    expect(messages.some((m: { content: string }) => m.content === "starting work")).toBe(true);
+    expect(
+      output.result.workspaces.workspaces.some(
+        (w: { id: string }) => w.id === output.result.ws.workspaceId,
+      ),
+    ).toBe(true);
+  });
+
+  it("merge_proposal persists the synthesis thought to real thought storage", async () => {
+    const { tool, storage } = await createHubHarness();
+
+    const setup = await tool.handle({
+      code: `async () => {
+        await tb.hub.register({ name: "Coordinator" });
+        const ws = await tb.hub.createWorkspace({
+          name: "Merge Workspace",
+          description: "merge_proposal persistence test",
+        });
+        const reviewer = await tb.hub.register({ name: "Reviewer" });
+        await tb.hub.joinWorkspace({ workspaceId: ws.workspaceId, agentId: reviewer.agentId });
+        const prop = await tb.hub.createProposal({
+          workspaceId: ws.workspaceId,
+          title: "Real delegation",
+          description: "Replace the stub with a facade",
+          sourceBranch: "coordinator/real-delegation",
+        });
+        await tb.hub.reviewProposal({
+          workspaceId: ws.workspaceId,
+          proposalId: prop.proposalId,
+          verdict: "approve",
+          reasoning: "delegation verified",
+          agentId: reviewer.agentId,
+        });
+        const merged = await tb.hub.mergeProposal({
+          workspaceId: ws.workspaceId,
+          proposalId: prop.proposalId,
+          mergeMessage: "Merged: stub replaced with real facade",
+        });
+        return { ws, merged };
+      }`,
+    });
+    const output = JSON.parse(setup.content[0].text);
+    expect(output.error).toBeUndefined();
+    expect(output.result.merged.mergeThoughtNumber).toBe(1);
+    expect(output.result.merged.proposal.status).toBe("merged");
+
+    // The synthesis thought must land in the REAL per-session thought
+    // storage (the same InMemoryStorage the session's ThoughtHandler uses),
+    // not a throwaway stub.
+    const mainSessionId = output.result.ws.mainSessionId;
+    const thoughts = await storage.getThoughts(mainSessionId);
+    expect(
+      thoughts.some((t) => t.thought === "Merged: stub replaced with real facade"),
+    ).toBe(true);
+  });
+
+  it("rejects agentId values not registered in this session", async () => {
+    const { tool } = await createHubHarness();
+    const result = await tool.handle({
+      code: `async () => {
+        await tb.hub.register({ name: "Coordinator" });
+        return await tb.hub.whoami({ agentId: "not-a-registered-agent" });
+      }`,
+    });
+    const output = JSON.parse(result.content[0].text);
+    expect(output.result).toBeNull();
+    expect(output.error).toContain("not registered in this session");
   });
 });

--- a/src/code-mode/__tests__/search-tool.test.ts
+++ b/src/code-mode/__tests__/search-tool.test.ts
@@ -14,6 +14,7 @@ describe("thoughtbox_search", () => {
     expect(output.error).toBeUndefined();
     expect(output.result).toEqual([
       "branch",
+      "hub",
       "knowledge",
       "notebook",
       "observability",
@@ -22,6 +23,19 @@ describe("thoughtbox_search", () => {
       "thought",
       "ulysses",
     ]);
+  });
+
+  it("hub operations are discoverable in the catalog", async () => {
+    const result = await tool.handle({
+      code: "async () => Object.keys(catalog.operations.hub).sort()",
+    });
+    const output = JSON.parse(result.content[0].text);
+    expect(output.error).toBeUndefined();
+    expect(output.result).toHaveLength(28);
+    expect(output.result).toContain("register");
+    expect(output.result).toContain("create_workspace");
+    expect(output.result).toContain("merge_proposal");
+    expect(output.result).toContain("workspace_digest");
   });
 
   it("filters operations by module", async () => {

--- a/src/code-mode/execute-tool.ts
+++ b/src/code-mode/execute-tool.ts
@@ -20,6 +20,7 @@ import type { TheseusTool, TheseusToolInput } from "../protocol/theseus-tool.js"
 import type { UlyssesTool, UlyssesToolInput } from "../protocol/ulysses-tool.js";
 import type { ObservabilityGatewayHandler, ObservabilityInput } from "../observability/gateway-handler.js";
 import type { BranchHandler } from "../branch/index.js";
+import type { HubToolResult } from "../hub/hub-tool-handler.js";
 
 const MAX_LOGS = 100;
 const TIMEOUT_MS = 30_000;
@@ -33,6 +34,17 @@ export const executeToolInputSchema = z.object({
 });
 
 export type ExecuteToolInput = z.infer<typeof executeToolInputSchema>;
+
+/**
+ * Session-bound hub dispatch surface. The server factory wraps the
+ * session's HubToolHandler (which holds the register-once identity
+ * registry) with the MCP session key, so tb.hub callers get an implicit
+ * agentId after their first register/quick_join. agentId remains
+ * overridable per call for multi-agent flows within one session.
+ */
+export interface HubDispatcher {
+  handle(input: { operation: string; [key: string]: unknown }): Promise<HubToolResult>;
+}
 
 export interface ExecuteToolDeps {
   thoughtTool: ThoughtTool;
@@ -56,13 +68,19 @@ export interface ExecuteToolDeps {
    * of crashing session setup.
    */
   branchHandler?: BranchHandler;
+  /**
+   * Per-session dispatcher over the process-shared hub storage. Undefined
+   * when no hub storage was wired at server creation; `tb.hub.*` then
+   * returns a clear error instead of crashing.
+   */
+  hubDispatcher?: HubDispatcher;
 }
 
 export const EXECUTE_TOOL = {
   name: "thoughtbox_execute",
   description: `Run JavaScript using the \`tb\` SDK to chain Thoughtbox operations in a single call.
 
-**One state-mutating operation per call.** Submit only one \`tb.thought()\`, \`tb.ulysses()\`, or \`tb.theseus()\` call per \`thoughtbox_execute\` invocation. Each response contains guidance (patterns, session state, protocol state) that should inform your next operation. Batching multiple state-mutating calls bypasses this feedback loop and produces lower-quality reasoning. Read-only operations (\`tb.session.*\`, \`tb.knowledge.*\`, \`tb.observability()\`, \`tb.branch.*\`) may be freely chained.
+**One state-mutating operation per call.** Submit only one \`tb.thought()\`, \`tb.ulysses()\`, or \`tb.theseus()\` call per \`thoughtbox_execute\` invocation. Each response contains guidance (patterns, session state, protocol state) that should inform your next operation. Batching multiple state-mutating calls bypasses this feedback loop and produces lower-quality reasoning. Read-only operations (\`tb.session.*\`, \`tb.knowledge.*\`, \`tb.observability()\`, \`tb.branch.*\`) and hub coordination calls (\`tb.hub.*\`) may be freely chained.
 
 ${TB_SDK_TYPES}
 
@@ -140,13 +158,73 @@ function normalizeEntityResult(raw: unknown): unknown {
   return raw;
 }
 
+/**
+ * Extract the result value from a hub dispatcher response.
+ * HubToolHandler returns { content: [text, resource?], isError? } where the
+ * text block carries either the operation result or { error } as JSON.
+ */
+function unwrapHubResult(raw: HubToolResult): unknown {
+  const textBlock = raw.content.find(
+    (block): block is { type: "text"; text: string } => block.type === "text",
+  );
+  let parsed: unknown = textBlock?.text;
+  if (textBlock?.text) {
+    try {
+      parsed = JSON.parse(textBlock.text);
+    } catch {
+      parsed = textBlock.text;
+    }
+  }
+  if (raw.isError) {
+    const message = (parsed as { error?: string } | null)?.error;
+    throw new Error(message ?? "Hub operation failed");
+  }
+  return parsed;
+}
+
+/**
+ * tb.hub method names mapped to hub operation names
+ * (canonical list: src/hub/operations.ts).
+ */
+const HUB_SDK_METHODS: Record<string, string> = {
+  register: "register",
+  quickJoin: "quick_join",
+  listWorkspaces: "list_workspaces",
+  whoami: "whoami",
+  createWorkspace: "create_workspace",
+  joinWorkspace: "join_workspace",
+  getProfilePrompt: "get_profile_prompt",
+  createProblem: "create_problem",
+  claimProblem: "claim_problem",
+  updateProblem: "update_problem",
+  listProblems: "list_problems",
+  addDependency: "add_dependency",
+  removeDependency: "remove_dependency",
+  readyProblems: "ready_problems",
+  blockedProblems: "blocked_problems",
+  createSubProblem: "create_sub_problem",
+  createProposal: "create_proposal",
+  reviewProposal: "review_proposal",
+  mergeProposal: "merge_proposal",
+  listProposals: "list_proposals",
+  markConsensus: "mark_consensus",
+  endorseConsensus: "endorse_consensus",
+  listConsensus: "list_consensus",
+  postMessage: "post_message",
+  readChannel: "read_channel",
+  postSystemMessage: "post_system_message",
+  workspaceStatus: "workspace_status",
+  workspaceDigest: "workspace_digest",
+};
+
 interface TbContext {
   sessionId?: string;
 }
 
 function buildTbObject(deps: ExecuteToolDeps, ctx: TbContext): Record<string, unknown> {
   const { thoughtTool, sessionTool, knowledgeTool, notebookTool,
-          theseusTool, ulyssesTool, observabilityHandler, branchHandler } = deps;
+          theseusTool, ulyssesTool, observabilityHandler, branchHandler,
+          hubDispatcher } = deps;
 
   const requireKnowledgeTool = (): KnowledgeTool => {
     if (!knowledgeTool) {
@@ -167,6 +245,23 @@ function buildTbObject(deps: ExecuteToolDeps, ctx: TbContext): Record<string, un
     }
     return branchHandler;
   };
+
+  const requireHubDispatcher = (): HubDispatcher => {
+    if (!hubDispatcher) {
+      throw new Error(
+        "Hub operations are unavailable: no hub storage was wired into this " +
+          "server instance. tb.hub.* requires the server to be started with " +
+          "hub storage (see createMcpServer's hubStorage argument).",
+      );
+    }
+    return hubDispatcher;
+  };
+
+  const hub: Record<string, (args?: Record<string, unknown>) => Promise<unknown>> = {};
+  for (const [method, operation] of Object.entries(HUB_SDK_METHODS)) {
+    hub[method] = async (hubArgs: Record<string, unknown> = {}) =>
+      unwrapHubResult(await requireHubDispatcher().handle({ operation, ...hubArgs }));
+  }
 
   return {
     thought: async (input: ThoughtToolInput) => {
@@ -321,6 +416,8 @@ function buildTbObject(deps: ExecuteToolDeps, ctx: TbContext): Record<string, un
       get: async (args: Record<string, unknown>) =>
         unwrapToolResult(await requireBranchHandler().processTool("get", args)),
     },
+
+    hub,
   };
 }
 

--- a/src/code-mode/execute-tool.ts
+++ b/src/code-mode/execute-tool.ts
@@ -80,7 +80,7 @@ export const EXECUTE_TOOL = {
   name: "thoughtbox_execute",
   description: `Run JavaScript using the \`tb\` SDK to chain Thoughtbox operations in a single call.
 
-**One state-mutating operation per call.** Submit only one \`tb.thought()\`, \`tb.ulysses()\`, or \`tb.theseus()\` call per \`thoughtbox_execute\` invocation. Each response contains guidance (patterns, session state, protocol state) that should inform your next operation. Batching multiple state-mutating calls bypasses this feedback loop and produces lower-quality reasoning. Read-only operations (\`tb.session.*\`, \`tb.knowledge.*\`, \`tb.observability()\`, \`tb.branch.*\`) and hub coordination calls (\`tb.hub.*\`) may be freely chained.
+**One state-mutating operation per call.** Submit only one \`tb.thought()\`, \`tb.ulysses()\`, \`tb.theseus()\`, or hub-mutating call (\`tb.hub.register()\`, \`tb.hub.createWorkspace()\`, \`tb.hub.createProblem()\`, \`tb.hub.mergeProposal()\`, etc.) per \`thoughtbox_execute\` invocation. Each response contains guidance (patterns, session state, protocol state) that should inform your next operation. Batching multiple state-mutating calls bypasses this feedback loop and produces lower-quality reasoning. Read-only operations (\`tb.session.*\`, \`tb.knowledge.*\`, \`tb.observability()\`, \`tb.branch.*\`, \`tb.hub.whoami()\`, \`tb.hub.listWorkspaces()\`, \`tb.hub.readChannel()\`, etc.) may be freely chained.
 
 ${TB_SDK_TYPES}
 

--- a/src/code-mode/index.ts
+++ b/src/code-mode/index.ts
@@ -2,4 +2,4 @@ export { type CodeModeResult } from "./types.js";
 export { type SearchCatalog, buildSearchCatalog } from "./search-index.js";
 export { traceSearch, traceExecute } from "./trace.js";
 export { SearchTool, SEARCH_TOOL, type SearchToolInput } from "./search-tool.js";
-export { ExecuteTool, EXECUTE_TOOL, type ExecuteToolInput, type ExecuteToolDeps } from "./execute-tool.js";
+export { ExecuteTool, EXECUTE_TOOL, type ExecuteToolInput, type ExecuteToolDeps, type HubDispatcher } from "./execute-tool.js";

--- a/src/code-mode/sdk-types.ts
+++ b/src/code-mode/sdk-types.ts
@@ -11,9 +11,12 @@
  * - theseus:       src/protocol/theseus-tool.ts (theseusToolInputSchema)
  * - ulysses:       src/protocol/ulysses-tool.ts (ulyssesToolInputSchema)
  * - observability: src/observability/gateway-handler.ts (ObservabilityInputSchema)
+ * - hub:           src/hub/operations.ts (HUB_OPERATIONS catalog)
  */
 
 export const TB_SDK_TYPES = `\`\`\`ts
+type HubProfile = "MANAGER" | "ARCHITECT" | "DEBUGGER" | "SECURITY" | "RESEARCHER" | "REVIEWER";
+
 interface TB {
   /** Submit a structured thought. Source: src/thought/tool.ts */
   thought(input: {
@@ -149,6 +152,45 @@ interface TB {
     merge(args: { sessionId: string; synthesis: string; selectedBranchId?: string; resolution: "selected" | "synthesized" | "abandoned" }): Promise<unknown>;
     list(args: { sessionId: string }): Promise<unknown>;
     get(args: { sessionId: string; branchId: string }): Promise<unknown>;
+  };
+
+  /**
+   * Multi-agent hub coordination: workspaces, problems, proposals, consensus,
+   * channels. Call register or quickJoin once per session — the returned
+   * agentId is then implicit for every other call. Pass agentId explicitly
+   * only to act as another agent registered in this session.
+   * Source: src/hub/operations.ts
+   */
+  hub: {
+    register(args: { name: string; profile?: HubProfile; clientInfo?: string }): Promise<unknown>;
+    quickJoin(args: { name: string; workspaceId: string; profile?: HubProfile; clientInfo?: string }): Promise<unknown>;
+    listWorkspaces(): Promise<unknown>;
+    whoami(args?: { agentId?: string }): Promise<unknown>;
+    createWorkspace(args: { name: string; description: string; agentId?: string }): Promise<unknown>;
+    joinWorkspace(args: { workspaceId: string; agentId?: string }): Promise<unknown>;
+    getProfilePrompt(args: { profile: HubProfile }): Promise<unknown>;
+    createProblem(args: { workspaceId: string; title: string; description: string; agentId?: string }): Promise<unknown>;
+    claimProblem(args: { workspaceId: string; problemId: string; branchId?: string; agentId?: string }): Promise<unknown>;
+    updateProblem(args: { workspaceId: string; problemId: string; status: "open" | "in-progress" | "resolved" | "closed"; resolution?: string; agentId?: string }): Promise<unknown>;
+    listProblems(args: { workspaceId: string; status?: "open" | "in-progress" | "resolved" | "closed"; assignedTo?: string }): Promise<unknown>;
+    addDependency(args: { workspaceId: string; problemId: string; dependsOnProblemId: string; agentId?: string }): Promise<unknown>;
+    removeDependency(args: { workspaceId: string; problemId: string; dependsOnProblemId: string; agentId?: string }): Promise<unknown>;
+    readyProblems(args: { workspaceId: string }): Promise<unknown>;
+    blockedProblems(args: { workspaceId: string }): Promise<unknown>;
+    createSubProblem(args: { workspaceId: string; parentId: string; title: string; description: string; agentId?: string }): Promise<unknown>;
+    createProposal(args: { workspaceId: string; title: string; description: string; sourceBranch: string; problemId?: string; agentId?: string }): Promise<unknown>;
+    reviewProposal(args: { workspaceId: string; proposalId: string; verdict: "approve" | "request-changes" | "reject"; reasoning: string; thoughtRefs?: number[]; agentId?: string }): Promise<unknown>;
+    /** Coordinator-only; requires at least one approve review. The synthesis thought persists to the workspace main session. */
+    mergeProposal(args: { workspaceId: string; proposalId: string; mergeMessage: string; agentId?: string }): Promise<unknown>;
+    listProposals(args: { workspaceId: string; status?: "open" | "reviewing" | "merged" | "rejected" }): Promise<unknown>;
+    markConsensus(args: { workspaceId: string; name: string; description: string; thoughtRef: number; branchId?: string; agentId?: string }): Promise<unknown>;
+    endorseConsensus(args: { workspaceId: string; consensusId: string; agentId?: string }): Promise<unknown>;
+    listConsensus(args: { workspaceId: string }): Promise<unknown>;
+    postMessage(args: { workspaceId: string; problemId: string; content: string; ref?: { sessionId?: string; thoughtNumber?: number; branchId?: string }; agentId?: string }): Promise<unknown>;
+    readChannel(args: { workspaceId: string; problemId: string; since?: string }): Promise<unknown>;
+    postSystemMessage(args: { workspaceId: string; problemId: string; content: string; ref?: { sessionId?: string; thoughtNumber?: number; branchId?: string } }): Promise<unknown>;
+    workspaceStatus(args: { workspaceId: string }): Promise<unknown>;
+    workspaceDigest(args: { workspaceId: string }): Promise<unknown>;
   };
 }
 \`\`\``;

--- a/src/code-mode/search-index.ts
+++ b/src/code-mode/search-index.ts
@@ -19,6 +19,7 @@ import {
   OBSERVABILITY_OPERATIONS,
 } from "../observability/operations.js";
 import { BRANCH_OPERATIONS } from "../branch/operations.js";
+import { HUB_OPERATIONS } from "../hub/operations.js";
 import { PEER_NOTEBOOK_TOOL } from "../peer-notebook/tool.js";
 
 export interface SearchCatalog {
@@ -240,6 +241,7 @@ export function buildSearchCatalog(): SearchCatalog {
       ulysses: indexOperations(ULYSSES_OPERATIONS),
       observability: indexOperations(OBSERVABILITY_OPERATIONS),
       branch: indexOperations(BRANCH_OPERATIONS),
+      hub: indexOperations(HUB_OPERATIONS),
     },
 
     prompts: [
@@ -350,6 +352,12 @@ export function buildSearchCatalog(): SearchCatalog {
         mimeType: "application/json",
       },
       {
+        name: "Hub Operations Catalog",
+        uri: "thoughtbox://hub/operations",
+        description: "Complete catalog of all 28 hub operations organized by category with stage metadata and vocabulary",
+        mimeType: "application/json",
+      },
+      {
         name: "Thoughtbox Patterns Cookbook",
         uri: "thoughtbox://patterns-cookbook",
         description: "Guide to core reasoning patterns for thoughtbox tool",
@@ -435,6 +443,12 @@ export function buildSearchCatalog(): SearchCatalog {
         name: "Knowledge Operation Detail",
         uriTemplate: "thoughtbox://knowledge/operations/{op}",
         description: "Individual knowledge graph operation schema and examples",
+        mimeType: "application/json",
+      },
+      {
+        name: "Hub Operation Detail",
+        uriTemplate: "thoughtbox://hub/operations/{op}",
+        description: "Individual hub operation schema and examples",
         mimeType: "application/json",
       },
       {

--- a/src/code-mode/search-tool.ts
+++ b/src/code-mode/search-tool.ts
@@ -45,9 +45,9 @@ interface SearchCatalog {
   resourceTemplates: Array<{ name: string; uriTemplate: string; description: string; mimeType: string }>;
 }
 
-Modules in catalog.operations: session, thought, knowledge, notebook, theseus, ulysses, observability, branch
+Modules in catalog.operations: session, thought, knowledge, notebook, theseus, ulysses, observability, branch, hub
 Public MCP tools in catalog.publicTools: thoughtbox_search, thoughtbox_execute, thoughtbox_peer_notebook
-Legacy entrypoints like init and hub are intentionally absent from the Code Mode catalog.
+The legacy init entrypoint is intentionally absent from the Code Mode catalog.
 
 Examples:
 - List all modules: \`async () => Object.keys(catalog.operations)\`

--- a/src/hub/__tests__/tenant-hub-storage.test.ts
+++ b/src/hub/__tests__/tenant-hub-storage.test.ts
@@ -1,0 +1,62 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { createTenantHubStorageProvider } from "../hub-storage-fs.js";
+import type { Workspace } from "../hub-types.js";
+
+const TENANT_A = "11111111-1111-4111-a111-111111111111";
+const TENANT_B = "22222222-2222-4222-a222-222222222222";
+
+function workspace(id: string, name: string): Workspace {
+  return {
+    id,
+    name,
+    description: "",
+    createdBy: "agent-1",
+    createdAt: new Date().toISOString(),
+    agents: [],
+    status: "active",
+  } as unknown as Workspace;
+}
+
+describe("createTenantHubStorageProvider", () => {
+  let baseDir: string;
+
+  beforeEach(async () => {
+    baseDir = await mkdtemp(join(tmpdir(), "tb-tenant-hub-"));
+  });
+
+  afterEach(async () => {
+    await rm(baseDir, { recursive: true, force: true });
+  });
+
+  it("returns the same storage instance for the same tenant", () => {
+    const provider = createTenantHubStorageProvider(baseDir);
+    expect(provider(TENANT_A)).toBe(provider(TENANT_A));
+    expect(provider(TENANT_A)).not.toBe(provider(TENANT_B));
+  });
+
+  it("isolates hub workspaces between tenants", async () => {
+    const provider = createTenantHubStorageProvider(baseDir);
+    const storageA = provider(TENANT_A);
+    const storageB = provider(TENANT_B);
+
+    await storageA.saveWorkspace(workspace("ws-a", "Tenant A workspace"));
+
+    const seenByA = await storageA.listWorkspaces();
+    const seenByB = await storageB.listWorkspaces();
+
+    expect(seenByA.map((ws) => ws.id)).toEqual(["ws-a"]);
+    expect(seenByB).toEqual([]);
+    expect(await storageB.getWorkspace("ws-a")).toBeNull();
+  });
+
+  it("rejects tenant ids that are not path-safe", () => {
+    const provider = createTenantHubStorageProvider(baseDir);
+    expect(() => provider("../escape")).toThrow(/Invalid tenant workspace id/);
+    expect(() => provider("a/b")).toThrow(/Invalid tenant workspace id/);
+    expect(() => provider("")).toThrow(/Invalid tenant workspace id/);
+  });
+});

--- a/src/hub/hub-storage-fs.ts
+++ b/src/hub/hub-storage-fs.ts
@@ -190,3 +190,31 @@ export function createFileSystemHubStorage(dataDir: string): HubStorage {
     },
   };
 }
+
+/**
+ * Per-tenant hub storage provider for multi-tenant mode. Each tenant
+ * workspace gets its own storage root (data/hub-tenants/<workspaceId>),
+ * so hub workspaces, agents, proposals, and channels are invisible across
+ * tenants. Interim isolation until SupabaseHubStorage (SPEC-V1-INITIATIVE
+ * Phase 4.3) scopes rows by tenant in Postgres.
+ */
+export function createTenantHubStorageProvider(
+  baseDir: string,
+): (tenantWorkspaceId: string) => HubStorage {
+  const cache = new Map<string, HubStorage>();
+  return (tenantWorkspaceId: string): HubStorage => {
+    if (!/^[A-Za-z0-9_-]+$/.test(tenantWorkspaceId)) {
+      throw new Error(
+        `Invalid tenant workspace id for hub storage: ${tenantWorkspaceId}`,
+      );
+    }
+    let storage = cache.get(tenantWorkspaceId);
+    if (!storage) {
+      storage = createFileSystemHubStorage(
+        join(baseDir, 'hub-tenants', tenantWorkspaceId),
+      );
+      cache.set(tenantWorkspaceId, storage);
+    }
+    return storage;
+  };
+}

--- a/src/hub/operations.ts
+++ b/src/hub/operations.ts
@@ -1,7 +1,7 @@
 /**
  * Operations Catalog for Hub Toolhost
  *
- * Defines all 27 hub operations organized by category with stage metadata.
+ * Defines all 28 hub operations organized by category with stage metadata.
  * Includes hub vocabulary for agent onboarding.
  */
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,10 @@ import {
 import type { HubStorage } from "./hub/hub-types.js";
 import { initEvaluation, initMonitoring } from "./evaluation/index.js";
 import { createHubHandler, type HubEvent } from "./hub/hub-handler.js";
-import { createThoughtStoreAdapter } from "./hub/thought-store-adapter.js";
+import {
+  createThoughtStoreAdapter,
+  type ThoughtStoreAdapter,
+} from "./hub/thought-store-adapter.js";
 import { createHubApiSurface, shouldWarnOnExposedLocalMode } from "./http/hub-http.js";
 import { createEventStreamSurface } from "./http/event-stream.js";
 import type { ThoughtboxEvent } from "./events/types.js";
@@ -169,12 +172,28 @@ interface SessionEntry {
 
 async function startHttpServer() {
   const { factory, hubStorage, dataDir } = await createStorage();
+  const isMultiTenant = process.env.THOUGHTBOX_STORAGE === "supabase";
 
   // Multi-tenant hub isolation: each tenant workspace gets its own hub
   // storage root, so tb.hub can never enumerate or read another tenant's
   // workspaces/channels. The shared `hubStorage` is local-mode only.
   // SupabaseHubStorage (Phase 4.3) replaces this with row-level scoping.
   const tenantHubStorage = createTenantHubStorageProvider(dataDir);
+
+  // Local-mode hub thought store: ONE storage instance shared by /hub/api
+  // and every local MCP session's tb.hub dispatcher. Per-session
+  // FileSystemStorage instances each hold an in-memory session index, so a
+  // hub main-session created through one instance is invisible to the
+  // others — merge_proposal from a second MCP session would fail with
+  // "Session not found". Multi-tenant mode needs no shared instance:
+  // Supabase storage resolves sessions from the database on every call.
+  let localHubThoughtStore: ThoughtStoreAdapter | undefined;
+  if (!isMultiTenant) {
+    const hubSessionStorage = factory.getStorage();
+    await hubSessionStorage.initialize();
+    await hubSessionStorage.setProject(await ensureStaticWorkspace("local-dev"));
+    localHubThoughtStore = createThoughtStoreAdapter(hubSessionStorage);
+  }
 
   // Initialize LangSmith evaluation tracing (no-op if LANGSMITH_API_KEY not set)
   const traceListener = initEvaluation();
@@ -186,7 +205,6 @@ async function startHttpServer() {
   });
 
   const port = parseInt(process.env.PORT || "1731", 10);
-  const isMultiTenant = process.env.THOUGHTBOX_STORAGE === 'supabase';
   const sessions = new Map<string, SessionEntry>();
 
   // Cloud Run (and most reverse proxies) set X-Forwarded-For.
@@ -418,6 +436,7 @@ async function startHttpServer() {
         sessionId,
         storage,
         hubStorage,
+        hubThoughtStore: localHubThoughtStore,
         dataDir,
         knowledgeStorage,
         workspaceId: localWorkspaceId,
@@ -494,13 +513,10 @@ async function startHttpServer() {
   // delegates to real filesystem session storage scoped to the local
   // workspace — the same project MCP sessions write to — so hub-created
   // sessions and merge_proposal synthesis thoughts genuinely persist.
-  if (!isMultiTenant) {
-    const hubApiStorage = factory.getStorage();
-    await hubApiStorage.setProject(await ensureStaticWorkspace('local-dev'));
-
+  if (!isMultiTenant && localHubThoughtStore) {
     const hubHandler = createHubHandler(
       hubStorage,
-      createThoughtStoreAdapter(hubApiStorage),
+      localHubThoughtStore,
       broadcastHubEvent,
     );
     const hubApiSurface = createHubApiSurface(hubHandler);

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ import { createFileSystemHubStorage } from "./hub/hub-storage-fs.js";
 import type { HubStorage } from "./hub/hub-types.js";
 import { initEvaluation, initMonitoring } from "./evaluation/index.js";
 import { createHubHandler, type HubEvent } from "./hub/hub-handler.js";
+import { createThoughtStoreAdapter } from "./hub/thought-store-adapter.js";
 import { createHubApiSurface, shouldWarnOnExposedLocalMode } from "./http/hub-http.js";
 import { createEventStreamSurface } from "./http/event-stream.js";
 import type { ThoughtboxEvent } from "./events/types.js";
@@ -191,6 +192,19 @@ async function startHttpServer() {
       "[Security] Local/singleton mode is bound to 0.0.0.0. Hub HTTP endpoints and local storage are not workspace-isolated; do not expose this server to untrusted users.",
     );
   }
+
+  // Unified event stream — carries both Hub and Protocol events via SSE
+  // (mounted in local mode only, below)
+  const eventStream = createEventStreamSurface();
+  const broadcastHubEvent = (event: HubEvent) => {
+    eventStream.broadcast({
+      source: 'hub',
+      type: event.type,
+      workspaceId: event.workspaceId,
+      timestamp: new Date().toISOString(),
+      data: event.data,
+    });
+  };
 
   // ---------------------------------------------------------------------------
   // OAuth 2.1 — mount auth router (discovery, registration, token, revoke)
@@ -389,6 +403,7 @@ async function startHttpServer() {
         workspaceId: localWorkspaceId,
         onProtocolHandlerReady: (handler) => { localProtocolHandler = handler; },
         onProtocolEvent: (event) => eventStream.broadcast(event),
+        onHubEvent: broadcastHubEvent,
         config: {
           disableThoughtLogging:
             (process.env.DISABLE_THOUGHT_LOGGING || "").toLowerCase() === "true",
@@ -448,51 +463,6 @@ async function startHttpServer() {
   // Hub Event SSE Endpoint — pushes HubEvents to Channel subscribers
   // ---------------------------------------------------------------------------
 
-  // Minimal thought store for the shared hub-handler (hub operations that
-  // create sessions/thoughts use this; most Channel operations don't need it)
-  const sharedThoughtStore = {
-    sessions: new Map<string, Map<number, unknown>>(),
-    async createSession(sessionId: string) {
-      this.sessions.set(sessionId, new Map());
-    },
-    async saveThought(sessionId: string, thought: any) {
-      if (!this.sessions.has(sessionId)) this.sessions.set(sessionId, new Map());
-      this.sessions.get(sessionId)!.set(thought.thoughtNumber, thought);
-    },
-    async getThought(sessionId: string, thoughtNumber: number) {
-      return this.sessions.get(sessionId)?.get(thoughtNumber) ?? null;
-    },
-    async getThoughts(sessionId: string) {
-      const session = this.sessions.get(sessionId);
-      if (!session) return [];
-      return [...session.values()];
-    },
-    async getThoughtCount(sessionId: string) {
-      return this.sessions.get(sessionId)?.size ?? 0;
-    },
-    async saveBranchThought(_sessionId: string, _branchId: string, _thought: any) {},
-    async getBranch(_sessionId: string, _branchId: string) { return []; },
-  };
-
-  // Unified event stream — carries both Hub and Protocol events via SSE
-  const eventStream = createEventStreamSurface();
-
-  const hubHandler = createHubHandler(
-    hubStorage,
-    sharedThoughtStore,
-    (event: HubEvent) => {
-      eventStream.broadcast({
-        source: 'hub',
-        type: event.type,
-        workspaceId: event.workspaceId,
-        timestamp: new Date().toISOString(),
-        data: event.data,
-      });
-    },
-  );
-
-  const hubApiSurface = createHubApiSurface(hubHandler);
-
   const protocolHttpSurface = createProtocolHttpSurface(() => {
     for (const entry of sessions.values()) {
       if (entry.protocolHandler) return entry.protocolHandler;
@@ -500,7 +470,21 @@ async function startHttpServer() {
     return null;
   });
 
+  // Local-mode hub HTTP surface (`POST /hub/api`). Its thought store
+  // delegates to real filesystem session storage scoped to the local
+  // workspace — the same project MCP sessions write to — so hub-created
+  // sessions and merge_proposal synthesis thoughts genuinely persist.
   if (!isMultiTenant) {
+    const hubApiStorage = factory.getStorage();
+    await hubApiStorage.setProject(await ensureStaticWorkspace('local-dev'));
+
+    const hubHandler = createHubHandler(
+      hubStorage,
+      createThoughtStoreAdapter(hubApiStorage),
+      broadcastHubEvent,
+    );
+    const hubApiSurface = createHubApiSurface(hubHandler);
+
     eventStream.mount(app);
     hubApiSurface.mount(app);
     protocolHttpSurface.mount(app);

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,10 @@ import {
 } from "./persistence/index.js";
 import { SupabaseKnowledgeStorage } from "./knowledge/index.js";
 import type { KnowledgeStorage } from "./knowledge/types.js";
-import { createFileSystemHubStorage } from "./hub/hub-storage-fs.js";
+import {
+  createFileSystemHubStorage,
+  createTenantHubStorageProvider,
+} from "./hub/hub-storage-fs.js";
 import type { HubStorage } from "./hub/hub-types.js";
 import { initEvaluation, initMonitoring } from "./evaluation/index.js";
 import { createHubHandler, type HubEvent } from "./hub/hub-handler.js";
@@ -166,6 +169,12 @@ interface SessionEntry {
 
 async function startHttpServer() {
   const { factory, hubStorage, dataDir } = await createStorage();
+
+  // Multi-tenant hub isolation: each tenant workspace gets its own hub
+  // storage root, so tb.hub can never enumerate or read another tenant's
+  // workspaces/channels. The shared `hubStorage` is local-mode only.
+  // SupabaseHubStorage (Phase 4.3) replaces this with row-level scoping.
+  const tenantHubStorage = createTenantHubStorageProvider(dataDir);
 
   // Initialize LangSmith evaluation tracing (no-op if LANGSMITH_API_KEY not set)
   const traceListener = initEvaluation();
@@ -313,6 +322,16 @@ async function startHttpServer() {
     try {
       // --- Multi-tenant (Supabase) mode: per-session servers ---
       if (isMultiTenant) {
+        if (!workspaceId) {
+          // Auth above guarantees a workspaceId in multi-tenant mode; this
+          // guard keeps that invariant explicit and fails fast if it breaks.
+          res.status(401).json({
+            jsonrpc: "2.0",
+            error: { code: -32001, message: "Authenticated request resolved no workspace" },
+            id: null,
+          });
+          return;
+        }
         if (mcpSessionId && sessions.has(mcpSessionId)) {
           const entry = sessions.get(mcpSessionId)!;
 
@@ -341,7 +360,8 @@ async function startHttpServer() {
         const server = await createMcpServer({
           sessionId,
           storage,
-          hubStorage,
+          // Tenant-scoped: never the process-shared local hub storage.
+          hubStorage: tenantHubStorage(workspaceId),
           dataDir,
           knowledgeStorage,
           workspaceId,

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -4,7 +4,10 @@ import { z } from "zod"; // hypothesis test 3
 import type { HubStorage } from "./hub/hub-types.js";
 import type { HubEvent } from "./hub/hub-handler.js";
 import { createHubToolHandler } from "./hub/hub-tool-handler.js";
-import { createThoughtStoreAdapter } from "./hub/thought-store-adapter.js";
+import {
+  createThoughtStoreAdapter,
+  type ThoughtStoreAdapter,
+} from "./hub/thought-store-adapter.js";
 import { FileSystemTaskStore } from "./hub/hub-task-store.js";
 import { InMemoryTaskStore, InMemoryTaskMessageQueue } from "@modelcontextprotocol/sdk/experimental/tasks/stores/in-memory.js";
 import { PATTERNS_COOKBOOK } from "./resources/patterns-cookbook-content.js";
@@ -140,6 +143,16 @@ export interface CreateMcpServerArgs {
    * visible across MCP sessions; tb.hub.* is unavailable without it.
    */
   hubStorage?: HubStorage;
+  /**
+   * Shared thought store for hub session persistence. Local mode must pass
+   * the single process-shared adapter: per-session FileSystemStorage holds
+   * an in-memory session index, so hub main-sessions created by one MCP
+   * session would otherwise be invisible to another (merge_proposal would
+   * fail with "Session not found"). When omitted, falls back to this
+   * session's storage — correct for Supabase, which resolves sessions from
+   * the database on every call.
+   */
+  hubThoughtStore?: ThoughtStoreAdapter;
   /** Optional callback for hub events (local-mode unified event stream) */
   onHubEvent?: (event: HubEvent) => void;
   /** Data directory for task store (filesystem persistence) */
@@ -610,7 +623,7 @@ Use \`console.log()\` for debugging — output captured in response logs.`;
   const hubToolHandler = args.hubStorage
     ? createHubToolHandler({
         hubStorage: args.hubStorage,
-        thoughtStore: createThoughtStoreAdapter(storage),
+        thoughtStore: args.hubThoughtStore ?? createThoughtStoreAdapter(storage),
         envAgentId: process.env.THOUGHTBOX_AGENT_ID,
         envAgentName: process.env.THOUGHTBOX_AGENT_NAME,
         onEvent: args.onHubEvent,

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -2,6 +2,9 @@ import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mc
 import { ListResourcesRequestSchema, ListResourceTemplatesRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod"; // hypothesis test 3
 import type { HubStorage } from "./hub/hub-types.js";
+import type { HubEvent } from "./hub/hub-handler.js";
+import { createHubToolHandler } from "./hub/hub-tool-handler.js";
+import { createThoughtStoreAdapter } from "./hub/thought-store-adapter.js";
 import { FileSystemTaskStore } from "./hub/hub-task-store.js";
 import { InMemoryTaskStore, InMemoryTaskMessageQueue } from "@modelcontextprotocol/sdk/experimental/tasks/stores/in-memory.js";
 import { PATTERNS_COOKBOOK } from "./resources/patterns-cookbook-content.js";
@@ -131,8 +134,14 @@ export interface CreateMcpServerArgs {
    * Use FileSystemStorage for durable persistence to disk.
    */
   storage?: ThoughtboxStorage;
-  /** Hub storage for multi-agent coordination */
+  /**
+   * Hub storage for multi-agent coordination. Must be the single
+   * process-shared instance so workspaces, agents, and proposals are
+   * visible across MCP sessions; tb.hub.* is unavailable without it.
+   */
   hubStorage?: HubStorage;
+  /** Optional callback for hub events (local-mode unified event stream) */
+  onHubEvent?: (event: HubEvent) => void;
   /** Data directory for task store (filesystem persistence) */
   dataDir?: string;
   /** Optional pre-created knowledge storage (used by Supabase mode) */
@@ -591,6 +600,30 @@ Use \`console.log()\` for debugging — output captured in response logs.`;
   // Code Mode Tools (replaces individual tool registrations)
   // =============================================================================
 
+  // Hub dispatcher — tb.hub.* over the process-shared hub storage.
+  // Hub state (workspaces, agents, proposals) is shared across MCP sessions
+  // via args.hubStorage; the thought store delegates to THIS session's
+  // storage so merge_proposal synthesis thoughts persist with the session's
+  // real backend (filesystem locally, Supabase when hosted).
+  // The HubToolHandler keeps a register-once identity registry keyed by the
+  // session, so agentId is implicit after the first register/quick_join.
+  const hubToolHandler = args.hubStorage
+    ? createHubToolHandler({
+        hubStorage: args.hubStorage,
+        thoughtStore: createThoughtStoreAdapter(storage),
+        envAgentId: process.env.THOUGHTBOX_AGENT_ID,
+        envAgentName: process.env.THOUGHTBOX_AGENT_NAME,
+        onEvent: args.onHubEvent,
+      })
+    : undefined;
+  const hubSessionKey = sessionId ?? "local";
+  const hubDispatcher = hubToolHandler
+    ? {
+        handle: (input: { operation: string; [key: string]: unknown }) =>
+          hubToolHandler.handle(input, hubSessionKey),
+      }
+    : undefined;
+
   const searchCatalog = buildSearchCatalog();
   const searchTool = new SearchTool(searchCatalog);
   const executeTool = new ExecuteTool({
@@ -603,6 +636,7 @@ Use \`console.log()\` for debugging — output captured in response logs.`;
     ulyssesTool,
     observabilityHandler,
     branchHandler,
+    hubDispatcher,
   });
 
   registerTool(SEARCH_TOOL, searchTool);
@@ -1340,7 +1374,7 @@ async () => tb.thought({
     "hub-operations",
     "thoughtbox://hub/operations",
     {
-      description: "Complete catalog of all 27 hub operations organized by category with stage metadata and vocabulary",
+      description: "Complete catalog of all 28 hub operations organized by category with stage metadata and vocabulary",
       mimeType: "application/json",
     },
     async (uri) => ({
@@ -1358,7 +1392,7 @@ async () => tb.thought({
     "gateway-operations",
     "thoughtbox://gateway/operations",
     {
-      description: "Complete catalog of operations available through the Code Mode gateway, grouped by tb SDK module (thought, session, knowledge, notebook, theseus, ulysses, observability, branch)",
+      description: "Complete catalog of operations available through the Code Mode gateway, grouped by tb SDK module (thought, session, knowledge, notebook, theseus, ulysses, observability, branch, hub)",
       mimeType: "application/json",
     },
     async (uri) => ({
@@ -1752,7 +1786,7 @@ async () => tb.thought({
       {
         uri: "thoughtbox://gateway/operations",
         name: "Gateway Operations Catalog",
-        description: "Complete catalog of operations available through the Code Mode gateway, grouped by tb SDK module (thought, session, knowledge, notebook, theseus, ulysses, observability, branch)",
+        description: "Complete catalog of operations available through the Code Mode gateway, grouped by tb SDK module (thought, session, knowledge, notebook, theseus, ulysses, observability, branch, hub)",
         mimeType: "application/json",
       },
       {
@@ -1770,7 +1804,7 @@ async () => tb.thought({
       {
         uri: "thoughtbox://hub/operations",
         name: "Hub Operations Catalog",
-        description: "Complete catalog of all 27 hub operations with stage metadata and vocabulary",
+        description: "Complete catalog of all 28 hub operations with stage metadata and vocabulary",
         mimeType: "application/json",
       },
       {


### PR DESCRIPTION
Implements SPEC-V1-INITIATIVE Phase 4.1 and 4.2. Claim: `SPEC-V1-INITIATIVE:c10`.

## 4.1 — tb.hub.* through thoughtbox_execute

- `ExecuteToolDeps` gains an optional `hubDispatcher`; `buildTbObject` maps all 28 hub operations (canonical list: `src/hub/operations.ts`) under `tb.hub.*` with camelCase method names, following the `tb.branch` pattern.
- `createMcpServer` constructs a per-session `HubToolHandler` over the process-shared `hubStorage`, so workspaces/agents/proposals are shared across MCP sessions while identity stays session-scoped: `register`/`quickJoin` once, agentId is implicit afterward, overridable per call for agents registered in the same session. Multi-tenant sessions get `tb.hub` too (workspace is the trust boundary; FileSystemHubStorage interim until 4.3).
- `TB_SDK_TYPES` documents typed signatures for every hub operation (consensus params per the corrected catalog: `endorse_consensus.consensusId`, `mark_consensus.thoughtRef: number`, `merge_proposal.mergeMessage`).
- Search catalog adds the `hub` module plus the hub catalog resource/template entries; the "hub intentionally absent" sentence is removed from the search tool description. `init` remains absent.
- When no hub storage is wired, `tb.hub.*` returns a clear error (same pattern as `requireBranchHandler`).

## 4.2 — real thought-store delegation

- The in-memory `sharedThoughtStore` stub in `src/index.ts` (no-op `saveBranchThought`, empty `getBranch`) is deleted.
- Each session's hub dispatcher delegates through `createThoughtStoreAdapter` to that session's real storage, and the local-mode `/hub/api` surface uses the same adapter over filesystem storage scoped to the local workspace. `merge_proposal` synthesis thoughts now persist to real session storage; branch-thought methods delegate to `ThoughtboxStorage.saveBranchThought`/`getBranch`.
- Hub events from `tb.hub` sessions broadcast on the local `/events` SSE stream. `/hub/api` and `/events` remain local-mode-only; no new HTTP surfaces.

## Tests

- `execute-tool.test.ts`: register/whoami implicit-identity, workspace/problem/channel flow against a temp-dir FileSystemHubStorage, merge_proposal asserting the synthesis thought lands in the real per-session storage, unregistered-agentId rejection, and a clean error when the hub dep is absent.
- `search-tool.test.ts`: hub module in the module list; 28 hub operations discoverable.
- Suites run: `src/code-mode/` 40 passed, `src/hub/` 202 passed, full suite 610 passed / 1 pre-existing env-dependent failure in `src/branch/__tests__/handlers.test.ts` (fails identically on a clean checkout; unrelated to this change). `tsc --noEmit` and `oxlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)