### PR TITLE
test(branch): supply required signingSecret in handlers test deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,7 @@ ai_docs/claude-platform-docs/
 dgm-specs/history/runs/*.json
 thoughtbox-web-two/
 .worktrees/
+.claude/worktrees/
 
 *.db
 

--- a/src/branch/__tests__/handlers.test.ts
+++ b/src/branch/__tests__/handlers.test.ts
@@ -12,6 +12,7 @@ function createHandlerWithFakeClient(fakeClient: unknown): BranchHandlers {
   const handler = new BranchHandlers({
     supabaseUrl: 'http://127.0.0.1:54321',
     serviceRoleKey: 'service-role-key',
+    signingSecret: 'test-branch-signing-secret',
     workspaceId: WORKSPACE_ID,
   });
 


### PR DESCRIPTION
## What

Fixes the test failure that has kept main's CI **Test Suite red since the TB_BRANCH_SIGNING_SECRET change** (#362): `src/branch/__tests__/handlers.test.ts` predates the change and constructed `BranchHandlers` without the now-required `signingSecret`, so `createHmac` threw on `undefined` in the workspace-binding test. One-line dep addition.

## Why it slipped through

- `tsc --noEmit` doesn't cover test files (the missing required property would otherwise have been a compile error) — worth a follow-up to include tests in typecheck.
- Main's CI has been failing on exactly this test across the last several merges; I should have caught the red checks earlier.

## Verification

- `vitest run src/branch/__tests__/handlers.test.ts`: 6/6 pass.
- tsc/oxlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)