### PR TITLE
feat(notebook): typed outcome contracts and honest runbook verdicts

### DIFF
--- a/.specs/agx/SPEC-AGX-SUBSTRATE.md
+++ b/.specs/agx/SPEC-AGX-SUBSTRATE.md
@@ -231,6 +231,35 @@ verify ledger" manually from prose JSON, leaving no durable record. As a runbook
 `await` cells on workflow-conclusion claims, `exec` cells for cleanup via `gh`/`git` targets,
 `assert` cells on ledger state. This is Experiment H2's substrate.
 
+### 5.1 Outcome contract (adopted design, 2026-06-12 — implemented by B4a)
+
+1. **Per-cell contracts, document verdict derived.** An exec/code cell may declare an outcome
+   contract. The document verdict passes iff every declared expectation was evaluated and
+   passed (a procedurally failed cell still fails the run). A runbook with zero declared
+   contracts keeps its procedural verdict but carries `contractCoverage: 0` and a reason
+   stating "procedural completion only — no outcome contracts declared", so fitness (B9)
+   excludes contract-less runs from pass-rates.
+2. **Two tiers.** Tier 1 is pure data — `{ source, op, value }` with source ∈ { exitCode,
+   output (RFC 6901 JSON pointer into the cell's structured output), artifact ref,
+   claim-status } and op ∈ { eq, ne, lt, lte, gt, gte, matches, schema (minimal JSON Schema
+   subset) } — validated with zod on the compile path (authored data, not Effect Schema).
+   Claim-status resolution sits behind a narrow injected resolver interface; unwired it yields
+   an `error` result ("claim resolver not wired") until the claims layer merges. Tier 2 is the
+   existing validator-cell machinery (validatorFor, snapshot+hash), mechanics unchanged, with
+   verdicts mapped into the same per-expectation record model tagged `tier: 2` so future
+   fitness gating (negative controls) can discriminate.
+3. **Binding at authoring, hash-checked at run** (Ulysses pattern): contracts compile
+   parse-only (extract → zod → canonicalize → sha256, mirroring `peer.manifest.json`); the
+   hash is re-verified before any cell executes; mismatch = tampering = run rejected with a
+   distinct error.
+4. **Result semantics:** per-expectation result ∈ { pass, fail, error, skipped }. error =
+   could not evaluate; fail = evaluated false; skipped = cell never reached. skipped and error
+   are never pass. Verdict evidence carries per-expectation records
+   (cellId, expectation, tier, result, expected, actual-or-error).
+5. **Actuals from declared channels only:** exit code, JSON pointer into the structured output
+   the cell writes to its `TB_OUTPUT_PATH` sidecar (the validator env-var-to-sidecar pattern),
+   or artifact ref. Free-text stdout is never scraped.
+
 ## 6. Layer 3: Governed Capability Plane (EXISTS — deltas only)
 
 SPEC-CONTROL-PLANE delivered the broker (sole invocation authority; manifest, schema, budget,
@@ -281,7 +310,8 @@ Phases 4+5 (≈9 M-units) shipped in about a week of agent-team time.
 | B1 | Claim graph schema + storage + RLS migration | hub-table pattern (#377) | **M** | Low | Contract-suite-first; Supabase implementation first (§11.5); FS backend gated on H1/H2 passing |
 | B2 | `tb.claims.*` Code Mode surface | catalog/execute infra | **S** | Low | Mechanical once B1 lands |
 | B3 | Subscription registry + Realtime propagation + `affected` traversal | #380 publication | **M** | Med | Delivery split by subscriber type (§11.1): push to cells, staleness-check/digest for agents; depends on #393 for web clients |
-| B4 | Runbook template/instance model + typed outcome schema | notebook subsystem, agentic-runbooks spec | **M** | Med | The outcome-contract design is the load-bearing decision |
+| B4a | Typed outcome-contract schema + honest verdict derivation | notebook subsystem, agentic-runbooks spec | **M** | Med | The load-bearing decision; adopted design recorded in §5.1 |
+| B4b | Durable run/instance persistence + fitness ledger rows | B4a | **M** | Med | Discovered gap: NotebookRun is in-memory only; instances must become append-only durable records |
 | B5 | Ordered execution + append-only instance enforcement | B4 | **S/M** | Low | Reject, don't warn |
 | B6 | `await` cell ↔ claim subscription binding + runnable marking | B3+B4 | **M** | Med | The novel integration; nothing like it exists yet |
 | B7 | Brokered `exec`-cell execution (generalize broker beyond peers) | SPEC-CONTROL-PLANE broker | **M/L** | Med | Authority model resolved to manifest reuse (§11.2): approved templates carry declared authority; drafts run under declared ∩ executor |
@@ -294,11 +324,11 @@ Phases 4+5 (≈9 M-units) shipped in about a week of agent-team time.
 | — | Durable suspended execution | — | **XL** | — | Explicitly rejected (Principle 5) |
 | — | Production isolation runtime (smolvm) | SPEC-CONTROL-PLANE | **L** | — | Already tracked separately (thoughtbox-vdw) |
 
-**v0 testbed total: B1–B11 ≈ 10 units, predominantly M** — comparable to the Phase 4+5 block
+**v0 testbed total: B1–B11 ≈ 11 units, predominantly M** — comparable to the Phase 4+5 block
 just shipped. The decision that deserves the most design attention before code is the
-outcome-contract schema (B4); the cell execution authority model (B7) is resolved in
-principle (§11.2) but its manifest-reuse design should be validated against the actual
-compilation path before implementation.
+outcome-contract schema (B4a, adopted in §5.1); the cell execution authority model (B7) is
+resolved in principle (§11.2) but its manifest-reuse design should be validated against the
+actual compilation path before implementation.
 
 ## 9. Experiments — What We Are Trying to Test
 

--- a/.specs/agx/SPEC-AGX-SUBSTRATE.md
+++ b/.specs/agx/SPEC-AGX-SUBSTRATE.md
@@ -259,6 +259,12 @@ verify ledger" manually from prose JSON, leaving no durable record. As a runbook
 5. **Actuals from declared channels only:** exit code, JSON pointer into the structured output
    the cell writes to its `TB_OUTPUT_PATH` sidecar (the validator env-var-to-sidecar pattern),
    or artifact ref. Free-text stdout is never scraped.
+6. **Bindings survive the .src.md encoding.** `encode` persists each bound cell's id,
+   contract (with hash), `validatorFor`, and validator snapshot hash in a
+   `<!-- thoughtbox:cell {...} -->` comment between the filename heading and the code fence;
+   `decode` restores them, re-verifies the contract hash (tampered exports are rejected
+   loudly, same gate as run time), and refuses dangling or duplicate bindings. Notebooks
+   without bindings encode byte-identically to the legacy format.
 
 ## 6. Layer 3: Governed Capability Plane (EXISTS — deltas only)
 

--- a/src/notebook/__tests__/contracts.test.ts
+++ b/src/notebook/__tests__/contracts.test.ts
@@ -1,0 +1,374 @@
+import { describe, expect, it } from "vitest";
+import {
+  checkJsonSchemaSubset,
+  compileOutcomeContract,
+  ContractCompileError,
+  ContractHashMismatchError,
+  evaluateExpectation,
+  expectationRecordFromValidation,
+  resolveJsonPointer,
+  skippedValidatorRecord,
+  verifyAttachedContract,
+  type ExpectationEvaluationContext,
+  type OutcomeExpectation,
+} from "../contracts.js";
+
+function contract(expectations: unknown[]): unknown {
+  return { schemaVersion: "outcome-contract.v0", expectations };
+}
+
+const completedContext = (
+  overrides: Partial<ExpectationEvaluationContext> = {},
+): ExpectationEvaluationContext => ({
+  cellId: "cell_1",
+  cellStatus: "completed",
+  exitCode: 0,
+  ...overrides,
+});
+
+describe("outcome contract compile path", () => {
+  it("compiles a valid contract with a canonical sha256 hash", () => {
+    const attached = compileOutcomeContract(
+      contract([{ source: { kind: "exitCode" }, op: "eq", value: 0 }]),
+    );
+    expect(attached.contractHash).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(attached.contract.expectations).toHaveLength(1);
+  });
+
+  it("hashes are key-order independent (canonicalization)", () => {
+    const a = compileOutcomeContract({
+      schemaVersion: "outcome-contract.v0",
+      expectations: [{ source: { kind: "exitCode" }, op: "eq", value: 0 }],
+    });
+    const b = compileOutcomeContract({
+      expectations: [{ value: 0, op: "eq", source: { kind: "exitCode" } }],
+      schemaVersion: "outcome-contract.v0",
+    });
+    expect(a.contractHash).toBe(b.contractHash);
+  });
+
+  it("rejects empty expectation lists", () => {
+    expect(() => compileOutcomeContract(contract([]))).toThrow(ContractCompileError);
+  });
+
+  it("rejects ordered ops with non-numeric values", () => {
+    expect(() =>
+      compileOutcomeContract(
+        contract([{ source: { kind: "exitCode" }, op: "lt", value: "ten" }]),
+      ),
+    ).toThrow(/numeric value/);
+  });
+
+  it("rejects matches with an invalid regex", () => {
+    expect(() =>
+      compileOutcomeContract(
+        contract([{ source: { kind: "output", pointer: "/x" }, op: "matches", value: "(" }]),
+      ),
+    ).toThrow(/not a valid regex/);
+  });
+
+  it("rejects schema op with a non-subset value", () => {
+    expect(() =>
+      compileOutcomeContract(
+        contract([{ source: { kind: "output", pointer: "" }, op: "schema", value: { type: "integer" } }]),
+      ),
+    ).toThrow(/JSON Schema subset/);
+  });
+
+  it("rejects unknown source kinds and malformed pointers", () => {
+    expect(() =>
+      compileOutcomeContract(contract([{ source: { kind: "stdout" }, op: "eq", value: 1 }])),
+    ).toThrow(ContractCompileError);
+    expect(() =>
+      compileOutcomeContract(
+        contract([{ source: { kind: "output", pointer: "x/y" }, op: "eq", value: 1 }]),
+      ),
+    ).toThrow(/JSON pointer/);
+  });
+
+  it("detects post-attach tampering via hash re-verification", () => {
+    const attached = compileOutcomeContract(
+      contract([{ source: { kind: "exitCode" }, op: "eq", value: 0 }]),
+    );
+    expect(() => verifyAttachedContract("cell_1", attached)).not.toThrow();
+
+    const tampered = structuredClone(attached);
+    (tampered.contract.expectations[0] as { value: unknown }).value = 1;
+    expect(() => verifyAttachedContract("cell_1", tampered)).toThrow(
+      ContractHashMismatchError,
+    );
+  });
+});
+
+describe("RFC 6901 JSON pointer resolution", () => {
+  const doc = {
+    metrics: { count: 3, "a/b": "slash", "m~n": "tilde" },
+    items: [{ ok: true }, { ok: false }],
+  };
+
+  it('resolves "" to the whole document', () => {
+    expect(resolveJsonPointer(doc, "")).toEqual({ found: true, value: doc });
+  });
+
+  it("resolves nested properties and array indices", () => {
+    expect(resolveJsonPointer(doc, "/metrics/count")).toEqual({ found: true, value: 3 });
+    expect(resolveJsonPointer(doc, "/items/1/ok")).toEqual({ found: true, value: false });
+  });
+
+  it("unescapes ~1 and ~0 tokens", () => {
+    expect(resolveJsonPointer(doc, "/metrics/a~1b")).toEqual({ found: true, value: "slash" });
+    expect(resolveJsonPointer(doc, "/metrics/m~0n")).toEqual({ found: true, value: "tilde" });
+  });
+
+  it("reports missing properties, bad indices, and non-container descent", () => {
+    expect(resolveJsonPointer(doc, "/metrics/missing").found).toBe(false);
+    expect(resolveJsonPointer(doc, "/items/9").found).toBe(false);
+    expect(resolveJsonPointer(doc, "/items/01").found).toBe(false);
+    expect(resolveJsonPointer(doc, "/metrics/count/deeper").found).toBe(false);
+  });
+});
+
+describe("tier-1 expectation evaluation (pass/fail/error/skipped)", () => {
+  const exitZero: OutcomeExpectation = { source: { kind: "exitCode" }, op: "eq", value: 0 };
+
+  it("passes when the extracted actual satisfies the op", () => {
+    const record = evaluateExpectation(exitZero, completedContext());
+    expect(record).toMatchObject({ result: "pass", tier: 1, actual: 0 });
+  });
+
+  it("fails when evaluated false — and fail is not error", () => {
+    const record = evaluateExpectation(exitZero, completedContext({ exitCode: 2 }));
+    expect(record.result).toBe("fail");
+    expect(record.error).toBeUndefined();
+    expect(record.actual).toBe(2);
+  });
+
+  it("errors when the exit code is unavailable", () => {
+    const record = evaluateExpectation(exitZero, completedContext({ exitCode: null }));
+    expect(record.result).toBe("error");
+    expect(record.error).toContain("exit code unavailable");
+  });
+
+  it("skips when the cell was never reached — skipped is not pass", () => {
+    const record = evaluateExpectation(
+      exitZero,
+      completedContext({ cellStatus: "skipped", exitCode: null }),
+    );
+    expect(record.result).toBe("skipped");
+  });
+
+  it("extracts structured output via JSON pointer", () => {
+    const expectation: OutcomeExpectation = {
+      source: { kind: "output", pointer: "/metrics/count" },
+      op: "gte",
+      value: 3,
+    };
+    const record = evaluateExpectation(
+      expectation,
+      completedContext({ structuredOutputRaw: '{"metrics":{"count":3}}' }),
+    );
+    expect(record).toMatchObject({ result: "pass", actual: 3 });
+  });
+
+  it("errors on a missing pointer (never fail, never pass)", () => {
+    const expectation: OutcomeExpectation = {
+      source: { kind: "output", pointer: "/metrics/missing" },
+      op: "eq",
+      value: 1,
+    };
+    const record = evaluateExpectation(
+      expectation,
+      completedContext({ structuredOutputRaw: '{"metrics":{}}' }),
+    );
+    expect(record.result).toBe("error");
+    expect(record.error).toContain("not found");
+  });
+
+  it("errors when the cell wrote no structured output", () => {
+    const expectation: OutcomeExpectation = {
+      source: { kind: "output", pointer: "/x" },
+      op: "eq",
+      value: 1,
+    };
+    const record = evaluateExpectation(expectation, completedContext());
+    expect(record.result).toBe("error");
+    expect(record.error).toContain("TB_OUTPUT_PATH");
+  });
+
+  it("errors when structured output is not valid JSON", () => {
+    const expectation: OutcomeExpectation = {
+      source: { kind: "output", pointer: "" },
+      op: "eq",
+      value: 1,
+    };
+    const record = evaluateExpectation(
+      expectation,
+      completedContext({ structuredOutputRaw: "not json" }),
+    );
+    expect(record.result).toBe("error");
+  });
+
+  it("errors on output expectations when the cell failed pre-assertion", () => {
+    const expectation: OutcomeExpectation = {
+      source: { kind: "output", pointer: "/x" },
+      op: "eq",
+      value: 1,
+    };
+    const record = evaluateExpectation(
+      expectation,
+      completedContext({
+        cellStatus: "failed",
+        exitCode: 1,
+        structuredOutputRaw: '{"x":1}',
+      }),
+    );
+    expect(record.result).toBe("error");
+  });
+
+  it("still evaluates exitCode expectations on failed cells", () => {
+    const expectation: OutcomeExpectation = { source: { kind: "exitCode" }, op: "eq", value: 2 };
+    const record = evaluateExpectation(
+      expectation,
+      completedContext({ cellStatus: "failed", exitCode: 2 }),
+    );
+    expect(record.result).toBe("pass");
+  });
+
+  it("supports ne, matches, and schema ops; type mismatches are errors", () => {
+    const raw = '{"status":"green","count":7}';
+    const ne = evaluateExpectation(
+      { source: { kind: "output", pointer: "/status" }, op: "ne", value: "red" },
+      completedContext({ structuredOutputRaw: raw }),
+    );
+    expect(ne.result).toBe("pass");
+
+    const matches = evaluateExpectation(
+      { source: { kind: "output", pointer: "/status" }, op: "matches", value: "^gr" },
+      completedContext({ structuredOutputRaw: raw }),
+    );
+    expect(matches.result).toBe("pass");
+
+    const matchesNonString = evaluateExpectation(
+      { source: { kind: "output", pointer: "/count" }, op: "matches", value: "^7$" },
+      completedContext({ structuredOutputRaw: raw }),
+    );
+    expect(matchesNonString.result).toBe("error");
+
+    const ltNonNumber = evaluateExpectation(
+      { source: { kind: "output", pointer: "/status" }, op: "lt", value: 5 },
+      completedContext({ structuredOutputRaw: raw }),
+    );
+    expect(ltNonNumber.result).toBe("error");
+
+    const schemaPass = evaluateExpectation(
+      {
+        source: { kind: "output", pointer: "" },
+        op: "schema",
+        value: { type: "object", required: ["status"], properties: { count: { type: "number" } } },
+      },
+      completedContext({ structuredOutputRaw: raw }),
+    );
+    expect(schemaPass.result).toBe("pass");
+
+    const schemaFail = evaluateExpectation(
+      { source: { kind: "output", pointer: "" }, op: "schema", value: { type: "object", required: ["missing"] } },
+      completedContext({ structuredOutputRaw: raw }),
+    );
+    expect(schemaFail.result).toBe("fail");
+  });
+
+  it("extracts from run artifacts by name", () => {
+    const expectation: OutcomeExpectation = {
+      source: { kind: "artifact", name: "inputs.json", pointer: "/dataset" },
+      op: "eq",
+      value: "demo",
+    };
+    const record = evaluateExpectation(
+      expectation,
+      completedContext({
+        readArtifact: (name) => (name === "inputs.json" ? '{"dataset":"demo"}' : undefined),
+      }),
+    );
+    expect(record).toMatchObject({ result: "pass", actual: "demo" });
+
+    const missing = evaluateExpectation(
+      { source: { kind: "artifact", name: "nope.json" }, op: "eq", value: 1 },
+      completedContext({ readArtifact: () => undefined }),
+    );
+    expect(missing.result).toBe("error");
+    expect(missing.error).toContain("not found");
+  });
+
+  it("claim-status expectations error with a clear message until the resolver is wired", () => {
+    const expectation: OutcomeExpectation = {
+      source: { kind: "claimStatus", claimId: "claim_42" },
+      op: "eq",
+      value: "supported",
+    };
+    const unwired = evaluateExpectation(expectation, completedContext());
+    expect(unwired.result).toBe("error");
+    expect(unwired.error).toBe("claim resolver not wired");
+
+    const wired = evaluateExpectation(
+      expectation,
+      completedContext({ claimResolver: { resolve: () => "supported" } }),
+    );
+    expect(wired.result).toBe("pass");
+  });
+});
+
+describe("JSON Schema subset checker", () => {
+  it("checks types, required, nested properties, items, and additionalProperties", () => {
+    expect(checkJsonSchemaSubset({ a: 1 }, { type: "object" })).toBeNull();
+    expect(checkJsonSchemaSubset([], { type: "object" })).toContain("expected type object");
+    expect(checkJsonSchemaSubset(null, { type: "null" })).toBeNull();
+    expect(
+      checkJsonSchemaSubset({ a: { b: "x" } }, { properties: { a: { properties: { b: { type: "number" } } } } }),
+    ).toContain("properties.a");
+    expect(checkJsonSchemaSubset([1, "two"], { items: { type: "number" } })).toContain("items[1]");
+    expect(
+      checkJsonSchemaSubset({ a: 1, b: 2 }, { properties: { a: {} }, additionalProperties: false }),
+    ).toContain('additional property "b"');
+  });
+});
+
+describe("tier-2 validator verdict mapping", () => {
+  const base = { validatorCellId: "val_1", targetCellId: "step_1" };
+
+  it("maps a passing validator verdict to a tier-2 pass record", () => {
+    const record = expectationRecordFromValidation({
+      ...base,
+      result: { pass: true, reason: "count is 3", hashMatched: true, exitCode: 0 },
+    });
+    expect(record).toMatchObject({ tier: 2, result: "pass", cellId: "val_1" });
+  });
+
+  it("maps a verdict-written fail to fail, not error", () => {
+    const record = expectationRecordFromValidation({
+      ...base,
+      result: { pass: false, reason: "count != 3", evidence: { count: 5 }, hashMatched: true, exitCode: 0 },
+    });
+    expect(record.result).toBe("fail");
+    expect(record.error).toBeUndefined();
+  });
+
+  it("maps machinery failures (crash, timeout, malformed, hash mismatch) to error", () => {
+    for (const reason of [
+      "validator_crash",
+      "validator_timeout_or_crash",
+      "malformed_verdict",
+      "snapshot_hash_mismatch",
+    ]) {
+      const record = expectationRecordFromValidation({
+        ...base,
+        result: { pass: false, reason, hashMatched: reason !== "snapshot_hash_mismatch", exitCode: 1 },
+      });
+      expect(record.result).toBe("error");
+      expect(record.error).toBe(reason);
+    }
+  });
+
+  it("produces skipped records for unreached validators", () => {
+    expect(skippedValidatorRecord("val_1", "step_1").result).toBe("skipped");
+  });
+});

--- a/src/notebook/__tests__/encoding.test.ts
+++ b/src/notebook/__tests__/encoding.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from "vitest";
+import { encode, decode } from "../encoding.js";
+import { compileOutcomeContract } from "../contracts.js";
+import type { Notebook, CodeCell } from "../types.js";
+
+function baseNotebook(cells: Notebook["cells"]): Notebook {
+  return {
+    id: "nb_test",
+    cells,
+    language: "javascript",
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}
+
+function codeCell(overrides: Partial<CodeCell> & { id: string; filename: string }): CodeCell {
+  return {
+    type: "code",
+    language: "javascript",
+    source: 'console.log("hi");',
+    status: "idle",
+    ...overrides,
+  };
+}
+
+const CONTRACT_INPUT = {
+  schemaVersion: "outcome-contract.v0",
+  expectations: [
+    { source: { kind: "exitCode" }, op: "eq", value: 0 },
+    { source: { kind: "output", pointer: "/count" }, op: "gte", value: 3 },
+  ],
+};
+
+describe(".src.md encoding round trip", () => {
+  it("round-trips a plain notebook without emitting binding metadata", () => {
+    const notebook = baseNotebook([
+      { id: "t", type: "title", text: "Plain" },
+      codeCell({ id: "c1", filename: "step.js" }),
+    ]);
+
+    const srcmd = encode(notebook);
+    expect(srcmd).not.toContain("thoughtbox:cell");
+
+    const decoded = decode(srcmd);
+    const code = decoded.cells.find((c) => c.type === "code") as CodeCell;
+    expect(code.source).toBe('console.log("hi");');
+    expect(code.contract).toBeUndefined();
+    expect(code.validatorFor).toBeUndefined();
+  });
+
+  it("round-trips a tier-1 contract with its hash and the cell id", () => {
+    const attached = compileOutcomeContract(CONTRACT_INPUT);
+    const notebook = baseNotebook([
+      codeCell({ id: "cell_contracted", filename: "step.js", contract: attached }),
+    ]);
+
+    const srcmd = encode(notebook);
+    expect(srcmd).toContain("<!-- thoughtbox:cell ");
+
+    const decoded = decode(srcmd);
+    const code = decoded.cells.find((c) => c.type === "code") as CodeCell;
+    expect(code.id).toBe("cell_contracted");
+    expect(code.contract).toEqual(attached);
+    expect(code.contract!.contractHash).toBe(attached.contractHash);
+  });
+
+  it("round-trips a tier-2 validator binding including target cell id", () => {
+    const notebook = baseNotebook([
+      codeCell({ id: "subject", filename: "step.js" }),
+      codeCell({
+        id: "checker",
+        filename: "check.js",
+        validatorFor: "subject",
+        validatorSnapshotHash: "deadbeef",
+      }),
+    ]);
+
+    const decoded = decode(encode(notebook));
+    const cells = decoded.cells.filter((c) => c.type === "code") as CodeCell[];
+    const subject = cells.find((c) => c.filename === "step.js")!;
+    const checker = cells.find((c) => c.filename === "check.js")!;
+    // The target's id is persisted so the binding still resolves.
+    expect(subject.id).toBe("subject");
+    expect(checker.validatorFor).toBe("subject");
+    expect(checker.validatorSnapshotHash).toBe("deadbeef");
+  });
+
+  it("round-trip is stable: encode(decode(encode(n))) === encode(n)", () => {
+    const attached = compileOutcomeContract(CONTRACT_INPUT);
+    const notebook = baseNotebook([
+      { id: "t", type: "title", text: "Stable" },
+      codeCell({ id: "subject", filename: "step.js", contract: attached }),
+      codeCell({
+        id: "checker",
+        filename: "check.js",
+        validatorFor: "subject",
+        validatorSnapshotHash: "deadbeef",
+      }),
+    ]);
+
+    const once = encode(notebook);
+    expect(encode(decode(once))).toBe(once);
+  });
+
+  it("rejects a tampered contract loudly on decode (hash mismatch)", () => {
+    const attached = compileOutcomeContract(CONTRACT_INPUT);
+    const srcmd = encode(
+      baseNotebook([codeCell({ id: "c1", filename: "step.js", contract: attached })]),
+    );
+    const tampered = srcmd.replace('"value":0', '"value":1');
+    expect(tampered).not.toBe(srcmd);
+    expect(() => decode(tampered)).toThrow(/contract hash mismatch/);
+  });
+
+  it("rejects malformed binding metadata loudly", () => {
+    const srcmd = [
+      '<!-- srcbook:{"language":"javascript"} -->',
+      "",
+      "###### step.js",
+      "",
+      "<!-- thoughtbox:cell {not json} -->",
+      "",
+      "```javascript",
+      "console.log(1);",
+      "```",
+      "",
+    ].join("\n");
+    expect(() => decode(srcmd)).toThrow(/not valid JSON/);
+  });
+
+  it("rejects a dangling validatorFor reference loudly", () => {
+    const srcmd = [
+      '<!-- srcbook:{"language":"javascript"} -->',
+      "",
+      "###### check.js",
+      "",
+      '<!-- thoughtbox:cell {"id":"checker","validatorFor":"ghost"} -->',
+      "",
+      "```javascript",
+      "console.log(1);",
+      "```",
+      "",
+    ].join("\n");
+    expect(() => decode(srcmd)).toThrow(/validatorFor target ghost/);
+  });
+
+  it("rejects duplicate persisted cell ids loudly", () => {
+    const cellBlock = (filename: string) =>
+      [
+        `###### ${filename}`,
+        "",
+        '<!-- thoughtbox:cell {"id":"dup"} -->',
+        "",
+        "```javascript",
+        "console.log(1);",
+        "```",
+        "",
+      ].join("\n");
+    const srcmd = [
+      '<!-- srcbook:{"language":"javascript"} -->',
+      "",
+      cellBlock("a.js"),
+      cellBlock("b.js"),
+    ].join("\n");
+    expect(() => decode(srcmd)).toThrow(/Duplicate cell id "dup"/);
+  });
+
+  it("rejects metadata declaring both contract and validatorFor", () => {
+    const attached = compileOutcomeContract(CONTRACT_INPUT);
+    const metadata = JSON.stringify({
+      id: "c1",
+      contract: attached,
+      validatorFor: "c0",
+    });
+    const srcmd = [
+      '<!-- srcbook:{"language":"javascript"} -->',
+      "",
+      "###### step.js",
+      "",
+      `<!-- thoughtbox:cell ${metadata} -->`,
+      "",
+      "```javascript",
+      "console.log(1);",
+      "```",
+      "",
+    ].join("\n");
+    expect(() => decode(srcmd)).toThrow(/either a tier-1 contract or validatorFor/);
+  });
+
+  it("still decodes legacy .src.md content without binding metadata", () => {
+    const srcmd = [
+      '<!-- srcbook:{"language":"typescript"} -->',
+      "",
+      "# Legacy",
+      "",
+      "Some prose.",
+      "",
+      "###### step.ts",
+      "",
+      "```typescript",
+      'console.log("legacy");',
+      "```",
+      "",
+    ].join("\n");
+    const decoded = decode(srcmd);
+    expect(decoded.cells.map((c) => c.type)).toEqual(["title", "markdown", "code"]);
+  });
+});

--- a/src/notebook/__tests__/engine.test.ts
+++ b/src/notebook/__tests__/engine.test.ts
@@ -559,7 +559,11 @@ describe("Outcome contracts (SPEC-AGX-SUBSTRATE B4a)", () => {
 
     const verdict = await runVerdict(handler, notebookId);
     expect(verdict.pass).toBe(false);
+    // No subprocess ran, so stderr is empty — the verdict reason must carry
+    // the machinery diagnostic, not an empty trailer after "exit code none:".
+    expect(verdict.reason).toContain("snapshot_hash_mismatch");
     const check = verdict.evidence.find((cell) => cell.filename === "check.js")!;
+    expect(check.error).toBe("snapshot_hash_mismatch");
     expect(check.expectations![0]).toMatchObject({
       tier: 2,
       result: "error",

--- a/src/notebook/__tests__/engine.test.ts
+++ b/src/notebook/__tests__/engine.test.ts
@@ -614,3 +614,78 @@ describe("Outcome contracts (SPEC-AGX-SUBSTRATE B4a)", () => {
     expect(wiredVerdict.contractCoverage).toBe(1);
   });
 });
+
+describe("validatorFor authoring guards", () => {
+  async function newRunbookWithStep(handler: NotebookHandler) {
+    const created = await handler.handleCreateNotebook({
+      title: "Guards",
+      language: "javascript",
+    });
+    const notebookId = created.notebook.id as string;
+    const step = await handler.handleAddCell({
+      notebookId,
+      cellType: "code",
+      filename: "step.js",
+      content: WRITE_OUTPUT_SOURCE("{ count: 3 }"),
+    });
+    return { notebookId, stepId: step.cell.id as string };
+  }
+
+  it("rejects a validator that targets another validator cell", async () => {
+    const handler = new NotebookHandler();
+    await handler.init();
+    const { notebookId, stepId } = await newRunbookWithStep(handler);
+
+    const validator = await handler.handleAddCell({
+      notebookId,
+      cellType: "code",
+      filename: "check.js",
+      content: 'import { pass } from "./tb-validate.js"; pass("ok");',
+      validatorFor: stepId,
+    });
+
+    await expect(
+      handler.handleAddCell({
+        notebookId,
+        cellType: "code",
+        filename: "check2.js",
+        content: 'import { pass } from "./tb-validate.js"; pass("ok");',
+        validatorFor: validator.cell.id,
+      }),
+    ).rejects.toThrow(/is itself a validator cell/);
+  });
+
+  it("rejects a validator inserted at or before its target in document order", async () => {
+    const handler = new NotebookHandler();
+    await handler.init();
+    const { notebookId, stepId } = await newRunbookWithStep(handler);
+
+    await expect(
+      handler.handleAddCell({
+        notebookId,
+        cellType: "code",
+        filename: "check.js",
+        content: 'import { pass } from "./tb-validate.js"; pass("ok");',
+        validatorFor: stepId,
+        position: 0,
+      }),
+    ).rejects.toThrow(/must come after its target/);
+  });
+
+  it("accepts a validator inserted after its target via explicit position", async () => {
+    const handler = new NotebookHandler();
+    await handler.init();
+    const { notebookId, stepId } = await newRunbookWithStep(handler);
+
+    const added = await handler.handleAddCell({
+      notebookId,
+      cellType: "code",
+      filename: "check.js",
+      content: 'import { pass } from "./tb-validate.js"; pass("ok");',
+      validatorFor: stepId,
+      position: 99,
+    });
+    expect(added.success).toBe(true);
+    expect(added.cell.validatorFor).toBe(stepId);
+  });
+});

--- a/src/notebook/__tests__/engine.test.ts
+++ b/src/notebook/__tests__/engine.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { Effect, Schema as S } from "effect";
 import { NotebookHandler } from "../index.js";
-import { InMemoryNotebookEngineRuntime } from "../engine/runtime.js";
+import {
+  InMemoryNotebookEngineRuntime,
+  type CellExecutionEvidence,
+} from "../engine/runtime.js";
+import { compileOutcomeContract, type ExpectationRecord } from "../contracts.js";
 import {
   BoundValidatorSchema,
   NotebookDocumentSchema,
@@ -181,6 +185,12 @@ describe("Notebook Evidence Engine runs", () => {
     const verdict = runResult.run.outputs[0];
     expect(verdict._tag).toBe("RunbookVerdict");
     expect(verdict.pass).toBe(true);
+    // Zero declared contracts: backward-compatible procedural verdict, but
+    // explicitly marked so downstream fitness excludes it from pass-rates.
+    expect(verdict.contractCoverage).toBe(0);
+    expect(verdict.reason).toContain(
+      "procedural completion only — no outcome contracts declared",
+    );
     // Evidence covers the default package.json install cell plus step1.js.
     const evidence = verdict.evidence as Array<Record<string, unknown>>;
     expect(evidence).toHaveLength(2);
@@ -318,5 +328,289 @@ describe("Notebook Evidence Engine runs", () => {
 
     const listed = await handler.handleListRuns({ notebookId: created.notebook.id });
     expect(listed.runs).toHaveLength(0);
+  });
+});
+
+const WRITE_OUTPUT_SOURCE = (json: string) =>
+  `import { writeFileSync } from "node:fs";\n` +
+  `writeFileSync(process.env.TB_OUTPUT_PATH, JSON.stringify(${json}));\n` +
+  `console.log("step ran");`;
+
+type VerdictShape = {
+  pass: boolean;
+  reason: string;
+  contractCoverage: number;
+  evidence: Array<Record<string, unknown> & { expectations?: ExpectationRecord[] }>;
+};
+
+describe("Outcome contracts (SPEC-AGX-SUBSTRATE B4a)", () => {
+  async function newRunbook(handler: NotebookHandler, title: string) {
+    const created = await handler.handleCreateNotebook({ title, language: "javascript" });
+    return created.notebook.id as string;
+  }
+
+  async function runVerdict(handler: NotebookHandler, notebookId: string) {
+    const runResult = await handler.handleStartRun({ notebookId, mode: "runbook" });
+    expect(runResult.run.status).toBe("completed");
+    return runResult.run.outputs[0] as VerdictShape;
+  }
+
+  it("passes a contracted run when all declared expectations pass", async () => {
+    const handler = new NotebookHandler();
+    await handler.init();
+    const notebookId = await newRunbook(handler, "Contracted pass");
+
+    const added = await handler.handleAddCell({
+      notebookId,
+      cellType: "code",
+      filename: "step.js",
+      content: WRITE_OUTPUT_SOURCE('{ count: 3, status: "green" }'),
+      contract: {
+        schemaVersion: "outcome-contract.v0",
+        expectations: [
+          { source: { kind: "exitCode" }, op: "eq", value: 0 },
+          { source: { kind: "output", pointer: "/count" }, op: "gte", value: 3 },
+          { source: { kind: "output", pointer: "/status" }, op: "matches", value: "^gr" },
+        ],
+      },
+    });
+    expect(added.cell.contractHash).toMatch(/^sha256:/);
+
+    const verdict = await runVerdict(handler, notebookId);
+    expect(verdict.pass).toBe(true);
+    expect(verdict.contractCoverage).toBe(1);
+    expect(verdict.reason).toContain("declared expectation(s) passed");
+
+    const step = verdict.evidence.find((cell) => cell.filename === "step.js")!;
+    expect(step.contractHash).toBe(added.cell.contractHash);
+    expect(step.expectations).toHaveLength(3);
+    expect(step.expectations!.every((record) => record.result === "pass")).toBe(true);
+    expect(step.expectations!.every((record) => record.tier === 1)).toBe(true);
+  });
+
+  it("fails when an expectation evaluates false — contracted verdicts beat procedural completion", async () => {
+    const handler = new NotebookHandler();
+    await handler.init();
+    const notebookId = await newRunbook(handler, "Contracted fail");
+
+    // The cell completes procedurally (exit 0) but the declared outcome is wrong.
+    await handler.handleAddCell({
+      notebookId,
+      cellType: "code",
+      filename: "step.js",
+      content: WRITE_OUTPUT_SOURCE("{ count: 1 }"),
+      contract: {
+        schemaVersion: "outcome-contract.v0",
+        expectations: [{ source: { kind: "output", pointer: "/count" }, op: "gte", value: 3 }],
+      },
+    });
+
+    const verdict = await runVerdict(handler, notebookId);
+    expect(verdict.pass).toBe(false);
+    expect(verdict.reason).toContain("fail");
+    const step = verdict.evidence.find((cell) => cell.filename === "step.js")!;
+    expect(step.expectations![0]!.result).toBe("fail");
+    expect(step.expectations![0]!.actual).toBe(1);
+  });
+
+  it("marks unevaluable expectations as error, never pass or fail", async () => {
+    const handler = new NotebookHandler();
+    await handler.init();
+    const notebookId = await newRunbook(handler, "Contracted error");
+
+    await handler.handleAddCell({
+      notebookId,
+      cellType: "code",
+      filename: "step.js",
+      content: WRITE_OUTPUT_SOURCE("{ count: 3 }"),
+      contract: {
+        schemaVersion: "outcome-contract.v0",
+        expectations: [{ source: { kind: "output", pointer: "/missing" }, op: "eq", value: 3 }],
+      },
+    });
+
+    const verdict = await runVerdict(handler, notebookId);
+    expect(verdict.pass).toBe(false);
+    const step = verdict.evidence.find((cell) => cell.filename === "step.js")!;
+    expect(step.expectations![0]!.result).toBe("error");
+    expect(step.expectations![0]!.error).toContain("not found");
+  });
+
+  it("marks expectations on unreached cells as skipped — skipped is never pass", async () => {
+    const handler = new NotebookHandler();
+    await handler.init();
+    const notebookId = await newRunbook(handler, "Contracted skip");
+
+    await handler.handleAddCell({
+      notebookId,
+      cellType: "code",
+      filename: "boom.js",
+      content: "process.exit(1);",
+    });
+    await handler.handleAddCell({
+      notebookId,
+      cellType: "code",
+      filename: "later.js",
+      content: WRITE_OUTPUT_SOURCE("{ count: 3 }"),
+      contract: {
+        schemaVersion: "outcome-contract.v0",
+        expectations: [{ source: { kind: "output", pointer: "/count" }, op: "eq", value: 3 }],
+      },
+    });
+
+    const verdict = await runVerdict(handler, notebookId);
+    expect(verdict.pass).toBe(false);
+    const later = verdict.evidence.find((cell) => cell.filename === "later.js")!;
+    expect(later.status).toBe("skipped");
+    expect(later.expectations![0]!.result).toBe("skipped");
+  });
+
+  it("rejects the run when an attached contract was tampered with after authoring", async () => {
+    const handler = new NotebookHandler();
+    await handler.init();
+    const notebookId = await newRunbook(handler, "Tampered contract");
+
+    const added = await handler.handleAddCell({
+      notebookId,
+      cellType: "code",
+      filename: "step.js",
+      content: 'console.log("ok");',
+      contract: {
+        schemaVersion: "outcome-contract.v0",
+        expectations: [{ source: { kind: "exitCode" }, op: "eq", value: 0 }],
+      },
+    });
+
+    // Tamper with the stored contract without recompiling the hash.
+    const notebook = handler.getNotebook(notebookId)!;
+    const cell = notebook.cells.find((c) => c.id === added.cell.id)!;
+    if (cell.type !== "code" || cell.contract === undefined) throw new Error("setup broke");
+    (cell.contract.contract.expectations[0] as { value: unknown }).value = 1;
+
+    await expect(
+      handler.handleStartRun({ notebookId, mode: "runbook" }),
+    ).rejects.toThrow();
+
+    const listed = await handler.handleListRuns({ notebookId });
+    expect(listed.runs).toHaveLength(1);
+    const failed = listed.runs[0] as { status: string; error: string };
+    expect(failed.status).toBe("failed");
+    expect(failed.error).toContain("outcome contract hash mismatch");
+    expect(failed.error).toContain("run rejected");
+  });
+
+  it("maps tier-2 validator verdicts into the expectation model end to end", async () => {
+    const handler = new NotebookHandler();
+    await handler.init();
+    const notebookId = await newRunbook(handler, "Tier-2 pass");
+
+    const step = await handler.handleAddCell({
+      notebookId,
+      cellType: "code",
+      filename: "step.js",
+      content: WRITE_OUTPUT_SOURCE("{ count: 3 }"),
+    });
+    await handler.handleAddCell({
+      notebookId,
+      cellType: "code",
+      filename: "check.js",
+      content:
+        'import { observed, pass, fail } from "./tb-validate.js";\n' +
+        "const o = observed();\n" +
+        'if (o.count === 3) pass("count is 3"); else fail("count != 3", o);',
+      validatorFor: step.cell.id,
+    });
+
+    const verdict = await runVerdict(handler, notebookId);
+    expect(verdict.pass).toBe(true);
+    // The validator covers step.js; validator cells are excluded from the denominator.
+    expect(verdict.contractCoverage).toBe(1);
+    const check = verdict.evidence.find((cell) => cell.filename === "check.js")!;
+    expect(check.expectations).toHaveLength(1);
+    expect(check.expectations![0]).toMatchObject({ tier: 2, result: "pass" });
+  });
+
+  it("surfaces post-attach validator edits as error via snapshot hash mismatch", async () => {
+    const handler = new NotebookHandler();
+    await handler.init();
+    const notebookId = await newRunbook(handler, "Tier-2 tamper");
+
+    const step = await handler.handleAddCell({
+      notebookId,
+      cellType: "code",
+      filename: "step.js",
+      content: WRITE_OUTPUT_SOURCE("{ count: 3 }"),
+    });
+    const validator = await handler.handleAddCell({
+      notebookId,
+      cellType: "code",
+      filename: "check.js",
+      content:
+        'import { observed, pass, fail } from "./tb-validate.js";\n' +
+        'if (observed().count === 3) pass("ok"); else fail("bad");',
+      validatorFor: step.cell.id,
+    });
+    // Edit the validator source after its authoring-time snapshot was bound.
+    await handler.handleUpdateCell({
+      notebookId,
+      cellId: validator.cell.id,
+      content: 'import { pass } from "./tb-validate.js"; pass("always");',
+    });
+
+    const verdict = await runVerdict(handler, notebookId);
+    expect(verdict.pass).toBe(false);
+    const check = verdict.evidence.find((cell) => cell.filename === "check.js")!;
+    expect(check.expectations![0]).toMatchObject({
+      tier: 2,
+      result: "error",
+      error: "snapshot_hash_mismatch",
+    });
+  });
+
+  it("claim-status expectations error until a resolver is wired, then evaluate", async () => {
+    const attached = compileOutcomeContract({
+      schemaVersion: "outcome-contract.v0",
+      expectations: [
+        { source: { kind: "claimStatus", claimId: "claim_42" }, op: "eq", value: "supported" },
+      ],
+    });
+    const evidence: CellExecutionEvidence[] = [
+      {
+        cellId: "c1",
+        cellType: "code",
+        filename: "c1.js",
+        status: "completed",
+        exitCode: 0,
+        output: "",
+        error: "",
+        contract: attached,
+      },
+    ];
+
+    const unwired = new InMemoryNotebookEngineRuntime(async () => evidence);
+    const unwiredResult = await Effect.runPromise(
+      unwired.startRun({ notebookId: "nb_claims", mode: "runbook" }),
+    );
+    const unwiredRun = unwiredResult.run as Extract<
+      typeof unwiredResult.run,
+      { _tag: "CompletedRun" }
+    >;
+    const unwiredVerdict = unwiredRun.outputs[0] as unknown as VerdictShape;
+    expect(unwiredVerdict.pass).toBe(false);
+    expect(unwiredVerdict.evidence[0]!.expectations![0]).toMatchObject({
+      result: "error",
+      error: "claim resolver not wired",
+    });
+
+    const wired = new InMemoryNotebookEngineRuntime(async () => evidence, {
+      resolve: () => "supported",
+    });
+    const wiredResult = await Effect.runPromise(
+      wired.startRun({ notebookId: "nb_claims", mode: "runbook" }),
+    );
+    const wiredRun = wiredResult.run as Extract<typeof wiredResult.run, { _tag: "CompletedRun" }>;
+    const wiredVerdict = wiredRun.outputs[0] as unknown as VerdictShape;
+    expect(wiredVerdict.pass).toBe(true);
+    expect(wiredVerdict.contractCoverage).toBe(1);
   });
 });

--- a/src/notebook/contracts.ts
+++ b/src/notebook/contracts.ts
@@ -1,0 +1,568 @@
+/**
+ * Outcome contracts — typed per-cell expectations for honest runbook verdicts
+ * (SPEC-AGX-SUBSTRATE B4a, claim c3 template/contract half).
+ *
+ * Design (adopted 2026-06-12):
+ * - Tier 1 (declarative): a contract is pure data `{ source, op, value }`,
+ *   authored alongside the cell and validated with zod on the compile path
+ *   (extract → zod → canonicalize → sha256 — the same parse-only pattern as
+ *   `src/peer-notebook/manifest.ts`).
+ * - Tier 2 (executable): the existing validator-cell machinery
+ *   (ValidatorService snapshot+hash); its verdicts map into the same
+ *   per-expectation record model via `expectationRecordFromValidation`.
+ * - Binding at authoring, hash-checked at run (Ulysses pattern): the contract
+ *   hash is computed when the contract is attached and re-verified before any
+ *   cell executes; mismatch means tampering and the run is rejected.
+ * - Result semantics: pass | fail | error | skipped. `error` = could not
+ *   evaluate; `fail` = evaluated false; `skipped` = cell never reached.
+ *   skipped and error are NEVER pass.
+ * - Actuals come from declared channels only: exit code, JSON pointer
+ *   (RFC 6901) into the cell's structured output sidecar (TB_OUTPUT_PATH),
+ *   run artifact content, or claim status. Free-text stdout is never scraped.
+ */
+
+import { z } from "zod";
+import { canonicalizeJson, hashJson } from "../peer-notebook/manifest.js";
+
+// ---------------------------------------------------------------------------
+// Schemas (zod — contracts are authored external data on the compile path)
+// ---------------------------------------------------------------------------
+
+type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
+
+const JsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number(),
+    z.boolean(),
+    z.null(),
+    z.array(JsonValueSchema),
+    z.record(JsonValueSchema),
+  ]),
+);
+
+/** Minimal JSON Schema subset for the `schema` op — mirrors the peer-manifest subset. */
+export interface ContractJsonSchemaSubset {
+  type?: "object" | "array" | "string" | "number" | "boolean" | "null";
+  properties?: Record<string, ContractJsonSchemaSubset>;
+  required?: string[];
+  items?: ContractJsonSchemaSubset;
+  additionalProperties?: boolean;
+}
+
+const ContractJsonSchemaSubsetSchema: z.ZodType<ContractJsonSchemaSubset> = z.lazy(() =>
+  z.object({
+    type: z.enum(["object", "array", "string", "number", "boolean", "null"]).optional(),
+    properties: z.record(ContractJsonSchemaSubsetSchema).optional(),
+    required: z.array(z.string()).optional(),
+    items: ContractJsonSchemaSubsetSchema.optional(),
+    additionalProperties: z.boolean().optional(),
+  }) as z.ZodType<ContractJsonSchemaSubset>,
+);
+
+const JsonPointerSchema = z
+  .string()
+  .refine((p) => p === "" || p.startsWith("/"), {
+    message: 'JSON pointer must be "" (whole document) or start with "/" (RFC 6901)',
+  });
+
+const ExpectationSourceSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("exitCode") }),
+  z.object({ kind: z.literal("output"), pointer: JsonPointerSchema }),
+  z.object({
+    kind: z.literal("artifact"),
+    name: z.string().min(1),
+    pointer: JsonPointerSchema.optional(),
+  }),
+  z.object({ kind: z.literal("claimStatus"), claimId: z.string().min(1) }),
+]);
+export type ExpectationSource = z.infer<typeof ExpectationSourceSchema>;
+
+export const OutcomeOpSchema = z.enum([
+  "eq",
+  "ne",
+  "lt",
+  "lte",
+  "gt",
+  "gte",
+  "matches",
+  "schema",
+]);
+export type OutcomeOp = z.infer<typeof OutcomeOpSchema>;
+
+const ORDERED_OPS: ReadonlySet<OutcomeOp> = new Set(["lt", "lte", "gt", "gte"]);
+
+export const OutcomeExpectationSchema = z
+  .object({
+    source: ExpectationSourceSchema,
+    op: OutcomeOpSchema,
+    value: JsonValueSchema,
+    description: z.string().optional(),
+  })
+  .superRefine((expectation, ctx) => {
+    const { op, value } = expectation;
+    if (ORDERED_OPS.has(op) && typeof value !== "number") {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["value"],
+        message: `op "${op}" requires a numeric value`,
+      });
+    }
+    if (op === "matches") {
+      if (typeof value !== "string") {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["value"],
+          message: 'op "matches" requires a string regex value',
+        });
+      } else {
+        try {
+          const compiled = new RegExp(value);
+          void compiled;
+        } catch (error) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["value"],
+            message: `op "matches" value is not a valid regex: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          });
+        }
+      }
+    }
+    if (op === "schema" && !ContractJsonSchemaSubsetSchema.safeParse(value).success) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["value"],
+        message:
+          'op "schema" requires a JSON Schema subset value ' +
+          "(type/properties/required/items/additionalProperties)",
+      });
+    }
+  });
+export type OutcomeExpectation = z.infer<typeof OutcomeExpectationSchema>;
+
+export const OutcomeContractSchema = z.object({
+  schemaVersion: z.literal("outcome-contract.v0"),
+  expectations: z.array(OutcomeExpectationSchema).min(1),
+});
+export type OutcomeContract = z.infer<typeof OutcomeContractSchema>;
+
+export const AttachedContractSchema = z.object({
+  contract: OutcomeContractSchema,
+  contractHash: z.string().min(1),
+  attachedAt: z.string().min(1),
+});
+export type AttachedContract = z.infer<typeof AttachedContractSchema>;
+
+// ---------------------------------------------------------------------------
+// Compile path: extract → zod → canonicalize → sha256 (parse-only)
+// ---------------------------------------------------------------------------
+
+export class ContractCompileError extends Error {
+  override readonly name = "ContractCompileError";
+}
+
+export class ContractHashMismatchError extends Error {
+  override readonly name = "ContractHashMismatchError";
+
+  constructor(
+    readonly cellId: string,
+    readonly expected: string,
+    readonly actual: string,
+  ) {
+    super(
+      `outcome contract hash mismatch on cell ${cellId}: expected ${expected}, ` +
+        `got ${actual} — contract was modified after attach; run rejected`,
+    );
+  }
+}
+
+/** Compile an authored contract: zod-parse, canonicalize, hash. Throws ContractCompileError. */
+export function compileOutcomeContract(input: unknown): AttachedContract {
+  const parsed = OutcomeContractSchema.safeParse(input);
+  if (!parsed.success) {
+    const issues = parsed.error.issues
+      .map((issue) => `${issue.path.join(".") || "(root)"}: ${issue.message}`)
+      .join("; ");
+    throw new ContractCompileError(`outcome contract failed validation: ${issues}`);
+  }
+  return {
+    contract: parsed.data,
+    contractHash: hashJson(parsed.data),
+    attachedAt: new Date().toISOString(),
+  };
+}
+
+/** Re-verify an attached contract's hash at run time. Throws ContractHashMismatchError. */
+export function verifyAttachedContract(cellId: string, attached: AttachedContract): void {
+  const liveHash = hashJson(attached.contract);
+  if (liveHash !== attached.contractHash) {
+    throw new ContractHashMismatchError(cellId, attached.contractHash, liveHash);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// RFC 6901 JSON pointer resolution
+// ---------------------------------------------------------------------------
+
+export type PointerResolution =
+  | { found: true; value: unknown }
+  | { found: false; reason: string };
+
+export function resolveJsonPointer(document: unknown, pointer: string): PointerResolution {
+  if (pointer === "") return { found: true, value: document };
+  if (!pointer.startsWith("/")) {
+    return { found: false, reason: `invalid JSON pointer "${pointer}" — must start with "/"` };
+  }
+  const tokens = pointer
+    .slice(1)
+    .split("/")
+    .map((token) => token.replace(/~1/g, "/").replace(/~0/g, "~"));
+  let current: unknown = document;
+  for (const token of tokens) {
+    if (Array.isArray(current)) {
+      if (!/^(0|[1-9][0-9]*)$/.test(token)) {
+        return { found: false, reason: `pointer token "${token}" is not a valid array index` };
+      }
+      const index = Number(token);
+      if (index >= current.length) {
+        return { found: false, reason: `array index ${index} out of bounds (length ${current.length})` };
+      }
+      current = current[index];
+    } else if (current !== null && typeof current === "object") {
+      if (!Object.prototype.hasOwnProperty.call(current, token)) {
+        return { found: false, reason: `property "${token}" not found` };
+      }
+      current = (current as Record<string, unknown>)[token];
+    } else {
+      return { found: false, reason: `cannot descend into ${JSON.stringify(current)} with token "${token}"` };
+    }
+  }
+  return { found: true, value: current };
+}
+
+// ---------------------------------------------------------------------------
+// Per-expectation result model (shared by tier 1 and tier 2)
+// ---------------------------------------------------------------------------
+
+export type ExpectationResult = "pass" | "fail" | "error" | "skipped";
+
+export interface ExpectationRecord {
+  cellId: string;
+  tier: 1 | 2;
+  /** Human-readable description of what was asserted. */
+  expectation: string;
+  result: ExpectationResult;
+  /** The declared expectation (tier 1) or validator descriptor (tier 2). */
+  expected: unknown;
+  /** The extracted actual (when evaluation reached comparison). */
+  actual?: unknown;
+  /** Populated when result is "error" or "skipped". */
+  error?: string;
+}
+
+/** Narrow interface for claim-status resolution; wired when the claims layer merges. */
+export interface ClaimStatusResolver {
+  resolve(claimId: string): unknown;
+}
+
+export interface ExpectationEvaluationContext {
+  cellId: string;
+  cellStatus: "completed" | "failed" | "skipped";
+  exitCode: number | null;
+  /** Raw JSON text the cell wrote to its TB_OUTPUT_PATH sidecar, if any. */
+  structuredOutputRaw?: string;
+  /** Resolve a run artifact's content by name (exact or runId-prefixed). */
+  readArtifact?: (name: string) => string | undefined;
+  claimResolver?: ClaimStatusResolver;
+}
+
+export function describeExpectation(expectation: OutcomeExpectation): string {
+  if (expectation.description) return expectation.description;
+  const source = expectation.source;
+  const sourceText =
+    source.kind === "exitCode"
+      ? "exitCode"
+      : source.kind === "output"
+        ? `output${source.pointer === "" ? "" : ` ${source.pointer}`}`
+        : source.kind === "artifact"
+          ? `artifact ${source.name}${source.pointer ? ` ${source.pointer}` : ""}`
+          : `claimStatus ${source.claimId}`;
+  return `${sourceText} ${expectation.op} ${JSON.stringify(expectation.value)}`;
+}
+
+/** Evaluate a tier-1 declarative expectation against a cell's declared channels. */
+export function evaluateExpectation(
+  expectation: OutcomeExpectation,
+  context: ExpectationEvaluationContext,
+): ExpectationRecord {
+  const base = {
+    cellId: context.cellId,
+    tier: 1 as const,
+    expectation: describeExpectation(expectation),
+    expected: { source: expectation.source, op: expectation.op, value: expectation.value },
+  };
+
+  if (context.cellStatus === "skipped") {
+    return { ...base, result: "skipped", error: "cell never reached (earlier cell failed)" };
+  }
+
+  const extraction = extractActual(expectation.source, context);
+  if (!extraction.ok) {
+    return { ...base, result: "error", error: extraction.error };
+  }
+
+  const comparison = applyOp(expectation.op, expectation.value, extraction.actual);
+  if (!comparison.ok) {
+    return { ...base, result: "error", actual: extraction.actual, error: comparison.error };
+  }
+  return { ...base, result: comparison.pass ? "pass" : "fail", actual: extraction.actual };
+}
+
+type Extraction = { ok: true; actual: unknown } | { ok: false; error: string };
+
+function extractActual(
+  source: ExpectationSource,
+  context: ExpectationEvaluationContext,
+): Extraction {
+  switch (source.kind) {
+    case "exitCode": {
+      if (context.exitCode === null) {
+        return { ok: false, error: "exit code unavailable (process did not report one)" };
+      }
+      return { ok: true, actual: context.exitCode };
+    }
+    case "output": {
+      if (context.cellStatus === "failed") {
+        return { ok: false, error: "cell failed before its structured output could be trusted" };
+      }
+      if (context.structuredOutputRaw === undefined) {
+        return {
+          ok: false,
+          error:
+            "cell declared a structured-output expectation but wrote nothing to TB_OUTPUT_PATH",
+        };
+      }
+      return parseAndPoint(context.structuredOutputRaw, source.pointer, "structured output");
+    }
+    case "artifact": {
+      const content = context.readArtifact?.(source.name);
+      if (content === undefined) {
+        return { ok: false, error: `run artifact "${source.name}" not found` };
+      }
+      return parseAndPoint(content, source.pointer ?? "", `artifact "${source.name}"`);
+    }
+    case "claimStatus": {
+      if (!context.claimResolver) {
+        return { ok: false, error: "claim resolver not wired" };
+      }
+      try {
+        return { ok: true, actual: context.claimResolver.resolve(source.claimId) };
+      } catch (error) {
+        return {
+          ok: false,
+          error: `claim resolver failed for ${source.claimId}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        };
+      }
+    }
+  }
+}
+
+function parseAndPoint(raw: string, pointer: string, channel: string): Extraction {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    return {
+      ok: false,
+      error: `${channel} is not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+  const resolution = resolveJsonPointer(parsed, pointer);
+  if (!resolution.found) {
+    return { ok: false, error: `JSON pointer "${pointer}" not found in ${channel}: ${resolution.reason}` };
+  }
+  return { ok: true, actual: resolution.value };
+}
+
+type Comparison = { ok: true; pass: boolean } | { ok: false; error: string };
+
+function applyOp(op: OutcomeOp, value: JsonValue, actual: unknown): Comparison {
+  switch (op) {
+    case "eq":
+    case "ne": {
+      let equal: boolean;
+      try {
+        equal = canonicalizeJson(actual) === canonicalizeJson(value);
+      } catch (error) {
+        return {
+          ok: false,
+          error: `actual is not comparable JSON: ${error instanceof Error ? error.message : String(error)}`,
+        };
+      }
+      return { ok: true, pass: op === "eq" ? equal : !equal };
+    }
+    case "lt":
+    case "lte":
+    case "gt":
+    case "gte": {
+      if (typeof actual !== "number" || Number.isNaN(actual)) {
+        return { ok: false, error: `op "${op}" requires a numeric actual, got ${JSON.stringify(actual)}` };
+      }
+      const threshold = value as number;
+      const pass =
+        op === "lt"
+          ? actual < threshold
+          : op === "lte"
+            ? actual <= threshold
+            : op === "gt"
+              ? actual > threshold
+              : actual >= threshold;
+      return { ok: true, pass };
+    }
+    case "matches": {
+      if (typeof actual !== "string") {
+        return { ok: false, error: `op "matches" requires a string actual, got ${JSON.stringify(actual)}` };
+      }
+      return { ok: true, pass: new RegExp(value as string).test(actual) };
+    }
+    case "schema": {
+      const mismatch = checkJsonSchemaSubset(actual, value as ContractJsonSchemaSubset);
+      return { ok: true, pass: mismatch === null };
+    }
+  }
+}
+
+/** Returns null when the value conforms, otherwise a mismatch description. */
+export function checkJsonSchemaSubset(
+  value: unknown,
+  schema: ContractJsonSchemaSubset,
+): string | null {
+  if (schema.type !== undefined) {
+    const matchesType =
+      schema.type === "object"
+        ? value !== null && typeof value === "object" && !Array.isArray(value)
+        : schema.type === "array"
+          ? Array.isArray(value)
+          : schema.type === "null"
+            ? value === null
+            : typeof value === schema.type;
+    if (!matchesType) {
+      return `expected type ${schema.type}, got ${Array.isArray(value) ? "array" : value === null ? "null" : typeof value}`;
+    }
+  }
+  if (Array.isArray(value) && schema.items !== undefined) {
+    for (let index = 0; index < value.length; index += 1) {
+      const mismatch = checkJsonSchemaSubset(value[index], schema.items);
+      if (mismatch !== null) return `items[${index}]: ${mismatch}`;
+    }
+  }
+  if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+    const record = value as Record<string, unknown>;
+    for (const key of schema.required ?? []) {
+      if (!Object.prototype.hasOwnProperty.call(record, key)) {
+        return `missing required property "${key}"`;
+      }
+    }
+    if (schema.properties !== undefined) {
+      for (const [key, propertySchema] of Object.entries(schema.properties)) {
+        if (Object.prototype.hasOwnProperty.call(record, key)) {
+          const mismatch = checkJsonSchemaSubset(record[key], propertySchema);
+          if (mismatch !== null) return `properties.${key}: ${mismatch}`;
+        }
+      }
+    }
+    if (schema.additionalProperties === false) {
+      const allowed = new Set(Object.keys(schema.properties ?? {}));
+      for (const key of Object.keys(record)) {
+        if (!allowed.has(key)) return `unexpected additional property "${key}"`;
+      }
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Tier 2: map validator verdicts into the per-expectation result model
+// ---------------------------------------------------------------------------
+
+/** Structural subset of ValidationResult (src/notebook/types.ts) needed for mapping. */
+export interface ValidatorOutcomeLike {
+  pass: boolean;
+  reason: string;
+  evidence?: unknown;
+  hashMatched: boolean;
+  exitCode: number | null;
+}
+
+/**
+ * Reasons the validator machinery emits when it could not obtain a verdict.
+ * These map to "error" (could not evaluate), never to "fail".
+ */
+const VALIDATOR_MACHINERY_REASONS: ReadonlySet<string> = new Set([
+  "snapshot_hash_mismatch",
+  "validator_timeout_or_crash",
+  "validator_crash",
+  "malformed_verdict",
+]);
+
+export function expectationRecordFromValidation(input: {
+  validatorCellId: string;
+  targetCellId: string;
+  result: ValidatorOutcomeLike;
+}): ExpectationRecord {
+  const { validatorCellId, targetCellId, result } = input;
+  const base = {
+    cellId: validatorCellId,
+    tier: 2 as const,
+    expectation: `validator ${validatorCellId} over structured output of cell ${targetCellId}`,
+    expected: { kind: "validator", validatorCellId, targetCellId },
+  };
+  if (result.pass) {
+    return {
+      ...base,
+      result: "pass",
+      actual: { reason: result.reason, ...(result.evidence !== undefined ? { evidence: result.evidence } : {}) },
+    };
+  }
+  if (VALIDATOR_MACHINERY_REASONS.has(result.reason)) {
+    return { ...base, result: "error", error: result.reason };
+  }
+  return {
+    ...base,
+    result: "fail",
+    actual: { reason: result.reason, ...(result.evidence !== undefined ? { evidence: result.evidence } : {}) },
+  };
+}
+
+export function skippedValidatorRecord(
+  validatorCellId: string,
+  targetCellId: string,
+): ExpectationRecord {
+  return {
+    cellId: validatorCellId,
+    tier: 2,
+    expectation: `validator ${validatorCellId} over structured output of cell ${targetCellId}`,
+    expected: { kind: "validator", validatorCellId, targetCellId },
+    result: "skipped",
+    error: "cell never reached (earlier cell failed)",
+  };
+}
+
+export function erroredValidatorRecord(
+  validatorCellId: string,
+  targetCellId: string,
+  error: string,
+): ExpectationRecord {
+  return {
+    cellId: validatorCellId,
+    tier: 2,
+    expectation: `validator ${validatorCellId} over structured output of cell ${targetCellId}`,
+    expected: { kind: "validator", validatorCellId, targetCellId },
+    result: "error",
+    error,
+  };
+}

--- a/src/notebook/contracts.ts
+++ b/src/notebook/contracts.ts
@@ -390,6 +390,20 @@ function parseAndPoint(raw: string, pointer: string, channel: string): Extractio
 
 type Comparison = { ok: true; pass: boolean } | { ok: false; error: string };
 
+// Patterns are zod-validated at authoring time; cache the compiled form so
+// repeated evaluations don't re-compile. Unanchored substring semantics, no
+// flags — a shared instance carries no lastIndex state.
+const compiledRegexCache = new Map<string, RegExp>();
+
+function compiledRegex(pattern: string): RegExp {
+  let regex = compiledRegexCache.get(pattern);
+  if (regex === undefined) {
+    regex = new RegExp(pattern);
+    compiledRegexCache.set(pattern, regex);
+  }
+  return regex;
+}
+
 function applyOp(op: OutcomeOp, value: JsonValue, actual: unknown): Comparison {
   switch (op) {
     case "eq":
@@ -427,7 +441,7 @@ function applyOp(op: OutcomeOp, value: JsonValue, actual: unknown): Comparison {
       if (typeof actual !== "string") {
         return { ok: false, error: `op "matches" requires a string actual, got ${JSON.stringify(actual)}` };
       }
-      return { ok: true, pass: new RegExp(value as string).test(actual) };
+      return { ok: true, pass: compiledRegex(value as string).test(actual) };
     }
     case "schema": {
       const mismatch = checkJsonSchemaSubset(actual, value as ContractJsonSchemaSubset);

--- a/src/notebook/contracts.ts
+++ b/src/notebook/contracts.ts
@@ -392,13 +392,19 @@ type Comparison = { ok: true; pass: boolean } | { ok: false; error: string };
 
 // Patterns are zod-validated at authoring time; cache the compiled form so
 // repeated evaluations don't re-compile. Unanchored substring semantics, no
-// flags — a shared instance carries no lastIndex state.
+// flags — a shared instance carries no lastIndex state. Bounded: once full,
+// the oldest entry is evicted (insertion-order FIFO).
+const REGEX_CACHE_MAX_ENTRIES = 256;
 const compiledRegexCache = new Map<string, RegExp>();
 
 function compiledRegex(pattern: string): RegExp {
   let regex = compiledRegexCache.get(pattern);
   if (regex === undefined) {
     regex = new RegExp(pattern);
+    if (compiledRegexCache.size >= REGEX_CACHE_MAX_ENTRIES) {
+      const oldest = compiledRegexCache.keys().next().value;
+      if (oldest !== undefined) compiledRegexCache.delete(oldest);
+    }
     compiledRegexCache.set(pattern, regex);
   }
   return regex;

--- a/src/notebook/encoding.ts
+++ b/src/notebook/encoding.ts
@@ -1,5 +1,85 @@
-import type { Notebook, Cell, NotebookMetadata, CodeLanguage } from "./types.js";
+import { z } from "zod";
+import type { Notebook, Cell, CodeCell, NotebookMetadata, CodeLanguage } from "./types.js";
 import { randomid, buildDefaultTsconfig, buildDefaultPackageJson } from "./types.js";
+import { AttachedContractSchema, verifyAttachedContract } from "./contracts.js";
+
+/**
+ * Per-cell binding metadata persisted in the .src.md format as an HTML comment
+ * (`<!-- thoughtbox:cell {...} -->`) between the `###### filename` heading and
+ * the code fence. Carries the contract/validator bindings introduced by
+ * SPEC-AGX-SUBSTRATE B4a, plus the cell id so `validatorFor` references
+ * survive an export → load round trip.
+ */
+const CellBindingMetadataSchema = z
+  .object({
+    id: z.string().min(1),
+    contract: AttachedContractSchema.optional(),
+    validatorFor: z.string().min(1).optional(),
+    validatorSnapshotHash: z.string().min(1).optional(),
+  })
+  .refine((m) => m.contract === undefined || m.validatorFor === undefined, {
+    message: "a cell declares either a tier-1 contract or validatorFor, not both",
+  });
+
+type CellBindingMetadata = z.infer<typeof CellBindingMetadataSchema>;
+
+const CELL_BINDING_PREFIX = "<!-- thoughtbox:cell ";
+
+function encodeCellBinding(
+  cell: CodeCell,
+  validatorTargetIds: Set<string>,
+): string | null {
+  const hasBinding =
+    cell.contract !== undefined ||
+    cell.validatorFor !== undefined ||
+    cell.validatorSnapshotHash !== undefined;
+  if (!hasBinding && !validatorTargetIds.has(cell.id)) {
+    return null;
+  }
+  const metadata: CellBindingMetadata = {
+    id: cell.id,
+    ...(cell.contract !== undefined ? { contract: cell.contract } : {}),
+    ...(cell.validatorFor !== undefined ? { validatorFor: cell.validatorFor } : {}),
+    ...(cell.validatorSnapshotHash !== undefined
+      ? { validatorSnapshotHash: cell.validatorSnapshotHash }
+      : {}),
+  };
+  return `${CELL_BINDING_PREFIX}${JSON.stringify(metadata)} -->`;
+}
+
+/**
+ * Parse a `<!-- thoughtbox:cell {...} -->` line. Throws on malformed JSON,
+ * schema violations, or a contract whose hash no longer matches its body
+ * (tampering) — contract bindings must never be dropped or accepted silently.
+ */
+function parseCellBinding(line: string): CellBindingMetadata {
+  const match = line.trim().match(/^<!-- thoughtbox:cell (.+) -->$/);
+  if (!match) {
+    throw new Error(`Malformed thoughtbox:cell metadata line: ${line.trim()}`);
+  }
+  let raw: unknown;
+  try {
+    raw = JSON.parse(match[1]);
+  } catch (error) {
+    throw new Error(
+      `thoughtbox:cell metadata is not valid JSON: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+  const parsed = CellBindingMetadataSchema.safeParse(raw);
+  if (!parsed.success) {
+    const issues = parsed.error.issues
+      .map((issue) => `${issue.path.join(".") || "(root)"}: ${issue.message}`)
+      .join("; ");
+    throw new Error(`thoughtbox:cell metadata failed validation: ${issues}`);
+  }
+  if (parsed.data.contract !== undefined) {
+    // Loud tamper detection at import time (same Ulysses gate as run time).
+    verifyAttachedContract(parsed.data.id, parsed.data.contract);
+  }
+  return parsed.data;
+}
 
 /**
  * Encode a notebook to .src.md format
@@ -7,6 +87,15 @@ import { randomid, buildDefaultTsconfig, buildDefaultPackageJson } from "./types
  */
 export function encode(notebook: Notebook): string {
   const lines: string[] = [];
+
+  // Cells referenced by a validator need their id persisted so the
+  // validatorFor link survives a decode (which otherwise regenerates ids).
+  const validatorTargetIds = new Set<string>();
+  for (const cell of notebook.cells) {
+    if (cell.type === "code" && cell.validatorFor !== undefined) {
+      validatorTargetIds.add(cell.validatorFor);
+    }
+  }
 
   // Add metadata header
   const metadata: NotebookMetadata = {
@@ -36,6 +125,11 @@ export function encode(notebook: Notebook): string {
     } else if (cell.type === "code") {
       lines.push(`###### ${cell.filename}`);
       lines.push("");
+      const binding = encodeCellBinding(cell, validatorTargetIds);
+      if (binding !== null) {
+        lines.push(binding);
+        lines.push("");
+      }
       const langTag = cell.language === "typescript" ? "typescript" : "javascript";
       lines.push(`\`\`\`${langTag}`);
       lines.push(cell.source);
@@ -102,6 +196,15 @@ export function decode(srcmd: string): Notebook {
       // Skip empty line
       if (i < lines.length && lines[i].trim() === "") i++;
 
+      // Optional per-cell binding metadata (contracts / validator bindings)
+      let binding: CellBindingMetadata | undefined;
+      if (i < lines.length && lines[i].trim().startsWith(CELL_BINDING_PREFIX)) {
+        binding = parseCellBinding(lines[i]);
+        i++;
+        // Skip empty line after the metadata comment
+        if (i < lines.length && lines[i].trim() === "") i++;
+      }
+
       // Expect code fence
       if (i < lines.length && lines[i].startsWith("```")) {
         const fenceLine = lines[i];
@@ -126,6 +229,11 @@ export function decode(srcmd: string): Notebook {
 
         // Package.json cell
         if (filename === "package.json") {
+          if (binding !== undefined) {
+            throw new Error(
+              "thoughtbox:cell metadata is not supported on package.json cells",
+            );
+          }
           cells.push({
             id: randomid(),
             type: "package.json",
@@ -139,14 +247,25 @@ export function decode(srcmd: string): Notebook {
           const language: CodeLanguage =
             lang === "typescript" ? "typescript" : "javascript";
           cells.push({
-            id: randomid(),
+            id: binding?.id ?? randomid(),
             type: "code",
             language,
             filename,
             source,
             status: "idle",
+            ...(binding?.contract !== undefined ? { contract: binding.contract } : {}),
+            ...(binding?.validatorFor !== undefined
+              ? { validatorFor: binding.validatorFor }
+              : {}),
+            ...(binding?.validatorSnapshotHash !== undefined
+              ? { validatorSnapshotHash: binding.validatorSnapshotHash }
+              : {}),
           });
         }
+      } else if (binding !== undefined) {
+        throw new Error(
+          `thoughtbox:cell metadata for cell ${binding.id} is not followed by a code fence`,
+        );
       }
     }
     // Markdown cell (everything else)
@@ -178,6 +297,27 @@ export function decode(srcmd: string): Notebook {
           text: markdownLines.join("\n"),
         });
       }
+    }
+  }
+
+  // Structural integrity: persisted ids must be unique and every
+  // validatorFor binding must resolve to a code cell. A dangling binding
+  // would silently degrade to a run-time error, so refuse the load instead.
+  const seenIds = new Set<string>();
+  for (const cell of cells) {
+    if (seenIds.has(cell.id)) {
+      throw new Error(`Duplicate cell id "${cell.id}" in thoughtbox:cell metadata`);
+    }
+    seenIds.add(cell.id);
+  }
+  for (const cell of cells) {
+    if (cell.type !== "code" || cell.validatorFor === undefined) continue;
+    const target = cells.find((c) => c.id === cell.validatorFor);
+    if (!target || target.type !== "code") {
+      throw new Error(
+        `validatorFor target ${cell.validatorFor} (declared by cell ${cell.id}) ` +
+          "not found or not a code cell",
+      );
     }
   }
 

--- a/src/notebook/engine/domain.ts
+++ b/src/notebook/engine/domain.ts
@@ -206,6 +206,13 @@ export const NotebookOutputSchema = S.Union(
     mode: S.Literal("runbook"),
     pass: S.Boolean,
     reason: S.String,
+    /**
+     * Fraction of non-validator code cells covered by a declared outcome
+     * contract (tier 1) or a tier-2 validator. 0 means the verdict is
+     * procedural only — downstream fitness must exclude such runs from
+     * pass-rates (SPEC-AGX-SUBSTRATE §5.1).
+     */
+    contractCoverage: S.Number,
     evidence: S.optional(S.Unknown),
   }),
   S.Struct({

--- a/src/notebook/engine/runtime.ts
+++ b/src/notebook/engine/runtime.ts
@@ -10,12 +10,23 @@ import {
   InvalidNotebookShape,
   NotebookModeNotImplemented,
   NotebookModeSchema,
+  SnapshotMismatch,
   describeRunStatus,
 } from "./domain.js";
 import { getNotebookMode } from "./registry.js";
+import {
+  ContractHashMismatchError,
+  evaluateExpectation,
+  type AttachedContract,
+  type ClaimStatusResolver,
+  type ExpectationRecord,
+} from "../contracts.js";
 
 const MAX_ARTIFACT_BYTES = 1_000_000;
 const MAX_EVIDENCE_OUTPUT_CHARS = 2_000;
+
+export const PROCEDURAL_ONLY_NOTE =
+  "procedural completion only — no outcome contracts declared";
 
 export interface StartNotebookRunInput {
   notebookId: string;
@@ -41,12 +52,22 @@ export interface CellExecutionEvidence {
   exitCode: number | null;
   output: string;
   error: string;
+  /** Raw JSON text the cell wrote to its TB_OUTPUT_PATH sidecar, if any. */
+  structuredOutput?: string;
+  /** Tier-1 outcome contract attached to the cell (hash-verified by the executor). */
+  contract?: AttachedContract;
+  /** When the cell is a tier-2 validator: the cell it validates. */
+  validatorFor?: string;
+  /** Pre-computed expectation records (tier 2 — produced by the executor). */
+  expectations?: ExpectationRecord[];
 }
 
 /**
  * Executes a notebook's executable cells in document order and reports
  * per-cell evidence. Implemented by NotebookHandler over the real
- * NotebookStateManager subprocess execution path.
+ * NotebookStateManager subprocess execution path. Throws
+ * ContractHashMismatchError when an attached outcome contract fails its
+ * run-time hash re-verification (tampering — the run is rejected).
  */
 export type NotebookCellExecutor = (
   notebookId: string,
@@ -56,7 +77,10 @@ export class InMemoryNotebookEngineRuntime {
   private runs = new Map<string, NotebookRun>();
   private artifacts = new Map<string, { ref: ArtifactRef; content: string }>();
 
-  constructor(private readonly executeNotebook: NotebookCellExecutor) {}
+  constructor(
+    private readonly executeNotebook: NotebookCellExecutor,
+    private readonly claimResolver?: ClaimStatusResolver,
+  ) {}
 
   persistNotebook(notebookId: string, content: string) {
     return Effect.gen(this, function* () {
@@ -120,16 +144,21 @@ export class InMemoryNotebookEngineRuntime {
       this.runs.set(runId, running);
 
       // Everything between marking the run running and marking it completed
-      // shares one error handler: any failure (execution or artifact
-      // persistence) must transition the run to FailedRun — a run may never
-      // be left in RunningRun forever.
+      // shares one error handler: any failure (execution, contract integrity,
+      // or artifact persistence) must transition the run to FailedRun — a run
+      // may never be left in RunningRun forever.
       const runBody = Effect.gen(this, function* () {
         const evidence = yield* Effect.tryPromise({
           try: () => this.executeNotebook(input.notebookId),
           catch: (cause) =>
-            new InvalidNotebookShape({
-              reason: `Notebook execution failed: ${cause instanceof Error ? cause.message : String(cause)}`,
-            }),
+            cause instanceof ContractHashMismatchError
+              ? new SnapshotMismatch({
+                  expected: cause.expected,
+                  actual: cause.actual,
+                })
+              : new InvalidNotebookShape({
+                  reason: `Notebook execution failed: ${cause instanceof Error ? cause.message : String(cause)}`,
+                }),
         });
         const inputsArtifact = yield* this.putArtifact(
           `${runId}-inputs.json`,
@@ -150,7 +179,10 @@ export class InMemoryNotebookEngineRuntime {
             const detail =
               error._tag === "ArtifactTooLarge"
                 ? `run artifact too large: ${error.sizeBytes} bytes (max ${error.maxBytes})`
-                : error.reason;
+                : error._tag === "SnapshotMismatch"
+                  ? `outcome contract hash mismatch: expected ${error.expected}, ` +
+                    `got ${error.actual} — contract was modified after attach; run rejected`
+                  : error.reason;
             const failed: NotebookRun = {
               _tag: "FailedRun",
               runId,
@@ -167,6 +199,7 @@ export class InMemoryNotebookEngineRuntime {
         ),
       );
 
+      const runArtifacts = [inputsArtifact, evidenceArtifact];
       const completedAt = new Date().toISOString();
       const completed: NotebookRun = {
         _tag: "CompletedRun",
@@ -177,8 +210,13 @@ export class InMemoryNotebookEngineRuntime {
         createdAt,
         startedAt,
         completedAt,
-        outputs: [buildRunbookVerdict(evidence)],
-        artifacts: [inputsArtifact, evidenceArtifact],
+        outputs: [
+          buildRunbookVerdict(evidence, {
+            readArtifact: (name) => this.readRunArtifact(runArtifacts, name),
+            claimResolver: this.claimResolver,
+          }),
+        ],
+        artifacts: runArtifacts,
       };
       this.runs.set(runId, completed);
 
@@ -224,6 +262,17 @@ export class InMemoryNotebookEngineRuntime {
     return this.artifacts.get(artifactId) ?? null;
   }
 
+  /**
+   * Resolve a run artifact's content by authored name. Run artifacts carry a
+   * runId prefix unknowable at authoring time, so "inputs.json" matches
+   * "<runId>-inputs.json".
+   */
+  private readRunArtifact(refs: ArtifactRef[], name: string): string | undefined {
+    const ref = refs.find((r) => r.name === name || r.name.endsWith(`-${name}`));
+    if (!ref) return undefined;
+    return this.artifacts.get(ref.artifactId)?.content;
+  }
+
   private putArtifact(name: string, mimeType: string, content: string) {
     return Effect.gen(this, function* () {
       const sizeBytes = Buffer.byteLength(content, "utf8");
@@ -240,14 +289,76 @@ export class InMemoryNotebookEngineRuntime {
   }
 }
 
+interface VerdictDerivationContext {
+  readArtifact: (name: string) => string | undefined;
+  claimResolver?: ClaimStatusResolver;
+}
+
 /**
- * Derive the runbook verdict from real per-cell execution results.
- * A passing verdict must rest on at least one completed code cell:
- * dependency installation (package.json cells) is recorded as evidence
- * but cannot verify a runbook by itself, so blank notebooks — which
- * always carry a default package.json cell — cannot pass.
+ * Derive the runbook verdict from real per-cell execution results
+ * (SPEC-AGX-SUBSTRATE §5.1 outcome-contract semantics).
+ *
+ * With declared expectations (tier-1 contracts or tier-2 validators), the
+ * verdict passes iff every declared expectation was evaluated and passed AND
+ * no cell failed procedurally — `skipped` and `error` expectations are never
+ * pass, and a crashed cell still fails the run.
+ *
+ * With ZERO declared expectations, the legacy procedural derivation applies
+ * unchanged, but the verdict carries contractCoverage 0 and a reason marking
+ * it as procedural-only so downstream fitness can exclude it: a passing
+ * verdict must rest on at least one completed code cell — dependency
+ * installation (package.json cells) is recorded as evidence but cannot verify
+ * a runbook by itself, so blank notebooks cannot pass.
  */
-function buildRunbookVerdict(evidence: CellExecutionEvidence[]): NotebookOutput {
+function buildRunbookVerdict(
+  evidence: CellExecutionEvidence[],
+  context: VerdictDerivationContext,
+): NotebookOutput {
+  const recordsByCell = new Map<string, ExpectationRecord[]>();
+  const allRecords: ExpectationRecord[] = [];
+  const coveredCellIds = new Set<string>();
+
+  for (const cell of evidence) {
+    const cellRecords: ExpectationRecord[] = [];
+    if (cell.expectations) {
+      // Tier 2 — pre-computed by the executor's validator machinery.
+      cellRecords.push(...cell.expectations);
+      if (cell.validatorFor !== undefined) coveredCellIds.add(cell.validatorFor);
+    }
+    if (cell.contract) {
+      coveredCellIds.add(cell.cellId);
+      for (const expectation of cell.contract.contract.expectations) {
+        cellRecords.push(
+          evaluateExpectation(expectation, {
+            cellId: cell.cellId,
+            cellStatus: cell.status,
+            exitCode: cell.exitCode,
+            ...(cell.structuredOutput !== undefined
+              ? { structuredOutputRaw: cell.structuredOutput }
+              : {}),
+            readArtifact: context.readArtifact,
+            ...(context.claimResolver !== undefined
+              ? { claimResolver: context.claimResolver }
+              : {}),
+          }),
+        );
+      }
+    }
+    if (cellRecords.length > 0) {
+      recordsByCell.set(cell.cellId, cellRecords);
+      allRecords.push(...cellRecords);
+    }
+  }
+
+  const subjectCodeCells = evidence.filter(
+    (cell) => cell.cellType === "code" && cell.validatorFor === undefined,
+  );
+  const contractCoverage =
+    subjectCodeCells.length === 0
+      ? 0
+      : subjectCodeCells.filter((cell) => coveredCellIds.has(cell.cellId)).length /
+        subjectCodeCells.length;
+
   const failed = evidence.filter((cell) => cell.status === "failed");
   const completedCode = evidence.filter(
     (cell) => cell.status === "completed" && cell.cellType === "code",
@@ -255,22 +366,48 @@ function buildRunbookVerdict(evidence: CellExecutionEvidence[]): NotebookOutput 
 
   let pass: boolean;
   let reason: string;
-  if (evidence.length === 0) {
-    pass = false;
-    reason = "runbook has no executable cells; nothing was verified";
-  } else if (failed.length > 0) {
-    pass = false;
-    const first = failed[0]!;
-    reason =
-      `cell ${first.cellId} (${first.filename}) failed with exit code ` +
-      `${first.exitCode ?? "none"}: ${truncate(first.error || first.output)}`;
-  } else if (completedCode.length === 0) {
-    pass = false;
-    reason =
-      "no code cells executed; dependency install alone does not verify a runbook";
+
+  if (allRecords.length === 0) {
+    // Legacy procedural derivation — kept verbatim, marked procedural-only.
+    if (evidence.length === 0) {
+      pass = false;
+      reason = "runbook has no executable cells; nothing was verified";
+    } else if (failed.length > 0) {
+      pass = false;
+      const first = failed[0]!;
+      reason =
+        `cell ${first.cellId} (${first.filename}) failed with exit code ` +
+        `${first.exitCode ?? "none"}: ${truncate(first.error || first.output)}`;
+    } else if (completedCode.length === 0) {
+      pass = false;
+      reason =
+        "no code cells executed; dependency install alone does not verify a runbook";
+    } else {
+      pass = true;
+      reason = `all executable cells completed (${completedCode.length} code)`;
+    }
+    reason = `${reason}; ${PROCEDURAL_ONLY_NOTE}`;
   } else {
-    pass = true;
-    reason = `all executable cells completed (${completedCode.length} code)`;
+    const notPassed = allRecords.filter((record) => record.result !== "pass");
+    if (failed.length > 0) {
+      pass = false;
+      const first = failed[0]!;
+      reason =
+        `cell ${first.cellId} (${first.filename}) failed with exit code ` +
+        `${first.exitCode ?? "none"}: ${truncate(first.error || first.output)}`;
+    } else if (notPassed.length > 0) {
+      pass = false;
+      const first = notPassed[0]!;
+      reason =
+        `expectation "${first.expectation}" on cell ${first.cellId} ` +
+        `${first.result}${first.error ? `: ${first.error}` : ""} ` +
+        `(${notPassed.length} of ${allRecords.length} declared expectations did not pass)`;
+    } else {
+      pass = true;
+      reason =
+        `all ${allRecords.length} declared expectation(s) passed ` +
+        `(contract coverage ${Math.round(contractCoverage * 100)}% of code cells)`;
+    }
   }
 
   return {
@@ -278,6 +415,7 @@ function buildRunbookVerdict(evidence: CellExecutionEvidence[]): NotebookOutput 
     mode: "runbook",
     pass,
     reason,
+    contractCoverage,
     evidence: evidence.map((cell) => ({
       cellId: cell.cellId,
       cellType: cell.cellType,
@@ -286,6 +424,12 @@ function buildRunbookVerdict(evidence: CellExecutionEvidence[]): NotebookOutput 
       exitCode: cell.exitCode,
       output: truncate(cell.output),
       error: truncate(cell.error),
+      ...(cell.contract !== undefined
+        ? { contractHash: cell.contract.contractHash }
+        : {}),
+      ...(recordsByCell.has(cell.cellId)
+        ? { expectations: recordsByCell.get(cell.cellId) }
+        : {}),
     })),
   };
 }

--- a/src/notebook/index.ts
+++ b/src/notebook/index.ts
@@ -406,6 +406,31 @@ export class NotebookHandler {
               `validatorFor target ${validatorFor} not found or not a code cell`,
             );
           }
+          if (target.validatorFor !== undefined) {
+            throw new Error(
+              `validatorFor target ${validatorFor} is itself a validator cell; ` +
+                "validators never write structured output, so chained validators " +
+                "always error at run time — target a subject cell instead",
+            );
+          }
+          // Cells execute in document order, so a validator inserted before
+          // its target would always run before any output exists.
+          const targetIndex = notebook.cells.findIndex(
+            (c: Cell) => c.id === validatorFor,
+          );
+          const insertionIndex =
+            typeof position === "number" &&
+            position >= 0 &&
+            position <= notebook.cells.length
+              ? position
+              : notebook.cells.length;
+          if (insertionIndex <= targetIndex) {
+            throw new Error(
+              `validator cell would be inserted at position ${insertionIndex}, at or ` +
+                `before its target ${validatorFor} (position ${targetIndex}); cells run ` +
+                "in document order, so the validator must come after its target",
+            );
+          }
         }
         // Parse-only compile path: extract → zod → canonicalize → sha256.
         // Throws ContractCompileError with the offending issues on bad input.

--- a/src/notebook/index.ts
+++ b/src/notebook/index.ts
@@ -1,8 +1,15 @@
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import { NotebookStateManager } from "./state.js";
-import type { Cell, CodeLanguage } from "./types.js";
+import type { Cell, CodeCell, CodeLanguage } from "./types.js";
 import { randomid } from "./types.js";
 import { ValidatorService } from "./validator.js";
+import {
+  compileOutcomeContract,
+  expectationRecordFromValidation,
+  erroredValidatorRecord,
+  skippedValidatorRecord,
+  verifyAttachedContract,
+} from "./contracts.js";
 import {
   InMemoryNotebookEngineRuntime,
   type CellExecutionEvidence,
@@ -40,6 +47,14 @@ export class NotebookHandler {
    * Execute every executable cell (package.json installs and code cells) in
    * document order through the real subprocess execution path, stopping at
    * the first failure; remaining executable cells are reported as skipped.
+   *
+   * Outcome-contract integration (SPEC-AGX-SUBSTRATE B4a):
+   * - Before anything executes, every attached tier-1 contract hash is
+   *   re-verified (Ulysses pattern); a mismatch throws and rejects the run.
+   * - Cells with `validatorFor` are tier-2 assertion cells: they run through
+   *   the existing ValidatorService (snapshot+hash, sidecar verdict) against
+   *   the target cell's structured output instead of executing as steps.
+   *   Assertion cells record verdicts but never halt later cells.
    */
   private async executeAllCells(
     notebookId: string,
@@ -52,9 +67,19 @@ export class NotebookHandler {
       (cell: Cell): cell is Extract<Cell, { type: "code" | "package.json" }> =>
         cell.type === "code" || cell.type === "package.json",
     );
+
+    // Ulysses gate: re-verify every contract hash before executing anything.
+    for (const cell of executable) {
+      if (cell.type === "code" && cell.contract !== undefined) {
+        verifyAttachedContract(cell.id, cell.contract);
+      }
+    }
+
     const evidence: CellExecutionEvidence[] = [];
+    const structuredOutputByCell = new Map<string, string>();
     let failed = false;
     for (const cell of executable) {
+      const validatorFor = cell.type === "code" ? cell.validatorFor : undefined;
       if (failed) {
         evidence.push({
           cellId: cell.id,
@@ -64,10 +89,28 @@ export class NotebookHandler {
           exitCode: null,
           output: "",
           error: "",
+          ...(cell.type === "code" && cell.contract !== undefined
+            ? { contract: cell.contract }
+            : {}),
+          ...(validatorFor !== undefined
+            ? {
+                validatorFor,
+                expectations: [skippedValidatorRecord(cell.id, validatorFor)],
+              }
+            : {}),
         });
         continue;
       }
+      if (cell.type === "code" && validatorFor !== undefined) {
+        evidence.push(
+          await this.runValidatorCell(notebookId, cell, structuredOutputByCell),
+        );
+        continue;
+      }
       const result = await this.stateManager.executeCell(notebookId, cell.id);
+      if (cell.type === "code" && result.structuredOutput !== undefined) {
+        structuredOutputByCell.set(cell.id, result.structuredOutput);
+      }
       evidence.push({
         cellId: cell.id,
         cellType: cell.type,
@@ -76,10 +119,97 @@ export class NotebookHandler {
         exitCode: result.exitCode,
         output: result.stdout,
         error: result.stderr,
+        ...(result.structuredOutput !== undefined
+          ? { structuredOutput: result.structuredOutput }
+          : {}),
+        ...(cell.type === "code" && cell.contract !== undefined
+          ? { contract: cell.contract }
+          : {}),
       });
       if (!result.success) failed = true;
     }
     return evidence;
+  }
+
+  /**
+   * Run a tier-2 validator cell through the existing ValidatorService against
+   * the target cell's structured output (TB_OUTPUT_PATH sidecar). The stored
+   * authoring-time snapshot hash is passed as the expected hash, so a
+   * post-attach edit of the validator source surfaces as a
+   * snapshot_hash_mismatch — an `error` expectation, never a pass.
+   */
+  private async runValidatorCell(
+    notebookId: string,
+    cell: Extract<Cell, { type: "code" }>,
+    structuredOutputByCell: Map<string, string>,
+  ): Promise<CellExecutionEvidence> {
+    const targetCellId = cell.validatorFor!;
+    const base = {
+      cellId: cell.id,
+      cellType: "code" as const,
+      filename: cell.filename,
+      validatorFor: targetCellId,
+    };
+
+    const observedRaw = structuredOutputByCell.get(targetCellId);
+    if (observedRaw === undefined) {
+      return {
+        ...base,
+        status: "completed",
+        exitCode: null,
+        output: "",
+        error: "",
+        expectations: [
+          erroredValidatorRecord(
+            cell.id,
+            targetCellId,
+            `target cell ${targetCellId} wrote no structured output (TB_OUTPUT_PATH)`,
+          ),
+        ],
+      };
+    }
+
+    let observed: unknown;
+    try {
+      observed = JSON.parse(observedRaw);
+    } catch (error) {
+      return {
+        ...base,
+        status: "completed",
+        exitCode: null,
+        output: "",
+        error: "",
+        expectations: [
+          erroredValidatorRecord(
+            cell.id,
+            targetCellId,
+            `target cell ${targetCellId} structured output is not valid JSON: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          ),
+        ],
+      };
+    }
+
+    const binding = await this.validatorService.bind(notebookId, cell.id);
+    const runOptions =
+      cell.validatorSnapshotHash !== undefined
+        ? { expectedSnapshotHash: cell.validatorSnapshotHash }
+        : {};
+    const result = await this.validatorService.run(binding, observed, runOptions);
+    const record = expectationRecordFromValidation({
+      validatorCellId: cell.id,
+      targetCellId,
+      result,
+    });
+    return {
+      ...base,
+      status: record.result === "error" ? "failed" : "completed",
+      exitCode: result.exitCode,
+      output: result.stdout,
+      error: result.stderr,
+      expectations: [record],
+    };
   }
 
   /**
@@ -217,7 +347,8 @@ export class NotebookHandler {
    * Handle notebook_add_cell tool call
    */
   async handleAddCell(args: any): Promise<any> {
-    const { notebookId, cellType, content, filename, position } = args;
+    const { notebookId, cellType, content, filename, position, contract, validatorFor } =
+      args;
 
     if (!notebookId || typeof notebookId !== "string") {
       throw new Error("notebookId is required and must be a string");
@@ -230,6 +361,10 @@ export class NotebookHandler {
     const notebook = this.stateManager.getNotebook(notebookId);
     if (!notebook) {
       throw new Error(`Notebook ${notebookId} not found`);
+    }
+
+    if ((contract !== undefined || validatorFor !== undefined) && cellType !== "code") {
+      throw new Error("contract and validatorFor are only valid on code cells");
     }
 
     let cell: Cell;
@@ -253,9 +388,29 @@ export class NotebookHandler {
         };
         break;
 
-      case "code":
+      case "code": {
         if (!content) throw new Error("content is required for code cells");
         if (!filename) throw new Error("filename is required for code cells");
+        if (contract !== undefined && validatorFor !== undefined) {
+          throw new Error(
+            "a cell declares either a tier-1 contract or validatorFor, not both",
+          );
+        }
+        if (validatorFor !== undefined) {
+          if (typeof validatorFor !== "string" || validatorFor.length === 0) {
+            throw new Error("validatorFor must be a non-empty cell id");
+          }
+          const target = notebook.cells.find((c: Cell) => c.id === validatorFor);
+          if (!target || target.type !== "code") {
+            throw new Error(
+              `validatorFor target ${validatorFor} not found or not a code cell`,
+            );
+          }
+        }
+        // Parse-only compile path: extract → zod → canonicalize → sha256.
+        // Throws ContractCompileError with the offending issues on bad input.
+        const attached =
+          contract !== undefined ? compileOutcomeContract(contract) : undefined;
         cell = {
           id: randomid(),
           type: "code",
@@ -263,8 +418,11 @@ export class NotebookHandler {
           filename,
           source: content,
           status: "idle",
+          ...(attached !== undefined ? { contract: attached } : {}),
+          ...(validatorFor !== undefined ? { validatorFor } : {}),
         };
         break;
+      }
 
       default:
         throw new Error(`Unsupported cell type: ${cellType}`);
@@ -272,11 +430,27 @@ export class NotebookHandler {
 
     await this.stateManager.addCell(notebookId, cell, position);
 
+    // Tier-2 binding at authoring (Ulysses pattern): snapshot the validator
+    // cell now; the hash is re-checked by ValidatorService at run time.
+    if (cell.type === "code" && cell.validatorFor !== undefined) {
+      const binding = await this.validatorService.bind(notebookId, cell.id);
+      await this.stateManager.updateCell(notebookId, cell.id, {
+        validatorSnapshotHash: binding.snapshotHash,
+      });
+    }
+
+    const codeCell = cell.type === "code" ? (cell as CodeCell) : undefined;
     return {
       success: true,
       cell: {
         id: cell.id,
         type: cell.type,
+        ...(codeCell?.contract !== undefined
+          ? { contractHash: codeCell.contract.contractHash }
+          : {}),
+        ...(codeCell?.validatorFor !== undefined
+          ? { validatorFor: codeCell.validatorFor }
+          : {}),
       },
     };
   }

--- a/src/notebook/index.ts
+++ b/src/notebook/index.ts
@@ -202,12 +202,22 @@ export class NotebookHandler {
       targetCellId,
       result,
     });
+    // Machinery errors (snapshot_hash_mismatch, validator_crash, ...) can
+    // produce no stderr — no subprocess ever launched. Fall back to the
+    // expectation record's reason so the run verdict carries the real
+    // diagnostic instead of an empty trailer.
+    const error =
+      result.stderr !== ""
+        ? result.stderr
+        : record.result === "error"
+          ? (record.error ?? "")
+          : "";
     return {
       ...base,
       status: record.result === "error" ? "failed" : "completed",
       exitCode: result.exitCode,
       output: result.stdout,
-      error: result.stderr,
+      error,
       expectations: [record],
     };
   }

--- a/src/notebook/operations.ts
+++ b/src/notebook/operations.ts
@@ -127,6 +127,21 @@ Both approaches create an identical in-memory notebook.`,
           type: "integer",
           description: "Optional position to insert cell (0-indexed), appends if not specified",
         },
+        contract: {
+          type: "object",
+          description:
+            "Optional tier-1 outcome contract for code cells: { schemaVersion: 'outcome-contract.v0', " +
+            "expectations: [{ source, op, value }] }. Sources: exitCode, output (RFC 6901 pointer into " +
+            "the JSON the cell writes to TB_OUTPUT_PATH), artifact, claimStatus. Ops: eq, ne, lt, lte, " +
+            "gt, gte, matches, schema. Compiled (zod → canonicalize → sha256) at attach; hash re-verified at run.",
+        },
+        validatorFor: {
+          type: "string",
+          description:
+            "Optional tier-2 marker for code cells: id of the code cell this validator asserts over. " +
+            "The validator runs via notebook_validate machinery against the target's structured output. " +
+            "Mutually exclusive with contract.",
+        },
       },
       required: ["notebookId", "cellType", "content"],
     },

--- a/src/notebook/state.ts
+++ b/src/notebook/state.ts
@@ -40,6 +40,14 @@ function sanitizePath(userPath: string, allowedDir: string): string {
 }
 
 /**
+ * Result of executing a notebook cell, including the optional structured
+ * output the cell wrote to its TB_OUTPUT_PATH sidecar (raw JSON text).
+ */
+export interface CellExecutionResult extends ExecutionResult {
+  structuredOutput?: string;
+}
+
+/**
  * Notebook state manager
  * Manages in-memory notebook state and execution
  */
@@ -274,12 +282,18 @@ export class NotebookStateManager {
   }
 
   /**
-   * Execute a code cell
+   * Execute a code cell.
+   *
+   * Code cells receive a `TB_OUTPUT_PATH` env var pointing at a per-execution
+   * sidecar file (mirroring the validator's TB_OBSERVED_PATH/TB_VERDICT_PATH
+   * pattern). A cell that wants to expose structured output — the only
+   * channel outcome-contract `output` expectations may read — writes JSON to
+   * that path; free-text stdout is never scraped.
    */
   async executeCell(
     notebookId: string,
     cellId: string
-  ): Promise<ExecutionResult> {
+  ): Promise<CellExecutionResult> {
     const notebook = this.notebooks.get(notebookId);
     if (!notebook) {
       throw new Error(`Notebook ${notebookId} not found`);
@@ -306,17 +320,31 @@ export class NotebookStateManager {
     cell.output = undefined;
     cell.error = undefined;
 
-    let result: ExecutionResult;
+    let result: CellExecutionResult;
 
     try {
       if (cell.type === "package.json") {
         // Run pnpm install
         result = await installDependencies({ cwd: notebookDir });
       } else {
-        // Execute code cell
+        // Execute code cell with a fresh structured-output sidecar
+        const outputDir = path.join(notebookDir, "out");
+        await fs.mkdir(outputDir, { recursive: true });
+        const structuredOutputPath = path.join(outputDir, `${cellId}.output.json`);
+        await fs.rm(structuredOutputPath, { force: true });
+
         result = await executeCodeCell(cell.filename, cell.language, {
           cwd: notebookDir,
+          env: { TB_OUTPUT_PATH: structuredOutputPath },
         });
+
+        try {
+          const structuredOutput = await fs.readFile(structuredOutputPath, "utf8");
+          result = { ...result, structuredOutput };
+        } catch {
+          // Cell wrote no structured output — that is the common case.
+        }
+        await fs.rm(structuredOutputPath, { force: true }).catch(() => {});
       }
 
       // Update cell with results

--- a/src/notebook/types.ts
+++ b/src/notebook/types.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { AttachedContractSchema } from "./contracts.js";
 
 // Cell Schemas
 export const TitleCellSchema = z.object({
@@ -42,6 +43,12 @@ export const CodeCellSchema = z.object({
   ]),
   output: z.string().optional(),
   error: z.string().optional(),
+  /** Tier-1 outcome contract, compiled (zod → canonicalize → sha256) at attach time. */
+  contract: AttachedContractSchema.optional(),
+  /** Tier-2 marker: this cell is a validator over the named cell's structured output. */
+  validatorFor: z.string().optional(),
+  /** Validator snapshot hash captured at authoring; re-verified at run (Ulysses pattern). */
+  validatorSnapshotHash: z.string().optional(),
 });
 
 export const CellSchema = z.union([


### PR DESCRIPTION
Implements **SPEC-AGX-SUBSTRATE:c3 — the template/contract half only**: typed outcome contracts per executable cell, validated at authoring time, driving the document verdict. The instance half (durable, append-only run/instance persistence + fitness ledger rows) is **B4b, deferred** — `NotebookRun` remains in-memory; the spec's §8 build inventory now tracks B4b as its own M unit.

## What's in the diff

- **`src/notebook/contracts.ts` (new)** — tier-1 outcome contracts as pure data `{ source, op, value }`, zod-validated, compiled parse-only (extract → zod → canonicalize → sha256, mirroring `peer-notebook/manifest.ts`). Sources: `exitCode`, `output` (RFC 6901 JSON pointer into the cell's structured output), `artifact`, `claimStatus` (narrow resolver interface, unwired → `error` result "claim resolver not wired" until the claims branches merge). Ops: `eq ne lt lte gt gte matches schema` (minimal JSON Schema subset). Per-expectation results: `pass | fail | error | skipped` — error and skipped are never pass. Tier-2 mapping from `ValidationResult` into the same record model, tagged `tier: 2`.
- **Verdict derivation (`engine/runtime.ts`, `engine/domain.ts`)** — contracted runs pass iff every declared expectation evaluated and passed (a procedurally failed cell still fails the run). Zero-contract runbooks keep the existing procedural verdict but carry `contractCoverage: 0` and a reason ending "procedural completion only — no outcome contracts declared" so downstream fitness (B9) can exclude them. `RunbookVerdict` gains a required `contractCoverage` field; evidence entries carry per-expectation records and contract hashes.
- **Tampering rejection (`index.ts`)** — every attached contract hash is re-verified before any cell executes; mismatch throws `ContractHashMismatchError`, mapped to a `SnapshotMismatch` failure and a `FailedRun` with a distinct "outcome contract hash mismatch … run rejected" error.
- **Structured output channel (`state.ts`)** — code cells get a `TB_OUTPUT_PATH` env var pointing at a per-execution sidecar (same pattern as the validator's `TB_OBSERVED_PATH`/`TB_VERDICT_PATH`); `output` expectations read only this channel. Free-text stdout is never scraped.
- **Tier 2 (`index.ts`, `types.ts`)** — code cells may declare `validatorFor`; such cells run through the existing `ValidatorService` (unchanged mechanics) against the target cell's structured output, with the authoring-time snapshot hash re-checked at run; post-attach edits surface as `snapshot_hash_mismatch` → `error`.
- **Authoring surface** — `notebook_add_cell` accepts optional `contract` and `validatorFor` (mutually exclusive) for code cells; the operations catalog documents both.
- **Spec (same PR per repo rule)** — §8 B4 split into B4a (this unit) and B4b (new M unit: durable run/instance persistence + fitness ledger rows; discovered gap: `NotebookRun` is in-memory only); total adjusted to ≈11; new §5.1 records the adopted contract design.

## Tests run

- `vitest run src/notebook` — 58 passed (30 new contract unit tests; engine suite extended with 8 contract integration tests: tri-state + skipped each reachable, error≠fail, hash-tampering rejection, JSON-pointer extraction incl. missing pointer → error, zero-contract backward compat with `contractCoverage: 0`, tier-2 validator mapping end-to-end incl. post-attach edit detection, claim-resolver stub error and injected-resolver pass). All pre-existing notebook/validator tests stay green (extended, none deleted).
- `vitest run src/peer-notebook src/protocol src/code-mode` — 185 passed (downstream consumers).
- `pnpm check:types` — clean. `pnpm check:lint` — 0 warnings, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)