### PR TITLE
fix(ci): link prod project before schema drift diff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,10 +119,25 @@ jobs:
       - name: Start local Supabase
         run: supabase start -x realtime,storage-api,imgproxy,mailpit,postgres-meta,studio,edge-runtime,logflare,vector,supavisor
 
+      - name: Link production project
+        # db diff --linked needs a linked project ref; the checkout has none
+        # (supabase/.temp is not committed). Without this step the diff fails
+        # with "Cannot find project ref" — which the old error handling then
+        # misreported as schema drift.
+        run: supabase link --project-ref akjccuoncxlvrrtkvtno
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+
       - name: Check for schema drift against production
         run: |
-          DIFF=$(supabase db diff --linked 2>&1) || true
-          if [ -n "$DIFF" ] && ! echo "$DIFF" | grep -q "^$"; then
+          set -uo pipefail
+          if ! DIFF=$(supabase db diff --linked); then
+            echo "::error::supabase db diff failed to run (not a drift verdict)"
+            echo "$DIFF"
+            exit 1
+          fi
+          if [ -n "$DIFF" ]; then
             echo "::error::Schema drift detected between migrations and production"
             echo "$DIFF"
             exit 1


### PR DESCRIPTION
## What

Main's **Schema Drift Check** has been failing on every run — masked until #375 turned Test Suite green. Root cause is plumbing, not drift: the job runs `supabase db diff --linked` with no linked project ref (`supabase/.temp` isn't committed), so it always dies with `Cannot find project ref`, and the old error handling (`2>&1 || true` + non-empty check) misreported that CLI error as schema drift.

### Changes

- Add a `supabase link --project-ref akjccuoncxlvrrtkvtno` step before the diff (uses the existing `SUPABASE_ACCESS_TOKEN` / `SUPABASE_DB_PASSWORD` secrets).
- Split failure modes honestly: command failure → "diff failed to run (not a drift verdict)"; non-empty diff → drift. No more `|| true` swallowing.

### Verification

- actionlint + zizmor clean.
- This PR's own CI run exercises the fixed job against live prod — its Schema Drift Check result is the real verdict. If it reports genuine drift, that's prod state to reconcile (separately), not this PR's failure mode. Note: if `SUPABASE_DB_PASSWORD` isn't actually prod's DB password, the link step will fail visibly — that secret's provenance is worth confirming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)