### PR TITLE
feat(notebook): durable runbook templates, instances, and fitness ledger

### DIFF
--- a/src/database.types.ts
+++ b/src/database.types.ts
@@ -1545,6 +1545,209 @@ export type Database = {
           },
         ]
       }
+      runbook_cell_executions: {
+        Row: {
+          agent_id: string
+          cell_id: string
+          expectations: Json
+          inputs_digest: string
+          instance_id: string
+          outputs_ref: string | null
+          recorded_at: string
+          seq: number
+          started_at: string
+          status: string
+          tenant_workspace_id: string
+        }
+        Insert: {
+          agent_id: string
+          cell_id: string
+          expectations?: Json
+          inputs_digest: string
+          instance_id: string
+          outputs_ref?: string | null
+          recorded_at?: string
+          seq: number
+          started_at: string
+          status: string
+          tenant_workspace_id: string
+        }
+        Update: {
+          agent_id?: string
+          cell_id?: string
+          expectations?: Json
+          inputs_digest?: string
+          instance_id?: string
+          outputs_ref?: string | null
+          recorded_at?: string
+          seq?: number
+          started_at?: string
+          status?: string
+          tenant_workspace_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "runbook_cell_executions_instance_id_fkey"
+            columns: ["instance_id"]
+            isOneToOne: false
+            referencedRelation: "runbook_instances"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "runbook_cell_executions_tenant_workspace_id_fkey"
+            columns: ["tenant_workspace_id"]
+            isOneToOne: false
+            referencedRelation: "workspaces"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      runbook_fitness_ledger: {
+        Row: {
+          actual: Json | null
+          agent_id: string
+          cell_id: string
+          error: string | null
+          expected: Json
+          id: number
+          instance_id: string
+          pass: boolean
+          result: string
+          template_id: string
+          template_version: number
+          tenant_workspace_id: string
+          tier: number
+          ts: string
+        }
+        Insert: {
+          actual?: Json | null
+          agent_id: string
+          cell_id: string
+          error?: string | null
+          expected: Json
+          id?: never
+          instance_id: string
+          pass: boolean
+          result: string
+          template_id: string
+          template_version: number
+          tenant_workspace_id: string
+          tier: number
+          ts?: string
+        }
+        Update: {
+          actual?: Json | null
+          agent_id?: string
+          cell_id?: string
+          error?: string | null
+          expected?: Json
+          id?: never
+          instance_id?: string
+          pass?: boolean
+          result?: string
+          template_id?: string
+          template_version?: number
+          tenant_workspace_id?: string
+          tier?: number
+          ts?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "runbook_fitness_ledger_instance_id_fkey"
+            columns: ["instance_id"]
+            isOneToOne: false
+            referencedRelation: "runbook_instances"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "runbook_fitness_ledger_tenant_workspace_id_fkey"
+            columns: ["tenant_workspace_id"]
+            isOneToOne: false
+            referencedRelation: "workspaces"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      runbook_instances: {
+        Row: {
+          created_at: string
+          created_by: string
+          id: string
+          template_id: string
+          template_version: number
+          tenant_workspace_id: string
+        }
+        Insert: {
+          created_at?: string
+          created_by: string
+          id: string
+          template_id: string
+          template_version: number
+          tenant_workspace_id: string
+        }
+        Update: {
+          created_at?: string
+          created_by?: string
+          id?: string
+          template_id?: string
+          template_version?: number
+          tenant_workspace_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "runbook_instances_template_id_template_version_fkey"
+            columns: ["template_id", "template_version"]
+            isOneToOne: false
+            referencedRelation: "runbook_templates"
+            referencedColumns: ["template_id", "version"]
+          },
+          {
+            foreignKeyName: "runbook_instances_tenant_workspace_id_fkey"
+            columns: ["tenant_workspace_id"]
+            isOneToOne: false
+            referencedRelation: "workspaces"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      runbook_templates: {
+        Row: {
+          cells: Json
+          cells_hash: string
+          created_at: string
+          created_by: string
+          template_id: string
+          tenant_workspace_id: string
+          version: number
+        }
+        Insert: {
+          cells: Json
+          cells_hash: string
+          created_at?: string
+          created_by: string
+          template_id: string
+          tenant_workspace_id: string
+          version: number
+        }
+        Update: {
+          cells?: Json
+          cells_hash?: string
+          created_at?: string
+          created_by?: string
+          template_id?: string
+          tenant_workspace_id?: string
+          version?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "runbook_templates_tenant_workspace_id_fkey"
+            columns: ["tenant_workspace_id"]
+            isOneToOne: false
+            referencedRelation: "workspaces"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       runs: {
         Row: {
           ended_at: string | null

--- a/src/database.types.ts
+++ b/src/database.types.ts
@@ -1745,11 +1745,11 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "runbook_cell_executions_instance_id_fkey"
-            columns: ["instance_id"]
+            foreignKeyName: "runbook_cell_executions_instance_tenant_fkey"
+            columns: ["instance_id", "tenant_workspace_id"]
             isOneToOne: false
             referencedRelation: "runbook_instances"
-            referencedColumns: ["id"]
+            referencedColumns: ["id", "tenant_workspace_id"]
           },
           {
             foreignKeyName: "runbook_cell_executions_tenant_workspace_id_fkey"
@@ -1811,11 +1811,11 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "runbook_fitness_ledger_instance_id_fkey"
-            columns: ["instance_id"]
+            foreignKeyName: "runbook_fitness_ledger_instance_tenant_fkey"
+            columns: ["instance_id", "tenant_workspace_id"]
             isOneToOne: false
             referencedRelation: "runbook_instances"
-            referencedColumns: ["id"]
+            referencedColumns: ["id", "tenant_workspace_id"]
           },
           {
             foreignKeyName: "runbook_fitness_ledger_tenant_workspace_id_fkey"

--- a/src/database.types.ts
+++ b/src/database.types.ts
@@ -1853,11 +1853,11 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "runbook_instances_template_id_template_version_fkey"
-            columns: ["template_id", "template_version"]
+            foreignKeyName: "runbook_instances_template_tenant_fkey"
+            columns: ["tenant_workspace_id", "template_id", "template_version"]
             isOneToOne: false
             referencedRelation: "runbook_templates"
-            referencedColumns: ["template_id", "version"]
+            referencedColumns: ["tenant_workspace_id", "template_id", "version"]
           },
           {
             foreignKeyName: "runbook_instances_tenant_workspace_id_fkey"

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,8 @@ import { createSupabaseHubStorageProvider } from "./hub/supabase-hub-storage.js"
 import type { HubStorage } from "./hub/hub-types.js";
 import { InMemoryClaimStorage } from "./claims/in-memory-claim-storage.js";
 import { createSupabaseClaimStorageProvider } from "./claims/supabase-claim-storage.js";
+import { InMemoryRunbookStorage } from "./notebook/runbook/in-memory-runbook-storage.js";
+import { createSupabaseRunbookStorageProvider } from "./notebook/runbook/supabase-runbook-storage.js";
 import { initEvaluation, initMonitoring } from "./evaluation/index.js";
 import { createHubHandler, type HubEvent } from "./hub/hub-handler.js";
 import {
@@ -197,6 +199,19 @@ async function startHttpServer() {
       })
     : null;
   const localClaimStorage = isMultiTenant ? null : new InMemoryClaimStorage();
+
+  // Durable runbook storage (SPEC-AGX-SUBSTRATE B4b): tenant-scoped
+  // SupabaseRunbookStorage when hosted; a single process-shared
+  // InMemoryRunbookStorage locally. Without it the notebook engine falls
+  // back to a per-handler InMemoryRunbookStorage and runbook
+  // templates/instances/executions/ledger rows are lost with the process.
+  const tenantRunbookStorage = isMultiTenant
+    ? createSupabaseRunbookStorageProvider({
+        supabaseUrl: process.env.SUPABASE_URL!,
+        serviceRoleKey: process.env.SUPABASE_SERVICE_ROLE_KEY!,
+      })
+    : null;
+  const localRunbookStorage = isMultiTenant ? null : new InMemoryRunbookStorage();
 
   // Local-mode hub thought store: ONE storage instance shared by /hub/api
   // and every local MCP session's tb.hub dispatcher. Per-session
@@ -399,6 +414,7 @@ async function startHttpServer() {
           // Tenant-scoped: never the process-shared local hub storage.
           hubStorage: tenantHubStorage!(workspaceId),
           claimStorage: tenantClaimStorage!(workspaceId),
+          runbookStorage: tenantRunbookStorage!(workspaceId),
           dataDir,
           knowledgeStorage,
           workspaceId,
@@ -456,6 +472,7 @@ async function startHttpServer() {
         storage,
         hubStorage,
         claimStorage: localClaimStorage!,
+        runbookStorage: localRunbookStorage!,
         hubThoughtStore: localHubThoughtStore,
         dataDir,
         knowledgeStorage,

--- a/src/notebook/__tests__/runbook-durability.test.ts
+++ b/src/notebook/__tests__/runbook-durability.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Durable runbook round-trip through the engine runtime
+ * (SPEC-AGX-SUBSTRATE B4b — claim c3 instance half + claim c7).
+ *
+ * Drives a real notebook execution through NotebookHandler with an injected
+ * RunbookStorage, then "restarts" the storage (a new instance of the class
+ * over the same substrate) and verifies the durable record alone carries:
+ * the versioned template (contract hash re-verifies), the instance pinning
+ * the template version, the append-only cell executions with their
+ * per-expectation results, and correct fitness ledger aggregates.
+ *
+ * Runs against InMemoryRunbookStorage (shared state) always, and against
+ * SupabaseRunbookStorage when the local stack is up.
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { randomUUID } from "node:crypto";
+import { Effect } from "effect";
+import { NotebookHandler } from "../index.js";
+import {
+  InMemoryNotebookEngineRuntime,
+  type CellExecutionEvidence,
+} from "../engine/runtime.js";
+import {
+  InMemoryRunbookStorage,
+  createRunbookMemoryState,
+} from "../runbook/in-memory-runbook-storage.js";
+import { SupabaseRunbookStorage } from "../runbook/supabase-runbook-storage.js";
+import {
+  deriveInstanceStatus,
+  verifyTemplateContracts,
+  type RunbookStorage,
+} from "../runbook/types.js";
+import {
+  ensureTestWorkspace,
+  isSupabaseAvailable,
+  SUPABASE_TEST_URL,
+  SUPABASE_TEST_SERVICE_ROLE_KEY,
+  TEST_WORKSPACE_ID,
+} from "../../__tests__/supabase-test-helpers.js";
+
+const WRITE_OUTPUT_SOURCE =
+  `import { writeFileSync } from "node:fs";\n` +
+  `writeFileSync(process.env.TB_OUTPUT_PATH, JSON.stringify({ count: 3 }));\n` +
+  `console.log("step ran");`;
+
+/**
+ * Execute a contracted runbook through the handler and return what the
+ * durable layer must reconstruct later.
+ */
+async function executeContractedRunbook(storage: RunbookStorage) {
+  const handler = new NotebookHandler(undefined, {
+    runbookStorage: storage,
+    agentId: "agent-session-1",
+  });
+  await handler.init();
+
+  const created = await handler.handleCreateNotebook({
+    title: `Durable runbook ${randomUUID()}`,
+    language: "javascript",
+  });
+  const notebookId = created.notebook.id as string;
+  const added = await handler.handleAddCell({
+    notebookId,
+    cellType: "code",
+    filename: "step.js",
+    content: WRITE_OUTPUT_SOURCE,
+    contract: {
+      schemaVersion: "outcome-contract.v0",
+      expectations: [
+        { source: { kind: "exitCode" }, op: "eq", value: 0 },
+        { source: { kind: "output", pointer: "/count" }, op: "gte", value: 3 },
+      ],
+    },
+  });
+
+  const runResult = await handler.handleStartRun({
+    notebookId,
+    mode: "runbook",
+    inputs: { reason: "durability round-trip" },
+  });
+  expect(runResult.run.status).toBe("completed");
+  expect(runResult.run.outputs[0].pass).toBe(true);
+
+  return {
+    notebookId,
+    runId: runResult.run.runId as string,
+    contractHash: added.cell.contractHash as string,
+  };
+}
+
+/** Verify the durable record from a RESTARTED storage instance alone. */
+async function verifyDurableRecord(
+  restarted: RunbookStorage,
+  expected: { notebookId: string; runId: string; contractHash: string },
+): Promise<void> {
+  const instance = await restarted.getInstance(expected.runId);
+  expect(instance).not.toBeNull();
+  expect(instance!.templateId).toBe(expected.notebookId);
+  expect(instance!.templateVersion).toBe(1);
+  expect(instance!.createdBy).toBe("agent-session-1");
+
+  // Template intact, contract survives persistence, hash re-verifies.
+  const template = await restarted.getTemplate(
+    instance!.templateId,
+    instance!.templateVersion,
+  );
+  expect(template).not.toBeNull();
+  expect(() => verifyTemplateContracts(template!)).not.toThrow();
+  const contracted = template!.cells.find((cell) => cell.contract !== undefined)!;
+  expect(contracted.contract!.contractHash).toBe(expected.contractHash);
+  expect(contracted.source).toContain("TB_OUTPUT_PATH");
+
+  // Executions intact: package.json install + contracted step, in order,
+  // with the per-expectation records (tier/expected/actual) attached.
+  const executions = await restarted.listCellExecutions(expected.runId);
+  expect(executions).toHaveLength(2);
+  expect(executions.map((record) => record.seq)).toEqual([1, 2]);
+  expect(executions.every((record) => record.agentId === "agent-session-1")).toBe(true);
+  const step = executions.find((record) => record.cellId === contracted.cellId)!;
+  expect(step.status).toBe("completed");
+  expect(step.expectations).toHaveLength(2);
+  expect(step.expectations.every((record) => record.result === "pass")).toBe(true);
+  expect(step.expectations.every((record) => record.tier === 1)).toBe(true);
+  expect(step.expectations.map((record) => record.actual)).toEqual([0, 3]);
+  expect(deriveInstanceStatus(template!, executions)).toBe("completed");
+
+  // Ledger aggregates correct: 2 machine-checked passes, no errors.
+  const aggregate = await restarted.getFitnessAggregate(
+    instance!.templateId,
+    instance!.templateVersion,
+  );
+  expect(aggregate.instances).toBe(1);
+  expect(aggregate.evaluated).toBe(2);
+  expect(aggregate.passed).toBe(2);
+  expect(aggregate.passRate).toBe(1);
+  expect(aggregate.errorRows).toBe(0);
+  expect(aggregate.errorRate).toBe(0);
+  expect(aggregate.distinctAgents).toBe(1);
+}
+
+describe("Durable runbook round-trip — InMemory storage (shared state restart)", () => {
+  it("reconstructs template, instance, executions, and ledger after restart", async () => {
+    const state = createRunbookMemoryState();
+    const expected = await executeContractedRunbook(new InMemoryRunbookStorage(state));
+    // Restart: new instance of the class over the same durable substrate.
+    await verifyDurableRecord(new InMemoryRunbookStorage(state), expected);
+  }, 120_000);
+
+  it("appends a new template version when cells change, and a new instance per run", async () => {
+    const state = createRunbookMemoryState();
+    const storage = new InMemoryRunbookStorage(state);
+    const handler = new NotebookHandler(undefined, {
+      runbookStorage: storage,
+      agentId: "agent-session-1",
+    });
+    await handler.init();
+
+    const created = await handler.handleCreateNotebook({
+      title: "Versioned runbook",
+      language: "javascript",
+    });
+    const notebookId = created.notebook.id as string;
+    await handler.handleAddCell({
+      notebookId,
+      cellType: "code",
+      filename: "step.js",
+      content: 'console.log("v1");',
+    });
+
+    const run1 = await handler.handleStartRun({ notebookId, mode: "runbook" });
+    // Same cells: second run reuses template v1 with a fresh instance.
+    const run2 = await handler.handleStartRun({ notebookId, mode: "runbook" });
+    // Changed cells: third run appends template v2.
+    await handler.handleAddCell({
+      notebookId,
+      cellType: "code",
+      filename: "step2.js",
+      content: 'console.log("v2");',
+    });
+    const run3 = await handler.handleStartRun({ notebookId, mode: "runbook" });
+
+    expect(await storage.listTemplateVersions(notebookId)).toEqual([1, 2]);
+    expect((await storage.getInstance(run1.run.runId))!.templateVersion).toBe(1);
+    expect((await storage.getInstance(run2.run.runId))!.templateVersion).toBe(1);
+    expect((await storage.getInstance(run3.run.runId))!.templateVersion).toBe(2);
+    expect(await storage.listInstances(notebookId)).toHaveLength(3);
+  }, 180_000);
+});
+
+describe("Durable runbook round-trip — Supabase storage (local stack)", () => {
+  let available = false;
+
+  beforeAll(async () => {
+    available = await isSupabaseAvailable();
+    if (!available) return;
+    await ensureTestWorkspace();
+  });
+
+  it("reconstructs template, instance, executions, and ledger after restart", async ({
+    skip,
+  }) => {
+    if (!available) skip();
+    const config = {
+      supabaseUrl: SUPABASE_TEST_URL,
+      serviceRoleKey: SUPABASE_TEST_SERVICE_ROLE_KEY,
+      tenantWorkspaceId: TEST_WORKSPACE_ID,
+    };
+    const expected = await executeContractedRunbook(new SupabaseRunbookStorage(config));
+    // Restart: a brand-new client over the same Postgres substrate.
+    await verifyDurableRecord(new SupabaseRunbookStorage(config), expected);
+  }, 120_000);
+});
+
+describe("Durable persistence failures fail the run", () => {
+  it("marks the run failed when the storage port rejects — never silent", async () => {
+    const evidence: CellExecutionEvidence[] = [
+      {
+        cellId: "step",
+        cellType: "code",
+        filename: "step.js",
+        status: "completed",
+        exitCode: 0,
+        output: "ok",
+        error: "",
+      },
+    ];
+    const broken = new InMemoryRunbookStorage();
+    broken.createInstance = async () => {
+      throw new Error("substrate offline");
+    };
+    const runtime = new InMemoryNotebookEngineRuntime(async () => evidence, undefined, {
+      storage: broken,
+    });
+
+    await expect(
+      Effect.runPromise(runtime.startRun({ notebookId: "nb_offline", mode: "runbook" })),
+    ).rejects.toThrow();
+
+    const runs = runtime.listRuns("nb_offline");
+    expect(runs).toHaveLength(1);
+    const failed = runs[0] as Extract<(typeof runs)[number], { _tag: "FailedRun" }>;
+    expect(failed.status).toBe("failed");
+    expect(failed.error).toContain("durable runbook persistence failed");
+    expect(failed.error).toContain("substrate offline");
+  });
+});

--- a/src/notebook/__tests__/runbook-storage.test.ts
+++ b/src/notebook/__tests__/runbook-storage.test.ts
@@ -364,6 +364,39 @@ function runRunbookStorageContract(
       ]),
     ).rejects.toThrow();
   });
+
+  it("rejects ledger rows for missing instances or mismatched template pinning", async ({
+    skip,
+  }) => {
+    if (!isAvailable()) skip();
+    const { storage } = ctx();
+    const template = makeTemplate(`rbt-${randomUUID()}`);
+    await storage.saveTemplate(template);
+    const instance = makeInstance(template);
+    await storage.createInstance(instance);
+
+    // Unknown instance — the instance_id FK (InMemory: explicit check).
+    await expect(
+      storage.appendFitnessRows([makeLedgerRow(template, `rbi-${randomUUID()}`)]),
+    ).rejects.toThrow();
+
+    // The denormalized (templateId, templateVersion) must match the
+    // instance's pinning even when the other version EXISTS as a template —
+    // migration 20260612130000's composite FK / the InMemory pinning check.
+    const v2 = makeTemplate(template.templateId, 2, [
+      ...makeTemplateCells(),
+      { cellId: "extra", cellType: "code", filename: "extra.js", source: "2" },
+    ]);
+    await storage.saveTemplate(v2);
+    await expect(
+      storage.appendFitnessRows([makeLedgerRow(v2, instance.instanceId)]),
+    ).rejects.toThrow();
+
+    // A matching row is still accepted, and nothing from the rejected
+    // batches leaked into the ledger.
+    await storage.appendFitnessRows([makeLedgerRow(template, instance.instanceId)]);
+    expect(await storage.listFitnessRows(template.templateId)).toHaveLength(1);
+  });
 }
 
 // =============================================================================

--- a/src/notebook/__tests__/runbook-storage.test.ts
+++ b/src/notebook/__tests__/runbook-storage.test.ts
@@ -614,4 +614,36 @@ describe("SupabaseRunbookStorage — tenant isolation", () => {
     expect(await tenantA.listCellExecutions(instance.instanceId)).toEqual([]);
     expect(await tenantA.listFitnessRows(template.templateId)).toEqual([]);
   });
+
+  it("isolates template keys by tenant: a shared (template_id, version) does not collide", async ({
+    skip,
+  }) => {
+    if (!available) skip();
+    const tenantA = makeSupabaseRunbookStorage(TEST_WORKSPACE_ID);
+    const tenantB = makeSupabaseRunbookStorage(TENANT_B_WORKSPACE_ID);
+    // The runtime sets template_id to the notebook id, so two tenants can use
+    // the same one. Before 20260613030000 the global PK made tenant B's save
+    // collide on A's row (a spurious TemplateVersionConflictError); the
+    // tenant-scoped PK must let both save it.
+    const sharedId = `rbt-${randomUUID()}`;
+    await tenantA.saveTemplate(makeTemplate(sharedId));
+    await tenantB.saveTemplate(makeTemplate(sharedId));
+
+    expect(await tenantA.getLatestTemplate(sharedId)).not.toBeNull();
+    expect(await tenantB.getLatestTemplate(sharedId)).not.toBeNull();
+  });
+
+  it("rejects an instance pinned to another tenant's template", async ({ skip }) => {
+    if (!available) skip();
+    const tenantA = makeSupabaseRunbookStorage(TEST_WORKSPACE_ID);
+    const tenantB = makeSupabaseRunbookStorage(TENANT_B_WORKSPACE_ID);
+    const template = makeTemplate(`rbt-${randomUUID()}`);
+    await tenantA.saveTemplate(template); // only tenant A holds this template
+
+    // Tenant B pinning an instance to A's template must fail the
+    // tenant-composite template FK, not silently bind across tenants.
+    await expect(tenantB.createInstance(makeInstance(template))).rejects.toThrow(
+      /not found/,
+    );
+  });
 });

--- a/src/notebook/__tests__/runbook-storage.test.ts
+++ b/src/notebook/__tests__/runbook-storage.test.ts
@@ -1,0 +1,535 @@
+/**
+ * RunbookStorage contract suite (SPEC-AGX-SUBSTRATE B4b — claim c3 instance
+ * half + claim c7 fitness ledger).
+ *
+ * Runs the shared contract against both backends — InMemoryRunbookStorage
+ * and SupabaseRunbookStorage (local stack) — then covers Supabase-specific
+ * guarantees: database-level append-only enforcement (revoked UPDATE/DELETE
+ * grants) and tenant isolation. Supabase tests skip gracefully when the
+ * local stack is not running (src/__tests__/supabase-test-helpers).
+ *
+ * Because the runbook tables revoke DELETE even from service_role, tests
+ * never clean these tables up — every test uses fresh random ids instead.
+ *
+ * A FileSystemRunbookStorage is deliberately absent (deferred per spec §11.5).
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { randomUUID } from "node:crypto";
+import {
+  InMemoryRunbookStorage,
+  createRunbookMemoryState,
+} from "../runbook/in-memory-runbook-storage.js";
+import { SupabaseRunbookStorage } from "../runbook/supabase-runbook-storage.js";
+import {
+  aggregateFitness,
+  deriveInstanceStatus,
+  hashTemplateCells,
+  verifyTemplateContracts,
+  type CellExecutionRecord,
+  type FitnessLedgerRow,
+  type RunbookInstance,
+  type RunbookStorage,
+  type RunbookTemplate,
+  type RunbookTemplateCell,
+} from "../runbook/types.js";
+import { compileOutcomeContract } from "../contracts.js";
+import {
+  createServiceClient,
+  ensureTestWorkspace,
+  isSupabaseAvailable,
+  SUPABASE_TEST_URL,
+  SUPABASE_TEST_SERVICE_ROLE_KEY,
+  TEST_WORKSPACE_ID,
+} from "../../__tests__/supabase-test-helpers.js";
+
+const TENANT_B_WORKSPACE_ID = "33333333-3333-4333-a333-333333333333";
+
+function makeTemplateCells(): RunbookTemplateCell[] {
+  return [
+    {
+      cellId: "pkg",
+      cellType: "package.json",
+      filename: "package.json",
+      source: '{ "type": "module", "dependencies": {} }',
+    },
+    {
+      cellId: "step",
+      cellType: "code",
+      filename: "step.js",
+      source: 'console.log("ok");',
+      contract: compileOutcomeContract({
+        schemaVersion: "outcome-contract.v0",
+        expectations: [{ source: { kind: "exitCode" }, op: "eq", value: 0 }],
+      }),
+    },
+  ];
+}
+
+function makeTemplate(
+  templateId: string,
+  version = 1,
+  cells: RunbookTemplateCell[] = makeTemplateCells(),
+): RunbookTemplate {
+  return {
+    templateId,
+    version,
+    cells,
+    cellsHash: hashTemplateCells(cells),
+    createdBy: "agent-alice",
+    createdAt: new Date().toISOString(),
+  };
+}
+
+function makeInstance(
+  template: RunbookTemplate,
+  overrides: Partial<RunbookInstance> = {},
+): RunbookInstance {
+  return {
+    instanceId: `rbi-${randomUUID()}`,
+    templateId: template.templateId,
+    templateVersion: template.version,
+    createdBy: "agent-alice",
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeExecution(
+  instanceId: string,
+  seq: number,
+  overrides: Partial<CellExecutionRecord> = {},
+): CellExecutionRecord {
+  return {
+    instanceId,
+    seq,
+    cellId: "step",
+    startedAt: new Date().toISOString(),
+    agentId: "agent-alice",
+    inputsDigest: "sha256:abc",
+    outputsRef: "nba_evidence",
+    status: "completed",
+    expectations: [
+      {
+        cellId: "step",
+        tier: 1,
+        expectation: "exitCode eq 0",
+        result: "pass",
+        expected: { source: { kind: "exitCode" }, op: "eq", value: 0 },
+        actual: 0,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function makeLedgerRow(
+  template: RunbookTemplate,
+  instanceId: string,
+  overrides: Partial<FitnessLedgerRow> = {},
+): FitnessLedgerRow {
+  return {
+    templateId: template.templateId,
+    templateVersion: template.version,
+    instanceId,
+    cellId: "step",
+    tier: 1,
+    result: "pass",
+    pass: true,
+    expected: { source: { kind: "exitCode" }, op: "eq", value: 0 },
+    actual: 0,
+    agentId: "agent-alice",
+    ts: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+interface ContractContext {
+  storage: RunbookStorage;
+}
+
+// =============================================================================
+// Shared RunbookStorage contract
+// =============================================================================
+
+function runRunbookStorageContract(
+  ctx: () => ContractContext,
+  isAvailable: () => boolean,
+): void {
+  it("round-trips template versions and rejects in-place rewrites", async ({ skip }) => {
+    if (!isAvailable()) skip();
+    const { storage } = ctx();
+    const templateId = `rbt-${randomUUID()}`;
+
+    const v1 = makeTemplate(templateId, 1);
+    await storage.saveTemplate(v1);
+    expect(await storage.getTemplate(templateId, 1)).toEqual(v1);
+    expect(await storage.getTemplate(templateId, 2)).toBeNull();
+    expect(await storage.getTemplate("rbt-missing", 1)).toBeNull();
+
+    // A version is immutable: re-saving (templateId, 1) throws, even with
+    // different cells — new content must become a new version.
+    const rewritten = makeTemplate(templateId, 1, [
+      { cellId: "other", cellType: "code", filename: "other.js", source: "1" },
+    ]);
+    await expect(storage.saveTemplate(rewritten)).rejects.toThrow(/already exists/);
+    expect(await storage.getTemplate(templateId, 1)).toEqual(v1);
+
+    const v2Cells: RunbookTemplateCell[] = [
+      ...makeTemplateCells(),
+      { cellId: "extra", cellType: "code", filename: "extra.js", source: "2" },
+    ];
+    const v2 = makeTemplate(templateId, 2, v2Cells);
+    await storage.saveTemplate(v2);
+
+    expect(await storage.listTemplateVersions(templateId)).toEqual([1, 2]);
+    expect(await storage.getLatestTemplate(templateId)).toEqual(v2);
+    expect(await storage.getLatestTemplate("rbt-missing")).toBeNull();
+  });
+
+  it("preserves compiled outcome contracts across the persistence round-trip", async ({
+    skip,
+  }) => {
+    if (!isAvailable()) skip();
+    const { storage } = ctx();
+    const templateId = `rbt-${randomUUID()}`;
+
+    await storage.saveTemplate(makeTemplate(templateId, 1));
+    const loaded = await storage.getTemplate(templateId, 1);
+
+    // Hash re-verification passes on the loaded contract (Ulysses pattern at
+    // the durable layer — closes the B4a "contracts don't survive export"
+    // gap for durable templates).
+    expect(() => verifyTemplateContracts(loaded!)).not.toThrow();
+    const contracted = loaded!.cells.find((cell) => cell.contract !== undefined)!;
+    expect(contracted.contract!.contractHash).toMatch(/^sha256:/);
+
+    // A tampered loaded copy fails verification.
+    (
+      contracted.contract!.contract.expectations[0] as { value: unknown }
+    ).value = 1;
+    expect(() => verifyTemplateContracts(loaded!)).toThrow(/hash mismatch/);
+  });
+
+  it("pins instances to an existing template version at creation", async ({ skip }) => {
+    if (!isAvailable()) skip();
+    const { storage } = ctx();
+    const template = makeTemplate(`rbt-${randomUUID()}`);
+    await storage.saveTemplate(template);
+
+    const instance = makeInstance(template);
+    await storage.createInstance(instance);
+    expect(await storage.getInstance(instance.instanceId)).toEqual(instance);
+    expect(await storage.getInstance("rbi-missing")).toBeNull();
+
+    await expect(storage.createInstance(instance)).rejects.toThrow(/already exists/);
+    await expect(
+      storage.createInstance(makeInstance(template, { templateVersion: 99 })),
+    ).rejects.toThrow(/not found/);
+
+    const second = makeInstance(template);
+    await storage.createInstance(second);
+    const listed = await storage.listInstances(template.templateId);
+    expect(listed.map((i) => i.instanceId).sort()).toEqual(
+      [instance.instanceId, second.instanceId].sort(),
+    );
+  });
+
+  it("appends cell executions and rejects any rewrite of a prior record", async ({
+    skip,
+  }) => {
+    if (!isAvailable()) skip();
+    const { storage } = ctx();
+    const template = makeTemplate(`rbt-${randomUUID()}`);
+    await storage.saveTemplate(template);
+    const instance = makeInstance(template);
+    await storage.createInstance(instance);
+
+    const first = makeExecution(instance.instanceId, 1, { cellId: "pkg" });
+    const second = makeExecution(instance.instanceId, 2, { status: "failed" });
+    await storage.appendCellExecution(first);
+    await storage.appendCellExecution(second);
+
+    // Rewriting seq 2 must fail — re-execution appends a fresh seq instead.
+    await expect(
+      storage.appendCellExecution(
+        makeExecution(instance.instanceId, 2, { status: "completed" }),
+      ),
+    ).rejects.toThrow(/append-only/);
+    const reExecution = makeExecution(instance.instanceId, 3, { status: "completed" });
+    await storage.appendCellExecution(reExecution);
+
+    const records = await storage.listCellExecutions(instance.instanceId);
+    expect(records).toEqual([first, second, reExecution]);
+    expect(records[1]!.status).toBe("failed");
+
+    await expect(
+      storage.appendCellExecution(makeExecution("rbi-missing", 1)),
+    ).rejects.toThrow(/not found/);
+
+    // Status is derived from the append-only history: the latest record per
+    // cell wins, so the seq-3 re-execution supersedes the seq-2 failure.
+    expect(deriveInstanceStatus(template, records)).toBe("completed");
+    expect(deriveInstanceStatus(template, [first, second])).toBe("failed");
+    expect(deriveInstanceStatus(template, [first])).toBe("in_progress");
+    expect(deriveInstanceStatus(template, [])).toBe("created");
+  });
+
+  it("records fitness rows and aggregates them per template version (spec §7)", async ({
+    skip,
+  }) => {
+    if (!isAvailable()) skip();
+    const { storage } = ctx();
+    const template = makeTemplate(`rbt-${randomUUID()}`);
+    await storage.saveTemplate(template);
+    const instanceA = makeInstance(template);
+    const instanceB = makeInstance(template);
+    await storage.createInstance(instanceA);
+    await storage.createInstance(instanceB);
+
+    await storage.appendFitnessRows([
+      makeLedgerRow(template, instanceA.instanceId),
+      makeLedgerRow(template, instanceA.instanceId, {
+        result: "fail",
+        pass: false,
+        actual: 1,
+        agentId: "agent-bob",
+        tier: 2,
+      }),
+      makeLedgerRow(template, instanceB.instanceId, {
+        result: "error",
+        pass: false,
+        error: "claim resolver not wired",
+      }),
+      makeLedgerRow(template, instanceB.instanceId, {
+        result: "skipped",
+        pass: false,
+        error: "cell never reached (earlier cell failed)",
+      }),
+    ]);
+
+    const rows = await storage.listFitnessRows(template.templateId, template.version);
+    expect(rows).toHaveLength(4);
+    expect(rows.filter((row) => row.tier === 2)).toHaveLength(1);
+
+    // Aggregate: error/skipped rows are recorded but never count toward the
+    // pass-rate; only machine-evaluated pass/fail rows do.
+    const aggregate = await storage.getFitnessAggregate(
+      template.templateId,
+      template.version,
+    );
+    expect(aggregate).toEqual({
+      templateId: template.templateId,
+      templateVersion: template.version,
+      instances: 2,
+      evaluated: 2,
+      passed: 1,
+      passRate: 0.5,
+      errorRows: 1,
+      errorRate: 0.25,
+      distinctAgents: 2,
+    });
+    expect(aggregate).toEqual(aggregateFitness(template.templateId, template.version, rows));
+
+    // Version filter: rows from a later version do not leak into v1 aggregates.
+    const v2 = makeTemplate(template.templateId, 2, [
+      ...makeTemplateCells(),
+      { cellId: "extra", cellType: "code", filename: "extra.js", source: "2" },
+    ]);
+    await storage.saveTemplate(v2);
+    const instanceV2 = makeInstance(v2);
+    await storage.createInstance(instanceV2);
+    await storage.appendFitnessRows([makeLedgerRow(v2, instanceV2.instanceId)]);
+
+    expect(
+      await storage.listFitnessRows(template.templateId, template.version),
+    ).toHaveLength(4);
+    expect(await storage.listFitnessRows(template.templateId)).toHaveLength(5);
+    expect(
+      (await storage.getFitnessAggregate(template.templateId, 2)).passRate,
+    ).toBe(1);
+  });
+
+  it("rejects ledger rows where pass disagrees with the result", async ({ skip }) => {
+    if (!isAvailable()) skip();
+    const { storage } = ctx();
+    const template = makeTemplate(`rbt-${randomUUID()}`);
+    await storage.saveTemplate(template);
+    const instance = makeInstance(template);
+    await storage.createInstance(instance);
+
+    await expect(
+      storage.appendFitnessRows([
+        makeLedgerRow(template, instance.instanceId, { result: "error", pass: true }),
+      ]),
+    ).rejects.toThrow();
+  });
+}
+
+// =============================================================================
+// InMemory backend
+// =============================================================================
+
+describe("RunbookStorage contract — InMemoryRunbookStorage", () => {
+  const context: ContractContext = { storage: new InMemoryRunbookStorage() };
+  runRunbookStorageContract(
+    () => context,
+    () => true,
+  );
+
+  it("survives a simulated restart when backed by shared state", async () => {
+    const state = createRunbookMemoryState();
+    const before = new InMemoryRunbookStorage(state);
+    const template = makeTemplate(`rbt-${randomUUID()}`);
+    await before.saveTemplate(template);
+    const instance = makeInstance(template);
+    await before.createInstance(instance);
+    await before.appendCellExecution(makeExecution(instance.instanceId, 1));
+
+    // New instance of the class over the same durable substrate.
+    const after = new InMemoryRunbookStorage(state);
+    expect(await after.getTemplate(template.templateId, 1)).toEqual(template);
+    expect(await after.getInstance(instance.instanceId)).toEqual(instance);
+    expect(await after.listCellExecutions(instance.instanceId)).toHaveLength(1);
+  });
+});
+
+// =============================================================================
+// Supabase backend (local stack; skips when unavailable)
+// =============================================================================
+
+function makeSupabaseRunbookStorage(tenantWorkspaceId: string): SupabaseRunbookStorage {
+  return new SupabaseRunbookStorage({
+    supabaseUrl: SUPABASE_TEST_URL,
+    serviceRoleKey: SUPABASE_TEST_SERVICE_ROLE_KEY,
+    tenantWorkspaceId,
+  });
+}
+
+async function ensureTenantBWorkspace(): Promise<void> {
+  const client = createServiceClient();
+  const { data: users } = await client.auth.admin.listUsers();
+  const testUser = users?.users?.find((u) => u.email === "test@test.local");
+  if (!testUser) throw new Error("Test user missing; run ensureTestWorkspace first");
+  const { error } = await client.from("workspaces").upsert(
+    {
+      id: TENANT_B_WORKSPACE_ID,
+      name: "Test Workspace B (runbooks)",
+      slug: "test-workspace-b-runbooks",
+      owner_user_id: testUser.id,
+      status: "active",
+      plan_id: "free",
+    },
+    { onConflict: "id" },
+  );
+  if (error) throw new Error(`Failed to create tenant B workspace: ${error.message}`);
+}
+
+describe("RunbookStorage contract — SupabaseRunbookStorage", () => {
+  let available = false;
+  let context: ContractContext;
+
+  beforeAll(async () => {
+    available = await isSupabaseAvailable();
+    if (!available) return;
+    await ensureTestWorkspace();
+    context = { storage: makeSupabaseRunbookStorage(TEST_WORKSPACE_ID) };
+  });
+
+  runRunbookStorageContract(
+    () => context,
+    () => available,
+  );
+});
+
+describe("SupabaseRunbookStorage — database-level append-only enforcement", () => {
+  let available = false;
+
+  beforeAll(async () => {
+    available = await isSupabaseAvailable();
+    if (!available) return;
+    await ensureTestWorkspace();
+  });
+
+  it("denies UPDATE and DELETE on execution records even for service_role", async ({
+    skip,
+  }) => {
+    if (!available) skip();
+    const storage = makeSupabaseRunbookStorage(TEST_WORKSPACE_ID);
+    const template = makeTemplate(`rbt-${randomUUID()}`);
+    await storage.saveTemplate(template);
+    const instance = makeInstance(template);
+    await storage.createInstance(instance);
+    await storage.appendCellExecution(makeExecution(instance.instanceId, 1));
+
+    // Raw service-role client bypasses the storage layer entirely; the
+    // revoked grants (migration 20260612120000) must still block rewrites.
+    const raw = createServiceClient();
+    const update = await raw
+      .from("runbook_cell_executions")
+      .update({ status: "completed" })
+      .eq("instance_id", instance.instanceId);
+    expect(update.error?.message).toMatch(/permission denied/);
+
+    const del = await raw
+      .from("runbook_cell_executions")
+      .delete()
+      .eq("instance_id", instance.instanceId);
+    expect(del.error?.message).toMatch(/permission denied/);
+
+    const templateUpdate = await raw
+      .from("runbook_templates")
+      .update({ cells_hash: "sha256:tampered" })
+      .eq("template_id", template.templateId);
+    expect(templateUpdate.error?.message).toMatch(/permission denied/);
+
+    const ledgerDelete = await raw
+      .from("runbook_fitness_ledger")
+      .delete()
+      .eq("instance_id", instance.instanceId);
+    expect(ledgerDelete.error?.message).toMatch(/permission denied/);
+
+    // The record is intact after all four attempts.
+    const records = await storage.listCellExecutions(instance.instanceId);
+    expect(records).toHaveLength(1);
+    expect(records[0]!.seq).toBe(1);
+  });
+});
+
+describe("SupabaseRunbookStorage — tenant isolation", () => {
+  let available = false;
+
+  beforeAll(async () => {
+    available = await isSupabaseAvailable();
+    if (!available) return;
+    await ensureTestWorkspace();
+    await ensureTenantBWorkspace();
+  });
+
+  it("templates, instances, executions, and ledger rows are invisible across tenants", async ({
+    skip,
+  }) => {
+    if (!available) skip();
+    const tenantA = makeSupabaseRunbookStorage(TEST_WORKSPACE_ID);
+    const tenantB = makeSupabaseRunbookStorage(TENANT_B_WORKSPACE_ID);
+
+    const template = makeTemplate(`rbt-${randomUUID()}`);
+    await tenantA.saveTemplate(template);
+    const instance = makeInstance(template);
+    await tenantA.createInstance(instance);
+    await tenantA.appendCellExecution(makeExecution(instance.instanceId, 1));
+    await tenantA.appendFitnessRows([makeLedgerRow(template, instance.instanceId)]);
+
+    expect(await tenantB.getTemplate(template.templateId, 1)).toBeNull();
+    expect(await tenantB.getLatestTemplate(template.templateId)).toBeNull();
+    expect(await tenantB.listTemplateVersions(template.templateId)).toEqual([]);
+    expect(await tenantB.getInstance(instance.instanceId)).toBeNull();
+    expect(await tenantB.listInstances(template.templateId)).toEqual([]);
+    expect(await tenantB.listCellExecutions(instance.instanceId)).toEqual([]);
+    expect(await tenantB.listFitnessRows(template.templateId)).toEqual([]);
+
+    const aggregate = await tenantB.getFitnessAggregate(template.templateId, 1);
+    expect(aggregate.instances).toBe(0);
+    expect(aggregate.passRate).toBeNull();
+  });
+});

--- a/src/notebook/__tests__/runbook-storage.test.ts
+++ b/src/notebook/__tests__/runbook-storage.test.ts
@@ -565,4 +565,53 @@ describe("SupabaseRunbookStorage — tenant isolation", () => {
     expect(aggregate.instances).toBe(0);
     expect(aggregate.passRate).toBeNull();
   });
+
+  it("rejects attaching a child row to another tenant's instance (composite FK)", async ({
+    skip,
+  }) => {
+    if (!available) skip();
+    const tenantA = makeSupabaseRunbookStorage(TEST_WORKSPACE_ID);
+    const template = makeTemplate(`rbt-${randomUUID()}`);
+    await tenantA.saveTemplate(template);
+    const instance = makeInstance(template);
+    await tenantA.createInstance(instance);
+
+    // Raw service-role client bypasses the storage layer's tenant scoping and
+    // tries to write an execution + ledger row for tenant B that points at
+    // tenant A's instance. The (instance_id, tenant_workspace_id) FK
+    // (migration 20260613020000) must reject both: no instance exists at
+    // (A's id, tenant B).
+    const raw = createServiceClient();
+    const execInsert = await raw.from("runbook_cell_executions").insert({
+      instance_id: instance.instanceId,
+      seq: 1,
+      cell_id: "step",
+      tenant_workspace_id: TENANT_B_WORKSPACE_ID,
+      started_at: new Date().toISOString(),
+      agent_id: "agent-mallory",
+      inputs_digest: "sha256:abc",
+      status: "completed",
+      expectations: [],
+    });
+    expect(execInsert.error?.message).toMatch(/foreign key constraint/);
+
+    const ledgerInsert = await raw.from("runbook_fitness_ledger").insert({
+      template_id: template.templateId,
+      template_version: template.version,
+      instance_id: instance.instanceId,
+      cell_id: "step",
+      tenant_workspace_id: TENANT_B_WORKSPACE_ID,
+      tier: 1,
+      result: "pass",
+      pass: true,
+      expected: { source: { kind: "exitCode" }, op: "eq", value: 0 },
+      actual: 0,
+      agent_id: "agent-mallory",
+    });
+    expect(ledgerInsert.error?.message).toMatch(/foreign key constraint/);
+
+    // Tenant A's instance is untouched by the rejected writes.
+    expect(await tenantA.listCellExecutions(instance.instanceId)).toEqual([]);
+    expect(await tenantA.listFitnessRows(template.templateId)).toEqual([]);
+  });
 });

--- a/src/notebook/__tests__/template-versioning.test.ts
+++ b/src/notebook/__tests__/template-versioning.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Concurrency-safe template version resolution (Greptile PR #401 — TOCTOU
+ * race between getLatestTemplate and saveTemplate).
+ *
+ * The race: two concurrent runs of the same notebook both read the latest
+ * template version, both compute version + 1, and the loser's saveTemplate
+ * hits the (templateId, version) uniqueness guarantee. ensureTemplateVersion
+ * must recover the loser — reusing the winner's just-written version when the
+ * cells hash matches, appending the next version when content diverged —
+ * instead of failing the run.
+ *
+ * Covered here: the resolver under a deterministic forced overlap (two
+ * storage instances over shared state, first reads barriered), the engine
+ * runtime end to end under the same overlap, and the Supabase backend's
+ * typed 23505 conflict plus a real two-client race (skips when the local
+ * stack is down).
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { randomUUID } from "node:crypto";
+import { Effect } from "effect";
+import {
+  InMemoryRunbookStorage,
+  createRunbookMemoryState,
+} from "../runbook/in-memory-runbook-storage.js";
+import { SupabaseRunbookStorage } from "../runbook/supabase-runbook-storage.js";
+import {
+  ensureTemplateVersion,
+  TemplateVersionConflictError,
+} from "../runbook/template-versioning.js";
+import type { RunbookStorage, RunbookTemplateCell } from "../runbook/types.js";
+import {
+  InMemoryNotebookEngineRuntime,
+  type CellExecutionEvidence,
+} from "../engine/runtime.js";
+import {
+  ensureTestWorkspace,
+  isSupabaseAvailable,
+  SUPABASE_TEST_URL,
+  SUPABASE_TEST_SERVICE_ROLE_KEY,
+  TEST_WORKSPACE_ID,
+} from "../../__tests__/supabase-test-helpers.js";
+
+function makeCells(marker = "ok"): RunbookTemplateCell[] {
+  return [
+    {
+      cellId: "step",
+      cellType: "code",
+      filename: "step.js",
+      source: `console.log("${marker}");`,
+    },
+  ];
+}
+
+/** Resolves every caller's promise once `parties` callers have arrived. */
+function makeBarrier(parties: number): () => Promise<void> {
+  let arrived = 0;
+  const resolvers: Array<() => void> = [];
+  return () =>
+    new Promise<void>((resolve) => {
+      resolvers.push(resolve);
+      arrived += 1;
+      if (arrived >= parties) {
+        for (const release of resolvers) release();
+      }
+    });
+}
+
+/**
+ * Delegating storage whose FIRST getLatestTemplate call blocks until all
+ * barrier parties arrive — forces both racers into the check-then-act window
+ * (both read "no template yet") before either may write.
+ */
+function withFirstReadBarrier(
+  inner: RunbookStorage,
+  arrive: () => Promise<void>,
+): RunbookStorage {
+  let first = true;
+  return {
+    saveTemplate: (template) => inner.saveTemplate(template),
+    getTemplate: (templateId, version) => inner.getTemplate(templateId, version),
+    getLatestTemplate: async (templateId) => {
+      if (first) {
+        first = false;
+        await arrive();
+      }
+      return inner.getLatestTemplate(templateId);
+    },
+    listTemplateVersions: (templateId) => inner.listTemplateVersions(templateId),
+    createInstance: (instance) => inner.createInstance(instance),
+    getInstance: (instanceId) => inner.getInstance(instanceId),
+    listInstances: (templateId) => inner.listInstances(templateId),
+    appendCellExecution: (record) => inner.appendCellExecution(record),
+    listCellExecutions: (instanceId) => inner.listCellExecutions(instanceId),
+    appendFitnessRows: (rows) => inner.appendFitnessRows(rows),
+    listFitnessRows: (templateId, templateVersion) =>
+      inner.listFitnessRows(templateId, templateVersion),
+    getFitnessAggregate: (templateId, templateVersion) =>
+      inner.getFitnessAggregate(templateId, templateVersion),
+  };
+}
+
+describe("ensureTemplateVersion — sequential behavior", () => {
+  it("reuses the latest version when the cells hash matches, appends when it changes", async () => {
+    const storage = new InMemoryRunbookStorage();
+    const templateId = `rbt-${randomUUID()}`;
+
+    const v1 = await ensureTemplateVersion(storage, {
+      templateId,
+      cells: makeCells("a"),
+      createdBy: "agent-alice",
+    });
+    expect(v1.version).toBe(1);
+
+    const reused = await ensureTemplateVersion(storage, {
+      templateId,
+      cells: makeCells("a"),
+      createdBy: "agent-bob",
+    });
+    expect(reused.version).toBe(1);
+    expect(reused.createdBy).toBe("agent-alice");
+
+    const v2 = await ensureTemplateVersion(storage, {
+      templateId,
+      cells: makeCells("b"),
+      createdBy: "agent-bob",
+    });
+    expect(v2.version).toBe(2);
+    expect(await storage.listTemplateVersions(templateId)).toEqual([1, 2]);
+  });
+
+  it("propagates non-conflict storage failures instead of retrying them", async () => {
+    const storage = new InMemoryRunbookStorage();
+    storage.saveTemplate = async () => {
+      throw new Error("substrate offline");
+    };
+    await expect(
+      ensureTemplateVersion(storage, {
+        templateId: `rbt-${randomUUID()}`,
+        cells: makeCells(),
+        createdBy: "agent-alice",
+      }),
+    ).rejects.toThrow(/substrate offline/);
+  });
+});
+
+describe("ensureTemplateVersion — check-then-act race (two storage instances)", () => {
+  it("identical cells: both racers converge on one version, neither fails", async () => {
+    const state = createRunbookMemoryState();
+    const arrive = makeBarrier(2);
+    const templateId = `rbt-${randomUUID()}`;
+    const racer = (createdBy: string) =>
+      ensureTemplateVersion(
+        withFirstReadBarrier(new InMemoryRunbookStorage(state), arrive),
+        { templateId, cells: makeCells(), createdBy },
+      );
+
+    // Both read "no template" before either writes: the loser's saveTemplate
+    // conflicts and must recover by reusing the winner's version 1.
+    const [a, b] = await Promise.all([racer("agent-a"), racer("agent-b")]);
+    expect(a.version).toBe(1);
+    expect(b.version).toBe(1);
+    expect(a.cellsHash).toBe(b.cellsHash);
+    expect(
+      await new InMemoryRunbookStorage(state).listTemplateVersions(templateId),
+    ).toEqual([1]);
+  });
+
+  it("divergent cells: both racers succeed with distinct appended versions", async () => {
+    const state = createRunbookMemoryState();
+    const arrive = makeBarrier(2);
+    const templateId = `rbt-${randomUUID()}`;
+    const racer = (marker: string) =>
+      ensureTemplateVersion(
+        withFirstReadBarrier(new InMemoryRunbookStorage(state), arrive),
+        { templateId, cells: makeCells(marker), createdBy: `agent-${marker}` },
+      );
+
+    const [a, b] = await Promise.all([racer("a"), racer("b")]);
+    expect([a.version, b.version].sort((x, y) => x - y)).toEqual([1, 2]);
+    expect(a.cellsHash).not.toBe(b.cellsHash);
+    expect(
+      await new InMemoryRunbookStorage(state).listTemplateVersions(templateId),
+    ).toEqual([1, 2]);
+  });
+});
+
+describe("Engine runtime — concurrent first runs of the same notebook", () => {
+  it("both runs complete and pin the single template version", async () => {
+    const evidence: CellExecutionEvidence[] = [
+      {
+        cellId: "step",
+        cellType: "code",
+        filename: "step.js",
+        status: "completed",
+        exitCode: 0,
+        output: "ok",
+        error: "",
+      },
+    ];
+    const state = createRunbookMemoryState();
+    const arrive = makeBarrier(2);
+    const makeRuntime = (agentId: string) =>
+      new InMemoryNotebookEngineRuntime(async () => evidence, undefined, {
+        storage: withFirstReadBarrier(new InMemoryRunbookStorage(state), arrive),
+        agentId,
+      });
+
+    const notebookId = "nb_version_race";
+    const [a, b] = await Promise.all([
+      Effect.runPromise(makeRuntime("agent-a").startRun({ notebookId, mode: "runbook" })),
+      Effect.runPromise(makeRuntime("agent-b").startRun({ notebookId, mode: "runbook" })),
+    ]);
+
+    // Before the fix the loser surfaced "already exists" as a FailedRun.
+    expect(a.run.status).toBe("completed");
+    expect(b.run.status).toBe("completed");
+
+    const storage = new InMemoryRunbookStorage(state);
+    expect(await storage.listTemplateVersions(notebookId)).toEqual([1]);
+    const instances = await storage.listInstances(notebookId);
+    expect(instances).toHaveLength(2);
+    expect(instances.every((instance) => instance.templateVersion === 1)).toBe(true);
+  });
+});
+
+describe("SupabaseRunbookStorage — version conflicts (local stack)", () => {
+  let available = false;
+
+  beforeAll(async () => {
+    available = await isSupabaseAvailable();
+    if (!available) return;
+    await ensureTestWorkspace();
+  });
+
+  function makeStorage(): SupabaseRunbookStorage {
+    return new SupabaseRunbookStorage({
+      supabaseUrl: SUPABASE_TEST_URL,
+      serviceRoleKey: SUPABASE_TEST_SERVICE_ROLE_KEY,
+      tenantWorkspaceId: TEST_WORKSPACE_ID,
+    });
+  }
+
+  it("maps the 23505 duplicate-version insert to TemplateVersionConflictError", async ({
+    skip,
+  }) => {
+    if (!available) skip();
+    const storage = makeStorage();
+    const templateId = `rbt-${randomUUID()}`;
+    const cells = makeCells();
+    const template = {
+      templateId,
+      version: 1,
+      cells,
+      cellsHash: "sha256:race-test",
+      createdBy: "agent-alice",
+      createdAt: new Date().toISOString(),
+    };
+    await storage.saveTemplate(template);
+    // The retry-on-conflict recovery depends on this exact typed error.
+    await expect(storage.saveTemplate(template)).rejects.toBeInstanceOf(
+      TemplateVersionConflictError,
+    );
+  });
+
+  it("two clients resolving the same new template converge on version 1", async ({
+    skip,
+  }) => {
+    if (!available) skip();
+    const templateId = `rbt-${randomUUID()}`;
+    const racer = (createdBy: string) =>
+      ensureTemplateVersion(makeStorage(), {
+        templateId,
+        cells: makeCells(),
+        createdBy,
+      });
+
+    const [a, b] = await Promise.all([racer("agent-a"), racer("agent-b")]);
+    expect(a.version).toBe(1);
+    expect(b.version).toBe(1);
+    expect(await makeStorage().listTemplateVersions(templateId)).toEqual([1]);
+  });
+});

--- a/src/notebook/engine/runtime.ts
+++ b/src/notebook/engine/runtime.ts
@@ -11,6 +11,7 @@ import {
   NotebookModeNotImplemented,
   NotebookModeSchema,
   SnapshotMismatch,
+  StoreUnavailable,
   describeRunStatus,
 } from "./domain.js";
 import { getNotebookMode } from "./registry.js";
@@ -21,6 +22,14 @@ import {
   type ClaimStatusResolver,
   type ExpectationRecord,
 } from "../contracts.js";
+import {
+  hashTemplateCells,
+  type FitnessLedgerRow,
+  type RunbookStorage,
+  type RunbookTemplateCell,
+} from "../runbook/types.js";
+import { InMemoryRunbookStorage } from "../runbook/in-memory-runbook-storage.js";
+import { hashJson } from "../../peer-notebook/manifest.js";
 
 const MAX_ARTIFACT_BYTES = 1_000_000;
 const MAX_EVIDENCE_OUTPUT_CHARS = 2_000;
@@ -73,14 +82,46 @@ export type NotebookCellExecutor = (
   notebookId: string,
 ) => Promise<CellExecutionEvidence[]>;
 
+/**
+ * Durable persistence wiring for the engine runtime (SPEC-AGX-SUBSTRATE B4b).
+ * The storage port defaults to InMemoryRunbookStorage so the runtime works
+ * unchanged without external infrastructure; deployments inject
+ * SupabaseRunbookStorage through the same port.
+ */
+export interface NotebookEngineRuntimeOptions {
+  storage?: RunbookStorage;
+  /**
+   * Snapshot of a notebook's executable cells (including compiled contracts)
+   * for durable template versioning. When absent, a degenerate template is
+   * derived from execution evidence (cell ids/types/contracts; source
+   * unavailable at that layer).
+   */
+  templateCellSource?: (notebookId: string) => RunbookTemplateCell[] | undefined;
+  /** Executing agent identity recorded on instances/executions/ledger rows. */
+  agentId?: string;
+}
+
 export class InMemoryNotebookEngineRuntime {
   private runs = new Map<string, NotebookRun>();
   private artifacts = new Map<string, { ref: ArtifactRef; content: string }>();
+  /** Durable runbook substrate (templates, instances, executions, ledger). */
+  readonly storage: RunbookStorage;
+  private readonly templateCellSource?: (
+    notebookId: string,
+  ) => RunbookTemplateCell[] | undefined;
+  private readonly agentId: string;
 
   constructor(
     private readonly executeNotebook: NotebookCellExecutor,
     private readonly claimResolver?: ClaimStatusResolver,
-  ) {}
+    options: NotebookEngineRuntimeOptions = {},
+  ) {
+    this.storage = options.storage ?? new InMemoryRunbookStorage();
+    if (options.templateCellSource !== undefined) {
+      this.templateCellSource = options.templateCellSource;
+    }
+    this.agentId = options.agentId ?? "local";
+  }
 
   persistNotebook(notebookId: string, content: string) {
     return Effect.gen(this, function* () {
@@ -170,10 +211,36 @@ export class InMemoryNotebookEngineRuntime {
           "application/json",
           JSON.stringify(evidence, null, 2),
         );
-        return { evidence, inputsArtifact, evidenceArtifact };
+        const runArtifacts = [inputsArtifact, evidenceArtifact];
+        const { verdict, records } = buildRunbookVerdict(evidence, {
+          readArtifact: (name) => this.readRunArtifact(runArtifacts, name),
+          claimResolver: this.claimResolver,
+        });
+        // Durable persistence (SPEC-AGX-SUBSTRATE B4b): template version,
+        // instance pinning it, append-only cell executions, and fitness
+        // ledger rows. A persistence failure fails the run — durable records
+        // are part of the run's contract, not a best-effort side channel.
+        yield* Effect.tryPromise({
+          try: () =>
+            this.persistDurableRecords({
+              runId,
+              notebookId: input.notebookId,
+              startedAt,
+              inputs: input.inputs ?? {},
+              evidence,
+              records,
+              outputsRef: evidenceArtifact.artifactId,
+            }),
+          catch: (cause) =>
+            new StoreUnavailable({
+              store: "runbook",
+              reason: cause instanceof Error ? cause.message : String(cause),
+            }),
+        });
+        return { verdict, runArtifacts };
       });
 
-      const { evidence, inputsArtifact, evidenceArtifact } = yield* runBody.pipe(
+      const { verdict, runArtifacts } = yield* runBody.pipe(
         Effect.tapError((error) =>
           Effect.sync(() => {
             const detail =
@@ -182,7 +249,9 @@ export class InMemoryNotebookEngineRuntime {
                 : error._tag === "SnapshotMismatch"
                   ? `outcome contract hash mismatch: expected ${error.expected}, ` +
                     `got ${error.actual} — contract was modified after attach; run rejected`
-                  : error.reason;
+                  : error._tag === "StoreUnavailable"
+                    ? `durable runbook persistence failed (${error.store}): ${error.reason}`
+                    : error.reason;
             const failed: NotebookRun = {
               _tag: "FailedRun",
               runId,
@@ -199,7 +268,6 @@ export class InMemoryNotebookEngineRuntime {
         ),
       );
 
-      const runArtifacts = [inputsArtifact, evidenceArtifact];
       const completedAt = new Date().toISOString();
       const completed: NotebookRun = {
         _tag: "CompletedRun",
@@ -210,12 +278,7 @@ export class InMemoryNotebookEngineRuntime {
         createdAt,
         startedAt,
         completedAt,
-        outputs: [
-          buildRunbookVerdict(evidence, {
-            readArtifact: (name) => this.readRunArtifact(runArtifacts, name),
-            claimResolver: this.claimResolver,
-          }),
-        ],
+        outputs: [verdict],
         artifacts: runArtifacts,
       };
       this.runs.set(runId, completed);
@@ -260,6 +323,96 @@ export class InMemoryNotebookEngineRuntime {
 
   getArtifact(artifactId: string): { ref: ArtifactRef; content: string } | null {
     return this.artifacts.get(artifactId) ?? null;
+  }
+
+  /**
+   * Persist the durable record of one run (SPEC-AGX-SUBSTRATE B4b):
+   * 1. Template version — the notebook id is the stable templateId; a new
+   *    immutable version is appended when the canonical cells hash changes,
+   *    otherwise the latest version is reused.
+   * 2. Instance — pins (templateId, version) at creation; instanceId = runId.
+   * 3. Cell executions — one append-only record per evidence cell
+   *    (seq = document order), carrying the per-expectation results.
+   * 4. Fitness ledger — one row per machine-checked expectation evaluation
+   *    (tier carried; error/skipped recorded with their state and excluded
+   *    from pass-rate aggregates by `aggregateFitness`).
+   */
+  private async persistDurableRecords(args: {
+    runId: string;
+    notebookId: string;
+    startedAt: string;
+    inputs: Record<string, unknown>;
+    evidence: CellExecutionEvidence[];
+    records: ExpectationRecord[];
+    outputsRef: string;
+  }): Promise<void> {
+    const { runId, notebookId, startedAt, inputs, evidence, records, outputsRef } = args;
+    const cells =
+      this.templateCellSource?.(notebookId) ?? templateCellsFromEvidence(evidence);
+    const cellsHash = hashTemplateCells(cells);
+
+    const latest = await this.storage.getLatestTemplate(notebookId);
+    let templateVersion: number;
+    if (latest && latest.cellsHash === cellsHash) {
+      templateVersion = latest.version;
+    } else {
+      templateVersion = (latest?.version ?? 0) + 1;
+      await this.storage.saveTemplate({
+        templateId: notebookId,
+        version: templateVersion,
+        cells,
+        cellsHash,
+        createdBy: this.agentId,
+        createdAt: new Date().toISOString(),
+      });
+    }
+
+    await this.storage.createInstance({
+      instanceId: runId,
+      templateId: notebookId,
+      templateVersion,
+      createdBy: this.agentId,
+      createdAt: startedAt,
+    });
+
+    const recordsByCell = new Map<string, ExpectationRecord[]>();
+    for (const record of records) {
+      const list = recordsByCell.get(record.cellId);
+      if (list) list.push(record);
+      else recordsByCell.set(record.cellId, [record]);
+    }
+
+    const inputsDigest = hashJson(inputs);
+    for (const [index, cell] of evidence.entries()) {
+      await this.storage.appendCellExecution({
+        instanceId: runId,
+        seq: index + 1,
+        cellId: cell.cellId,
+        startedAt,
+        agentId: this.agentId,
+        inputsDigest,
+        outputsRef,
+        status: cell.status,
+        expectations: recordsByCell.get(cell.cellId) ?? [],
+      });
+    }
+
+    const ts = new Date().toISOString();
+    const ledgerRows: FitnessLedgerRow[] = records.map((record) => ({
+      templateId: notebookId,
+      templateVersion,
+      instanceId: runId,
+      cellId: record.cellId,
+      tier: record.tier,
+      result: record.result,
+      pass: record.result === "pass",
+      expected: record.expected,
+      ...(record.actual !== undefined ? { actual: record.actual } : {}),
+      ...(record.error !== undefined ? { error: record.error } : {}),
+      agentId: this.agentId,
+      ts,
+    }));
+    await this.storage.appendFitnessRows(ledgerRows);
   }
 
   /**
@@ -309,11 +462,15 @@ interface VerdictDerivationContext {
  * verdict must rest on at least one completed code cell — dependency
  * installation (package.json cells) is recorded as evidence but cannot verify
  * a runbook by itself, so blank notebooks cannot pass.
+ *
+ * Returns the verdict plus the flat list of per-expectation records so the
+ * caller can flow them into durable instance records and fitness ledger rows
+ * (B4b) without re-evaluating.
  */
 function buildRunbookVerdict(
   evidence: CellExecutionEvidence[],
   context: VerdictDerivationContext,
-): NotebookOutput {
+): { verdict: NotebookOutput; records: ExpectationRecord[] } {
   const recordsByCell = new Map<string, ExpectationRecord[]>();
   const allRecords: ExpectationRecord[] = [];
   const coveredCellIds = new Set<string>();
@@ -411,30 +568,52 @@ function buildRunbookVerdict(
   }
 
   return {
-    _tag: "RunbookVerdict",
-    mode: "runbook",
-    pass,
-    reason,
-    contractCoverage,
-    evidence: evidence.map((cell) => ({
-      cellId: cell.cellId,
-      cellType: cell.cellType,
-      filename: cell.filename,
-      status: cell.status,
-      exitCode: cell.exitCode,
-      output: truncate(cell.output),
-      error: truncate(cell.error),
-      ...(cell.contract !== undefined
-        ? { contractHash: cell.contract.contractHash }
-        : {}),
-      ...(recordsByCell.has(cell.cellId)
-        ? { expectations: recordsByCell.get(cell.cellId) }
-        : {}),
-    })),
+    verdict: {
+      _tag: "RunbookVerdict",
+      mode: "runbook",
+      pass,
+      reason,
+      contractCoverage,
+      evidence: evidence.map((cell) => ({
+        cellId: cell.cellId,
+        cellType: cell.cellType,
+        filename: cell.filename,
+        status: cell.status,
+        exitCode: cell.exitCode,
+        output: truncate(cell.output),
+        error: truncate(cell.error),
+        ...(cell.contract !== undefined
+          ? { contractHash: cell.contract.contractHash }
+          : {}),
+        ...(recordsByCell.has(cell.cellId)
+          ? { expectations: recordsByCell.get(cell.cellId) }
+          : {}),
+      })),
+    },
+    records: allRecords,
   };
 }
 
 function truncate(text: string): string {
   if (text.length <= MAX_EVIDENCE_OUTPUT_CHARS) return text;
   return `${text.slice(0, MAX_EVIDENCE_OUTPUT_CHARS)}… [truncated]`;
+}
+
+/**
+ * Degenerate template snapshot derived from execution evidence, used only
+ * when no templateCellSource is wired (raw runtime usage). Cell identity,
+ * contracts (with hashes), and validator markers survive; authored source is
+ * not available at this layer, so prefer wiring a templateCellSource.
+ */
+function templateCellsFromEvidence(
+  evidence: CellExecutionEvidence[],
+): RunbookTemplateCell[] {
+  return evidence.map((cell) => ({
+    cellId: cell.cellId,
+    cellType: cell.cellType,
+    filename: cell.filename,
+    source: "",
+    ...(cell.contract !== undefined ? { contract: cell.contract } : {}),
+    ...(cell.validatorFor !== undefined ? { validatorFor: cell.validatorFor } : {}),
+  }));
 }

--- a/src/notebook/engine/runtime.ts
+++ b/src/notebook/engine/runtime.ts
@@ -23,11 +23,11 @@ import {
   type ExpectationRecord,
 } from "../contracts.js";
 import {
-  hashTemplateCells,
   type FitnessLedgerRow,
   type RunbookStorage,
   type RunbookTemplateCell,
 } from "../runbook/types.js";
+import { ensureTemplateVersion } from "../runbook/template-versioning.js";
 import { InMemoryRunbookStorage } from "../runbook/in-memory-runbook-storage.js";
 import { hashJson } from "../../peer-notebook/manifest.js";
 
@@ -349,23 +349,16 @@ export class InMemoryNotebookEngineRuntime {
     const { runId, notebookId, startedAt, inputs, evidence, records, outputsRef } = args;
     const cells =
       this.templateCellSource?.(notebookId) ?? templateCellsFromEvidence(evidence);
-    const cellsHash = hashTemplateCells(cells);
 
-    const latest = await this.storage.getLatestTemplate(notebookId);
-    let templateVersion: number;
-    if (latest && latest.cellsHash === cellsHash) {
-      templateVersion = latest.version;
-    } else {
-      templateVersion = (latest?.version ?? 0) + 1;
-      await this.storage.saveTemplate({
-        templateId: notebookId,
-        version: templateVersion,
-        cells,
-        cellsHash,
-        createdBy: this.agentId,
-        createdAt: new Date().toISOString(),
-      });
-    }
+    // Concurrency-safe: a lost saveTemplate race against a concurrent run of
+    // the same notebook reuses the winner's just-written version instead of
+    // failing this run (Greptile PR #401 — TOCTOU in template versioning).
+    const template = await ensureTemplateVersion(this.storage, {
+      templateId: notebookId,
+      cells,
+      createdBy: this.agentId,
+    });
+    const templateVersion = template.version;
 
     await this.storage.createInstance({
       instanceId: runId,

--- a/src/notebook/index.ts
+++ b/src/notebook/index.ts
@@ -14,6 +14,7 @@ import {
   InMemoryNotebookEngineRuntime,
   type CellExecutionEvidence,
 } from "./engine/runtime.js";
+import { templateCellsFromNotebook, type RunbookStorage } from "./runbook/types.js";
 import { getNotebookCapabilitiesJson } from "./engine/registry.js";
 import {
   NOTEBOOK_OPERATIONS,
@@ -27,6 +28,17 @@ export { getOperationNames };
 
 import { AVAILABLE_TEMPLATES } from "./templates.generated.js";
 
+export interface NotebookHandlerOptions {
+  /**
+   * Durable runbook substrate (SPEC-AGX-SUBSTRATE B4b). Defaults to
+   * InMemoryRunbookStorage inside the engine runtime; deployments inject
+   * SupabaseRunbookStorage here.
+   */
+  runbookStorage?: RunbookStorage;
+  /** Executing agent identity recorded on instances/executions/ledger rows. */
+  agentId?: string;
+}
+
 /**
  * Notebook Handler - MCP tool handlers for headless Srcbook notebooks
  */
@@ -35,12 +47,28 @@ export class NotebookHandler {
   private validatorService: ValidatorService;
   private engineRuntime: InMemoryNotebookEngineRuntime;
 
-  constructor(tempDir?: string) {
+  constructor(tempDir?: string, options: NotebookHandlerOptions = {}) {
     this.stateManager = new NotebookStateManager(tempDir);
     this.validatorService = new ValidatorService(this.stateManager);
-    this.engineRuntime = new InMemoryNotebookEngineRuntime((notebookId) =>
-      this.executeAllCells(notebookId),
+    this.engineRuntime = new InMemoryNotebookEngineRuntime(
+      (notebookId) => this.executeAllCells(notebookId),
+      undefined,
+      {
+        ...(options.runbookStorage !== undefined
+          ? { storage: options.runbookStorage }
+          : {}),
+        ...(options.agentId !== undefined ? { agentId: options.agentId } : {}),
+        templateCellSource: (notebookId) => {
+          const notebook = this.stateManager.getNotebook(notebookId);
+          return notebook ? templateCellsFromNotebook(notebook) : undefined;
+        },
+      },
     );
+  }
+
+  /** Durable runbook substrate behind the engine runtime (templates/instances/ledger). */
+  getRunbookStorage(): RunbookStorage {
+    return this.engineRuntime.storage;
   }
 
   /**

--- a/src/notebook/runbook/in-memory-runbook-storage.ts
+++ b/src/notebook/runbook/in-memory-runbook-storage.ts
@@ -1,0 +1,195 @@
+/**
+ * InMemoryRunbookStorage — volatile durable-runbook storage for tests and
+ * local mode (SPEC-AGX-SUBSTRATE B4b, §11.5: Supabase + InMemory first; a
+ * FileSystemRunbookStorage is deferred until H1/H2 pass).
+ *
+ * Mirrors SupabaseRunbookStorage semantics: structural copies on read and
+ * write (no shared references), append-only templates/instances/executions/
+ * ledger (duplicate natural keys throw — there is no update path at all).
+ *
+ * The backing state can be shared across storage instances via
+ * `createRunbookMemoryState()` so tests can simulate a process restart
+ * (new instance of the class, same durable substrate) without Supabase.
+ */
+
+import {
+  aggregateFitness,
+  type CellExecutionRecord,
+  type FitnessAggregate,
+  type FitnessLedgerRow,
+  type RunbookInstance,
+  type RunbookStorage,
+  type RunbookTemplate,
+} from "./types.js";
+
+export interface RunbookMemoryState {
+  /** Keyed by `${templateId}@${version}`. */
+  templates: Map<string, RunbookTemplate>;
+  instances: Map<string, RunbookInstance>;
+  /** Keyed by `${instanceId}#${seq}`. */
+  executions: Map<string, CellExecutionRecord>;
+  ledger: FitnessLedgerRow[];
+}
+
+export function createRunbookMemoryState(): RunbookMemoryState {
+  return {
+    templates: new Map(),
+    instances: new Map(),
+    executions: new Map(),
+    ledger: [],
+  };
+}
+
+function templateKey(templateId: string, version: number): string {
+  return `${templateId}@${version}`;
+}
+
+function executionKey(instanceId: string, seq: number): string {
+  return `${instanceId}#${seq}`;
+}
+
+function copy<T>(value: T): T {
+  return structuredClone(value);
+}
+
+export class InMemoryRunbookStorage implements RunbookStorage {
+  constructor(private readonly state: RunbookMemoryState = createRunbookMemoryState()) {}
+
+  async saveTemplate(template: RunbookTemplate): Promise<void> {
+    if (!Number.isInteger(template.version) || template.version < 1) {
+      throw new Error(
+        `InMemoryRunbookStorage.saveTemplate failed: version must be a positive integer, got ${template.version}`,
+      );
+    }
+    const key = templateKey(template.templateId, template.version);
+    if (this.state.templates.has(key)) {
+      throw new Error(
+        `InMemoryRunbookStorage.saveTemplate failed: template ${template.templateId} ` +
+          `version ${template.version} already exists — versions are immutable; append a new version`,
+      );
+    }
+    this.state.templates.set(key, copy(template));
+  }
+
+  async getTemplate(templateId: string, version: number): Promise<RunbookTemplate | null> {
+    const stored = this.state.templates.get(templateKey(templateId, version));
+    return stored ? copy(stored) : null;
+  }
+
+  async getLatestTemplate(templateId: string): Promise<RunbookTemplate | null> {
+    let latest: RunbookTemplate | undefined;
+    for (const template of this.state.templates.values()) {
+      if (template.templateId !== templateId) continue;
+      if (!latest || template.version > latest.version) latest = template;
+    }
+    return latest ? copy(latest) : null;
+  }
+
+  async listTemplateVersions(templateId: string): Promise<number[]> {
+    const versions: number[] = [];
+    for (const template of this.state.templates.values()) {
+      if (template.templateId === templateId) versions.push(template.version);
+    }
+    versions.sort((a, b) => a - b);
+    return versions;
+  }
+
+  async createInstance(instance: RunbookInstance): Promise<void> {
+    if (this.state.instances.has(instance.instanceId)) {
+      throw new Error(
+        `InMemoryRunbookStorage.createInstance failed: instance ${instance.instanceId} already exists`,
+      );
+    }
+    const template = this.state.templates.get(
+      templateKey(instance.templateId, instance.templateVersion),
+    );
+    if (!template) {
+      throw new Error(
+        `InMemoryRunbookStorage.createInstance failed: template ${instance.templateId} ` +
+          `version ${instance.templateVersion} not found — an instance must pin an existing template version`,
+      );
+    }
+    this.state.instances.set(instance.instanceId, copy(instance));
+  }
+
+  async getInstance(instanceId: string): Promise<RunbookInstance | null> {
+    const stored = this.state.instances.get(instanceId);
+    return stored ? copy(stored) : null;
+  }
+
+  async listInstances(templateId: string): Promise<RunbookInstance[]> {
+    const matches: RunbookInstance[] = [];
+    for (const instance of this.state.instances.values()) {
+      if (instance.templateId === templateId) matches.push(copy(instance));
+    }
+    matches.sort(
+      (a, b) =>
+        a.createdAt.localeCompare(b.createdAt) || a.instanceId.localeCompare(b.instanceId),
+    );
+    return matches;
+  }
+
+  async appendCellExecution(record: CellExecutionRecord): Promise<void> {
+    if (!Number.isInteger(record.seq) || record.seq < 1) {
+      throw new Error(
+        `InMemoryRunbookStorage.appendCellExecution failed: seq must be a positive integer, got ${record.seq}`,
+      );
+    }
+    if (!this.state.instances.has(record.instanceId)) {
+      throw new Error(
+        `InMemoryRunbookStorage.appendCellExecution failed: instance ${record.instanceId} not found`,
+      );
+    }
+    const key = executionKey(record.instanceId, record.seq);
+    if (this.state.executions.has(key)) {
+      throw new Error(
+        `InMemoryRunbookStorage.appendCellExecution failed: execution seq ${record.seq} ` +
+          `already recorded for instance ${record.instanceId} — records are append-only; ` +
+          `re-execution must append a new seq`,
+      );
+    }
+    this.state.executions.set(key, copy(record));
+  }
+
+  async listCellExecutions(instanceId: string): Promise<CellExecutionRecord[]> {
+    const matches: CellExecutionRecord[] = [];
+    for (const record of this.state.executions.values()) {
+      if (record.instanceId === instanceId) matches.push(copy(record));
+    }
+    matches.sort((a, b) => a.seq - b.seq);
+    return matches;
+  }
+
+  async appendFitnessRows(rows: FitnessLedgerRow[]): Promise<void> {
+    for (const row of rows) {
+      if (row.pass !== (row.result === "pass")) {
+        throw new Error(
+          `InMemoryRunbookStorage.appendFitnessRows failed: pass must equal (result === "pass") ` +
+            `for cell ${row.cellId} (result ${row.result}, pass ${row.pass})`,
+        );
+      }
+      this.state.ledger.push(copy(row));
+    }
+  }
+
+  async listFitnessRows(
+    templateId: string,
+    templateVersion?: number,
+  ): Promise<FitnessLedgerRow[]> {
+    const matches: FitnessLedgerRow[] = [];
+    for (const row of this.state.ledger) {
+      if (row.templateId !== templateId) continue;
+      if (templateVersion !== undefined && row.templateVersion !== templateVersion) continue;
+      matches.push(copy(row));
+    }
+    return matches;
+  }
+
+  async getFitnessAggregate(
+    templateId: string,
+    templateVersion: number,
+  ): Promise<FitnessAggregate> {
+    const rows = await this.listFitnessRows(templateId, templateVersion);
+    return aggregateFitness(templateId, templateVersion, rows);
+  }
+}

--- a/src/notebook/runbook/in-memory-runbook-storage.ts
+++ b/src/notebook/runbook/in-memory-runbook-storage.ts
@@ -21,6 +21,7 @@ import {
   type RunbookStorage,
   type RunbookTemplate,
 } from "./types.js";
+import { TemplateVersionConflictError } from "./template-versioning.js";
 
 export interface RunbookMemoryState {
   /** Keyed by `${templateId}@${version}`. */
@@ -63,10 +64,7 @@ export class InMemoryRunbookStorage implements RunbookStorage {
     }
     const key = templateKey(template.templateId, template.version);
     if (this.state.templates.has(key)) {
-      throw new Error(
-        `InMemoryRunbookStorage.saveTemplate failed: template ${template.templateId} ` +
-          `version ${template.version} already exists — versions are immutable; append a new version`,
-      );
+      throw new TemplateVersionConflictError(template.templateId, template.version);
     }
     this.state.templates.set(key, copy(template));
   }
@@ -161,13 +159,39 @@ export class InMemoryRunbookStorage implements RunbookStorage {
   }
 
   async appendFitnessRows(rows: FitnessLedgerRow[]): Promise<void> {
+    // Validate every row before appending any — the Supabase backend's batch
+    // insert is atomic, so a partially applied batch must be impossible here
+    // too. The first two checks mirror the database FKs (instance_id →
+    // runbook_instances, plus the composite pinning FK from migration
+    // 20260612130000) so tests that run only against this backend catch what
+    // Supabase would reject.
     for (const row of rows) {
+      const instance = this.state.instances.get(row.instanceId);
+      if (!instance) {
+        throw new Error(
+          `InMemoryRunbookStorage.appendFitnessRows failed: instance ${row.instanceId} not found`,
+        );
+      }
+      if (
+        instance.templateId !== row.templateId ||
+        instance.templateVersion !== row.templateVersion
+      ) {
+        throw new Error(
+          `InMemoryRunbookStorage.appendFitnessRows failed: row for cell ${row.cellId} ` +
+            `carries template ${row.templateId} version ${row.templateVersion}, but ` +
+            `instance ${row.instanceId} pins template ${instance.templateId} ` +
+            `version ${instance.templateVersion} — ledger rows must match the ` +
+            `instance's template pinning`,
+        );
+      }
       if (row.pass !== (row.result === "pass")) {
         throw new Error(
           `InMemoryRunbookStorage.appendFitnessRows failed: pass must equal (result === "pass") ` +
             `for cell ${row.cellId} (result ${row.result}, pass ${row.pass})`,
         );
       }
+    }
+    for (const row of rows) {
       this.state.ledger.push(copy(row));
     }
   }

--- a/src/notebook/runbook/supabase-runbook-storage.ts
+++ b/src/notebook/runbook/supabase-runbook-storage.ts
@@ -1,0 +1,329 @@
+/**
+ * SupabaseRunbookStorage — Postgres-backed durable runbook storage
+ * (SPEC-AGX-SUBSTRATE B4b, claims c3 instance half + c7).
+ *
+ * Implements the RunbookStorage contract over the runbook_templates /
+ * runbook_instances / runbook_cell_executions / runbook_fitness_ledger
+ * tables, scoped to a single tenant workspace — the same pattern as
+ * SupabaseHubStorage:
+ * - every table is insert-only from the storage's perspective; the
+ *   interface exposes no update path, and migration 20260612120000 revokes
+ *   UPDATE/DELETE from the API roles so even a raw client cannot rewrite a
+ *   record;
+ * - duplicate natural keys (template version, instance id, execution seq)
+ *   surface as errors, never as silent overwrites;
+ * - aggregates are computed in application code from ledger rows via the
+ *   shared `aggregateFitness` helper so both backends agree exactly (row
+ *   volumes per template version are small in v0; a SQL aggregate replaces
+ *   this when the ledger grows).
+ */
+
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import type { Database, Json } from "../../database.types.js";
+import {
+  aggregateFitness,
+  type CellExecutionRecord,
+  type CellExecutionStatus,
+  type FitnessAggregate,
+  type FitnessLedgerRow,
+  type RunbookInstance,
+  type RunbookStorage,
+  type RunbookTemplate,
+  type RunbookTemplateCell,
+} from "./types.js";
+import type { ExpectationRecord, ExpectationResult } from "../contracts.js";
+
+type Tables = Database["public"]["Tables"];
+type TemplateRow = Tables["runbook_templates"]["Row"];
+type InstanceRow = Tables["runbook_instances"]["Row"];
+type ExecutionRow = Tables["runbook_cell_executions"]["Row"];
+type LedgerRow = Tables["runbook_fitness_ledger"]["Row"];
+
+export interface SupabaseRunbookStorageConfig {
+  supabaseUrl: string;
+  /** Service role key — bypasses RLS; tenant isolation is enforced in queries. */
+  serviceRoleKey: string;
+  /** SaaS workspace (public.workspaces.id) all runbook rows are scoped to. */
+  tenantWorkspaceId: string;
+}
+
+function toIso(timestamp: string): string {
+  return new Date(timestamp).toISOString();
+}
+
+export class SupabaseRunbookStorage implements RunbookStorage {
+  private client: SupabaseClient<Database>;
+  private tenantWorkspaceId: string;
+
+  constructor(config: SupabaseRunbookStorageConfig) {
+    this.tenantWorkspaceId = config.tenantWorkspaceId;
+    this.client = createClient<Database>(config.supabaseUrl, config.serviceRoleKey, {
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
+  }
+
+  private fail(operation: string, message: string): never {
+    throw new Error(
+      `SupabaseRunbookStorage.${operation} failed (tenant ${this.tenantWorkspaceId}): ${message}`,
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Templates
+  // -------------------------------------------------------------------------
+
+  private rowToTemplate(row: TemplateRow): RunbookTemplate {
+    return {
+      templateId: row.template_id,
+      version: row.version,
+      cells: row.cells as unknown as RunbookTemplateCell[],
+      cellsHash: row.cells_hash,
+      createdBy: row.created_by,
+      createdAt: toIso(row.created_at),
+    };
+  }
+
+  async saveTemplate(template: RunbookTemplate): Promise<void> {
+    const { error } = await this.client.from("runbook_templates").insert({
+      template_id: template.templateId,
+      version: template.version,
+      tenant_workspace_id: this.tenantWorkspaceId,
+      cells: template.cells as unknown as Json,
+      cells_hash: template.cellsHash,
+      created_by: template.createdBy,
+      created_at: template.createdAt,
+    });
+    if (error) {
+      if (error.code === "23505") {
+        this.fail(
+          "saveTemplate",
+          `template ${template.templateId} version ${template.version} already exists — ` +
+            `versions are immutable; append a new version`,
+        );
+      }
+      this.fail("saveTemplate", error.message);
+    }
+  }
+
+  async getTemplate(templateId: string, version: number): Promise<RunbookTemplate | null> {
+    const { data, error } = await this.client
+      .from("runbook_templates")
+      .select()
+      .eq("template_id", templateId)
+      .eq("version", version)
+      .eq("tenant_workspace_id", this.tenantWorkspaceId)
+      .maybeSingle();
+    if (error) this.fail("getTemplate", error.message);
+    return data ? this.rowToTemplate(data) : null;
+  }
+
+  async getLatestTemplate(templateId: string): Promise<RunbookTemplate | null> {
+    const { data, error } = await this.client
+      .from("runbook_templates")
+      .select()
+      .eq("template_id", templateId)
+      .eq("tenant_workspace_id", this.tenantWorkspaceId)
+      .order("version", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    if (error) this.fail("getLatestTemplate", error.message);
+    return data ? this.rowToTemplate(data) : null;
+  }
+
+  async listTemplateVersions(templateId: string): Promise<number[]> {
+    const { data, error } = await this.client
+      .from("runbook_templates")
+      .select("version")
+      .eq("template_id", templateId)
+      .eq("tenant_workspace_id", this.tenantWorkspaceId)
+      .order("version", { ascending: true });
+    if (error) this.fail("listTemplateVersions", error.message);
+    return (data ?? []).map((row) => row.version);
+  }
+
+  // -------------------------------------------------------------------------
+  // Instances
+  // -------------------------------------------------------------------------
+
+  private rowToInstance(row: InstanceRow): RunbookInstance {
+    return {
+      instanceId: row.id,
+      templateId: row.template_id,
+      templateVersion: row.template_version,
+      createdBy: row.created_by,
+      createdAt: toIso(row.created_at),
+    };
+  }
+
+  async createInstance(instance: RunbookInstance): Promise<void> {
+    const { error } = await this.client.from("runbook_instances").insert({
+      id: instance.instanceId,
+      template_id: instance.templateId,
+      template_version: instance.templateVersion,
+      tenant_workspace_id: this.tenantWorkspaceId,
+      created_by: instance.createdBy,
+      created_at: instance.createdAt,
+    });
+    if (error) {
+      if (error.code === "23505") {
+        this.fail("createInstance", `instance ${instance.instanceId} already exists`);
+      }
+      if (error.code === "23503") {
+        this.fail(
+          "createInstance",
+          `template ${instance.templateId} version ${instance.templateVersion} not found — ` +
+            `an instance must pin an existing template version`,
+        );
+      }
+      this.fail("createInstance", error.message);
+    }
+  }
+
+  async getInstance(instanceId: string): Promise<RunbookInstance | null> {
+    const { data, error } = await this.client
+      .from("runbook_instances")
+      .select()
+      .eq("id", instanceId)
+      .eq("tenant_workspace_id", this.tenantWorkspaceId)
+      .maybeSingle();
+    if (error) this.fail("getInstance", error.message);
+    return data ? this.rowToInstance(data) : null;
+  }
+
+  async listInstances(templateId: string): Promise<RunbookInstance[]> {
+    const { data, error } = await this.client
+      .from("runbook_instances")
+      .select()
+      .eq("template_id", templateId)
+      .eq("tenant_workspace_id", this.tenantWorkspaceId)
+      .order("created_at", { ascending: true })
+      .order("id", { ascending: true });
+    if (error) this.fail("listInstances", error.message);
+    return (data ?? []).map((row) => this.rowToInstance(row));
+  }
+
+  // -------------------------------------------------------------------------
+  // Cell executions (append-only)
+  // -------------------------------------------------------------------------
+
+  private rowToExecution(row: ExecutionRow): CellExecutionRecord {
+    return {
+      instanceId: row.instance_id,
+      seq: row.seq,
+      cellId: row.cell_id,
+      startedAt: toIso(row.started_at),
+      agentId: row.agent_id,
+      inputsDigest: row.inputs_digest,
+      ...(row.outputs_ref !== null ? { outputsRef: row.outputs_ref } : {}),
+      status: row.status as CellExecutionStatus,
+      expectations: row.expectations as unknown as ExpectationRecord[],
+    };
+  }
+
+  async appendCellExecution(record: CellExecutionRecord): Promise<void> {
+    const { error } = await this.client.from("runbook_cell_executions").insert({
+      instance_id: record.instanceId,
+      seq: record.seq,
+      cell_id: record.cellId,
+      tenant_workspace_id: this.tenantWorkspaceId,
+      started_at: record.startedAt,
+      agent_id: record.agentId,
+      inputs_digest: record.inputsDigest,
+      outputs_ref: record.outputsRef ?? null,
+      status: record.status,
+      expectations: record.expectations as unknown as Json,
+    });
+    if (error) {
+      if (error.code === "23505") {
+        this.fail(
+          "appendCellExecution",
+          `execution seq ${record.seq} already recorded for instance ${record.instanceId} — ` +
+            `records are append-only; re-execution must append a new seq`,
+        );
+      }
+      if (error.code === "23503") {
+        this.fail("appendCellExecution", `instance ${record.instanceId} not found`);
+      }
+      this.fail("appendCellExecution", error.message);
+    }
+  }
+
+  async listCellExecutions(instanceId: string): Promise<CellExecutionRecord[]> {
+    const { data, error } = await this.client
+      .from("runbook_cell_executions")
+      .select()
+      .eq("instance_id", instanceId)
+      .eq("tenant_workspace_id", this.tenantWorkspaceId)
+      .order("seq", { ascending: true });
+    if (error) this.fail("listCellExecutions", error.message);
+    return (data ?? []).map((row) => this.rowToExecution(row));
+  }
+
+  // -------------------------------------------------------------------------
+  // Fitness ledger (append-only)
+  // -------------------------------------------------------------------------
+
+  private rowToLedgerRow(row: LedgerRow): FitnessLedgerRow {
+    return {
+      templateId: row.template_id,
+      templateVersion: row.template_version,
+      instanceId: row.instance_id,
+      cellId: row.cell_id,
+      tier: row.tier as 1 | 2,
+      result: row.result as ExpectationResult,
+      pass: row.pass,
+      expected: row.expected,
+      ...(row.actual !== null ? { actual: row.actual } : {}),
+      ...(row.error !== null ? { error: row.error } : {}),
+      agentId: row.agent_id,
+      ts: toIso(row.ts),
+    };
+  }
+
+  async appendFitnessRows(rows: FitnessLedgerRow[]): Promise<void> {
+    if (rows.length === 0) return;
+    const { error } = await this.client.from("runbook_fitness_ledger").insert(
+      rows.map((row) => ({
+        template_id: row.templateId,
+        template_version: row.templateVersion,
+        instance_id: row.instanceId,
+        cell_id: row.cellId,
+        tenant_workspace_id: this.tenantWorkspaceId,
+        tier: row.tier,
+        result: row.result,
+        pass: row.pass,
+        expected: row.expected as Json,
+        actual: (row.actual ?? null) as Json,
+        error: row.error ?? null,
+        agent_id: row.agentId,
+        ts: row.ts,
+      })),
+    );
+    if (error) this.fail("appendFitnessRows", error.message);
+  }
+
+  async listFitnessRows(
+    templateId: string,
+    templateVersion?: number,
+  ): Promise<FitnessLedgerRow[]> {
+    let request = this.client
+      .from("runbook_fitness_ledger")
+      .select()
+      .eq("template_id", templateId)
+      .eq("tenant_workspace_id", this.tenantWorkspaceId);
+    if (templateVersion !== undefined) {
+      request = request.eq("template_version", templateVersion);
+    }
+    const { data, error } = await request.order("id", { ascending: true });
+    if (error) this.fail("listFitnessRows", error.message);
+    return (data ?? []).map((row) => this.rowToLedgerRow(row));
+  }
+
+  async getFitnessAggregate(
+    templateId: string,
+    templateVersion: number,
+  ): Promise<FitnessAggregate> {
+    const rows = await this.listFitnessRows(templateId, templateVersion);
+    return aggregateFitness(templateId, templateVersion, rows);
+  }
+}

--- a/src/notebook/runbook/supabase-runbook-storage.ts
+++ b/src/notebook/runbook/supabase-runbook-storage.ts
@@ -339,3 +339,23 @@ export class SupabaseRunbookStorage implements RunbookStorage {
     return aggregateFitness(templateId, templateVersion, rows);
   }
 }
+
+/**
+ * Per-tenant SupabaseRunbookStorage provider for multi-tenant mode.
+ * Instances are cached per tenant workspace; all rows are scoped by
+ * tenant_workspace_id so durable runbooks never cross tenant boundaries.
+ * Mirrors createSupabaseClaimStorageProvider.
+ */
+export function createSupabaseRunbookStorageProvider(
+  config: Omit<SupabaseRunbookStorageConfig, "tenantWorkspaceId">,
+): (tenantWorkspaceId: string) => RunbookStorage {
+  const cache = new Map<string, RunbookStorage>();
+  return (tenantWorkspaceId: string): RunbookStorage => {
+    let storage = cache.get(tenantWorkspaceId);
+    if (!storage) {
+      storage = new SupabaseRunbookStorage({ ...config, tenantWorkspaceId });
+      cache.set(tenantWorkspaceId, storage);
+    }
+    return storage;
+  };
+}

--- a/src/notebook/runbook/supabase-runbook-storage.ts
+++ b/src/notebook/runbook/supabase-runbook-storage.ts
@@ -32,6 +32,7 @@ import {
   type RunbookTemplateCell,
 } from "./types.js";
 import type { ExpectationRecord, ExpectationResult } from "../contracts.js";
+import { TemplateVersionConflictError } from "./template-versioning.js";
 
 type Tables = Database["public"]["Tables"];
 type TemplateRow = Tables["runbook_templates"]["Row"];
@@ -95,10 +96,11 @@ export class SupabaseRunbookStorage implements RunbookStorage {
     });
     if (error) {
       if (error.code === "23505") {
-        this.fail(
-          "saveTemplate",
-          `template ${template.templateId} version ${template.version} already exists — ` +
-            `versions are immutable; append a new version`,
+        // Typed so ensureTemplateVersion can recover from a lost version race.
+        throw new TemplateVersionConflictError(
+          template.templateId,
+          template.version,
+          `tenant ${this.tenantWorkspaceId}`,
         );
       }
       this.fail("saveTemplate", error.message);
@@ -299,7 +301,17 @@ export class SupabaseRunbookStorage implements RunbookStorage {
         ts: row.ts,
       })),
     );
-    if (error) this.fail("appendFitnessRows", error.message);
+    if (error) {
+      if (error.code === "23503") {
+        this.fail(
+          "appendFitnessRows",
+          `a ledger row references a missing instance or carries a ` +
+            `(template_id, template_version) that does not match its instance's ` +
+            `template pinning: ${error.message}`,
+        );
+      }
+      this.fail("appendFitnessRows", error.message);
+    }
   }
 
   async listFitnessRows(

--- a/src/notebook/runbook/template-versioning.ts
+++ b/src/notebook/runbook/template-versioning.ts
@@ -1,0 +1,81 @@
+/**
+ * Concurrency-safe template version resolution (SPEC-AGX-SUBSTRATE B4b).
+ *
+ * `getLatestTemplate` → compute `version + 1` → `saveTemplate` is a
+ * check-then-act sequence: two concurrent runs of the same notebook can both
+ * read the same latest version, both compute the same next version, and the
+ * loser's insert hits the (templateId, version) uniqueness guarantee — the
+ * runbook_templates primary key on the Supabase backend, the duplicate-key
+ * check on the InMemory backend. `ensureTemplateVersion` makes the loser
+ * recover instead of failing the run: on a version conflict it re-fetches,
+ * reuses the winner's just-written version when the cells hash matches, and
+ * appends the next version when the content actually diverged.
+ */
+
+import {
+  hashTemplateCells,
+  type RunbookStorage,
+  type RunbookTemplate,
+  type RunbookTemplateCell,
+} from "./types.js";
+
+/**
+ * Thrown by `RunbookStorage.saveTemplate` when (templateId, version) already
+ * exists. Typed (rather than a message-matched generic Error) so
+ * `ensureTemplateVersion` can distinguish a lost version race — recoverable —
+ * from a genuine storage failure, on both backends.
+ */
+export class TemplateVersionConflictError extends Error {
+  constructor(
+    readonly templateId: string,
+    readonly version: number,
+    detail?: string,
+  ) {
+    super(
+      `template ${templateId} version ${version} already exists — ` +
+        `versions are immutable; append a new version` +
+        (detail ? ` (${detail})` : ""),
+    );
+    this.name = "TemplateVersionConflictError";
+  }
+}
+
+const MAX_VERSION_ATTEMPTS = 5;
+
+/**
+ * Resolve the template version for the given cells: reuse the latest version
+ * when its canonical cells hash matches, otherwise append the next version.
+ * Safe under concurrent callers — a lost `saveTemplate` race is retried
+ * against the fresh latest version instead of propagating as a failure.
+ */
+export async function ensureTemplateVersion(
+  storage: RunbookStorage,
+  args: { templateId: string; cells: RunbookTemplateCell[]; createdBy: string },
+): Promise<RunbookTemplate> {
+  const cellsHash = hashTemplateCells(args.cells);
+  for (let attempt = 1; attempt <= MAX_VERSION_ATTEMPTS; attempt += 1) {
+    const latest = await storage.getLatestTemplate(args.templateId);
+    if (latest && latest.cellsHash === cellsHash) return latest;
+    const candidate: RunbookTemplate = {
+      templateId: args.templateId,
+      version: (latest?.version ?? 0) + 1,
+      cells: args.cells,
+      cellsHash,
+      createdBy: args.createdBy,
+      createdAt: new Date().toISOString(),
+    };
+    try {
+      await storage.saveTemplate(candidate);
+      return candidate;
+    } catch (cause) {
+      if (!(cause instanceof TemplateVersionConflictError)) throw cause;
+      // Lost the race: a concurrent caller wrote this version first. Loop —
+      // the re-fetch reuses the winner's version when its cells hash matches
+      // ours, or appends the next version when the content diverged.
+    }
+  }
+  throw new Error(
+    `ensureTemplateVersion failed for template ${args.templateId}: ` +
+      `version still contended after ${MAX_VERSION_ATTEMPTS} attempts`,
+  );
+}

--- a/src/notebook/runbook/types.ts
+++ b/src/notebook/runbook/types.ts
@@ -1,0 +1,292 @@
+/**
+ * Durable runbook domain types and storage contract
+ * (SPEC-AGX-SUBSTRATE B4b — claim c3 instance half + claim c7 fitness ledger).
+ *
+ * Identity scheme (documented per spec §5 template-vs-instance):
+ * - A template is identified by a `templateId` that is STABLE across
+ *   versions; in the engine wiring the templateId is the notebook id.
+ * - Each distinct cell set is an immutable `(templateId, version)` record
+ *   with a 1-based monotonically increasing integer version. A new version
+ *   is appended whenever the canonical cells hash changes; no record is
+ *   ever mutated in place.
+ * - An instance pins `(templateId, templateVersion)` at creation and never
+ *   changes it. Instance status is DERIVED from its append-only execution
+ *   records via `deriveInstanceStatus` — it is never stored mutably.
+ * - Cell executions are append-only rows keyed by `(instanceId, seq)`;
+ *   re-executing a cell appends a new record with a fresh seq. There is no
+ *   update operation anywhere in the storage contract — that absence is the
+ *   structural append-only guarantee, enforced again at the database layer
+ *   by revoked UPDATE/DELETE grants (migration 20260612120000).
+ */
+
+import {
+  verifyAttachedContract,
+  type AttachedContract,
+  type ExpectationRecord,
+  type ExpectationResult,
+} from "../contracts.js";
+import { hashJson } from "../../peer-notebook/manifest.js";
+import type { Notebook } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Template (versioned like code — spec §5)
+// ---------------------------------------------------------------------------
+
+/**
+ * Snapshot of one executable cell as authored, including the compiled
+ * tier-1 contract (with its hash) so contracts survive persistence and can
+ * be re-verified after load (closes B4a's "contracts don't survive export"
+ * gap at the durable-template layer; .src.md encoding remains out of scope).
+ */
+export interface RunbookTemplateCell {
+  cellId: string;
+  cellType: "code" | "package.json";
+  filename: string;
+  source: string;
+  /** Compiled tier-1 outcome contract (zod → canonicalize → sha256). */
+  contract?: AttachedContract;
+  /** Tier-2 marker: this cell validates the named cell's structured output. */
+  validatorFor?: string;
+  /** Authoring-time validator snapshot hash (Ulysses pattern). */
+  validatorSnapshotHash?: string;
+}
+
+export interface RunbookTemplate {
+  /** Stable across versions (the notebook id in the engine wiring). */
+  templateId: string;
+  /** 1-based, monotonically increasing. New version = new immutable record. */
+  version: number;
+  cells: RunbookTemplateCell[];
+  /** sha256 over the canonicalized cells — version-dedup key. */
+  cellsHash: string;
+  createdBy: string;
+  createdAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Instance (append-only execution record — spec §5, claim c3)
+// ---------------------------------------------------------------------------
+
+export interface RunbookInstance {
+  instanceId: string;
+  templateId: string;
+  /** Pinned at creation; never changes. */
+  templateVersion: number;
+  createdBy: string;
+  createdAt: string;
+}
+
+export type CellExecutionStatus = "completed" | "failed" | "skipped";
+
+export interface CellExecutionRecord {
+  instanceId: string;
+  /** 1-based append sequence within the instance; unique, never reused. */
+  seq: number;
+  cellId: string;
+  startedAt: string;
+  /** Hub agentId (or "local") of the executing agent. */
+  agentId: string;
+  /** sha256 over the canonicalized run inputs. */
+  inputsDigest: string;
+  /** Artifact reference for the cell-results evidence, when persisted. */
+  outputsRef?: string;
+  status: CellExecutionStatus;
+  /** Per-expectation results (tier, expected, actual-or-error) for this cell. */
+  expectations: ExpectationRecord[];
+}
+
+export type RunbookInstanceStatus = "created" | "in_progress" | "completed" | "failed";
+
+// ---------------------------------------------------------------------------
+// Fitness ledger (spec §7, claim c7)
+// ---------------------------------------------------------------------------
+
+/**
+ * One machine-checked expectation evaluation. Rows are written only when a
+ * contracted cell's expectation evaluates (tier 1 declarative or tier 2
+ * validator — both machine-checked; tier provenance is carried). `error`
+ * and `skipped` evaluations are recorded with their state but are excluded
+ * from pass-rate aggregates.
+ */
+export interface FitnessLedgerRow {
+  templateId: string;
+  templateVersion: number;
+  instanceId: string;
+  cellId: string;
+  tier: 1 | 2;
+  result: ExpectationResult;
+  /** True iff result is "pass" — fail/error/skipped are never pass. */
+  pass: boolean;
+  expected: unknown;
+  actual?: unknown;
+  /** Populated when result is "error" or "skipped". */
+  error?: string;
+  agentId: string;
+  ts: string;
+}
+
+export interface FitnessAggregate {
+  templateId: string;
+  templateVersion: number;
+  /** Distinct instances that produced machine-checked ledger rows. */
+  instances: number;
+  /** Rows that reached a verdict (pass or fail). */
+  evaluated: number;
+  passed: number;
+  /** passed / evaluated; null when nothing was evaluated. */
+  passRate: number | null;
+  errorRows: number;
+  /** errorRows / total rows; 0 when the ledger is empty. */
+  errorRate: number;
+  distinctAgents: number;
+}
+
+// ---------------------------------------------------------------------------
+// Storage contract — implemented by SupabaseRunbookStorage (deployed) and
+// InMemoryRunbookStorage (tests/local). A FileSystemRunbookStorage is
+// deliberately deferred until H1/H2 pass (spec §11.5: contract-suite-first,
+// Supabase-first, FS gated on evidence).
+// ---------------------------------------------------------------------------
+
+export interface RunbookStorage {
+  /**
+   * Persist an immutable template version. Re-saving an existing
+   * (templateId, version) throws — versions are append-only.
+   */
+  saveTemplate(template: RunbookTemplate): Promise<void>;
+  getTemplate(templateId: string, version: number): Promise<RunbookTemplate | null>;
+  getLatestTemplate(templateId: string): Promise<RunbookTemplate | null>;
+  listTemplateVersions(templateId: string): Promise<number[]>;
+
+  /** Create an instance pinning (templateId, templateVersion). Duplicate ids throw. */
+  createInstance(instance: RunbookInstance): Promise<void>;
+  getInstance(instanceId: string): Promise<RunbookInstance | null>;
+  listInstances(templateId: string): Promise<RunbookInstance[]>;
+
+  /**
+   * Append one cell execution record. A duplicate (instanceId, seq) throws —
+   * nothing ever mutates a prior record; re-execution appends a fresh seq.
+   */
+  appendCellExecution(record: CellExecutionRecord): Promise<void>;
+  /** All execution records for an instance, ordered by seq ascending. */
+  listCellExecutions(instanceId: string): Promise<CellExecutionRecord[]>;
+
+  appendFitnessRows(rows: FitnessLedgerRow[]): Promise<void>;
+  listFitnessRows(
+    templateId: string,
+    templateVersion?: number,
+  ): Promise<FitnessLedgerRow[]>;
+  /** Aggregate per template version (spec §7: n instances, pass rate, error rate, distinct agents). */
+  getFitnessAggregate(
+    templateId: string,
+    templateVersion: number,
+  ): Promise<FitnessAggregate>;
+}
+
+// ---------------------------------------------------------------------------
+// Pure domain helpers (shared by both backends and the engine runtime)
+// ---------------------------------------------------------------------------
+
+/** Canonical content hash of a template's cells (version-dedup key). */
+export function hashTemplateCells(cells: RunbookTemplateCell[]): string {
+  return hashJson(cells);
+}
+
+/** Snapshot a live notebook's executable cells for durable template versioning. */
+export function templateCellsFromNotebook(
+  notebook: Pick<Notebook, "cells">,
+): RunbookTemplateCell[] {
+  const cells: RunbookTemplateCell[] = [];
+  for (const cell of notebook.cells) {
+    if (cell.type !== "code" && cell.type !== "package.json") continue;
+    cells.push({
+      cellId: cell.id,
+      cellType: cell.type,
+      filename: cell.filename,
+      source: cell.source,
+      ...(cell.type === "code" && cell.contract !== undefined
+        ? { contract: cell.contract }
+        : {}),
+      ...(cell.type === "code" && cell.validatorFor !== undefined
+        ? { validatorFor: cell.validatorFor }
+        : {}),
+      ...(cell.type === "code" && cell.validatorSnapshotHash !== undefined
+        ? { validatorSnapshotHash: cell.validatorSnapshotHash }
+        : {}),
+    });
+  }
+  return cells;
+}
+
+/**
+ * Re-verify every attached contract hash on a template loaded from storage
+ * (Ulysses pattern at the durable layer). Throws ContractHashMismatchError
+ * on tampering.
+ */
+export function verifyTemplateContracts(template: RunbookTemplate): void {
+  for (const cell of template.cells) {
+    if (cell.contract !== undefined) {
+      verifyAttachedContract(cell.cellId, cell.contract);
+    }
+  }
+}
+
+/**
+ * Derive an instance's status from its append-only execution records —
+ * the latest record per cell wins (decided design: derived, never stored).
+ */
+export function deriveInstanceStatus(
+  template: RunbookTemplate,
+  executions: CellExecutionRecord[],
+): RunbookInstanceStatus {
+  if (executions.length === 0) return "created";
+  const latestByCell = new Map<string, CellExecutionRecord>();
+  for (const record of [...executions].sort((a, b) => a.seq - b.seq)) {
+    latestByCell.set(record.cellId, record);
+  }
+  for (const record of latestByCell.values()) {
+    if (record.status === "failed") return "failed";
+  }
+  const allCompleted = template.cells.every(
+    (cell) => latestByCell.get(cell.cellId)?.status === "completed",
+  );
+  return allCompleted ? "completed" : "in_progress";
+}
+
+/**
+ * Compute the fitness aggregate from ledger rows (spec §7). Pass rate counts
+ * only rows that reached a verdict; error/skipped rows are carried in the
+ * ledger but never contribute to pass-rates.
+ */
+export function aggregateFitness(
+  templateId: string,
+  templateVersion: number,
+  rows: FitnessLedgerRow[],
+): FitnessAggregate {
+  const instances = new Set<string>();
+  const agents = new Set<string>();
+  let evaluated = 0;
+  let passed = 0;
+  let errorRows = 0;
+  for (const row of rows) {
+    instances.add(row.instanceId);
+    agents.add(row.agentId);
+    if (row.result === "pass" || row.result === "fail") {
+      evaluated += 1;
+      if (row.pass) passed += 1;
+    } else if (row.result === "error") {
+      errorRows += 1;
+    }
+  }
+  return {
+    templateId,
+    templateVersion,
+    instances: instances.size,
+    evaluated,
+    passed,
+    passRate: evaluated === 0 ? null : passed / evaluated,
+    errorRows,
+    errorRate: rows.length === 0 ? 0 : errorRows / rows.length,
+    distinctAgents: agents.size,
+  };
+}

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -6,6 +6,7 @@ import type { HubEvent } from "./hub/hub-handler.js";
 import { createHubToolHandler } from "./hub/hub-tool-handler.js";
 import { SessionIdentityRegistry } from "./hub/session-identity.js";
 import type { ClaimStorage } from "./claims/types.js";
+import type { RunbookStorage } from "./notebook/runbook/types.js";
 import { createClaimsToolHandler } from "./claims/claims-tool-handler.js";
 import {
   createThoughtStoreAdapter,
@@ -167,6 +168,14 @@ export interface CreateMcpServerArgs {
    * tb.claims requires hubStorage to be wired as well.
    */
   claimStorage?: ClaimStorage;
+  /**
+   * Durable runbook storage (SPEC-AGX-SUBSTRATE B4b). Like claimStorage,
+   * must be shared across MCP sessions (tenant-scoped SupabaseRunbookStorage
+   * when hosted; a single in-memory instance locally). Without it the
+   * notebook engine falls back to a per-handler InMemoryRunbookStorage, so
+   * templates/instances/executions/ledger rows are lost with the process.
+   */
+  runbookStorage?: RunbookStorage;
   /** Data directory for task store (filesystem persistence) */
   dataDir?: string;
   /** Optional pre-created knowledge storage (used by Supabase mode) */
@@ -345,7 +354,10 @@ Use \`console.log()\` for debugging — output captured in response logs.`;
   }, sessionId);
   thoughtHandler.setEventEmitter(eventEmitter);
 
-  const notebookHandler = new NotebookHandler();
+  const notebookHandler = new NotebookHandler(
+    undefined,
+    args.runbookStorage ? { runbookStorage: args.runbookStorage } : {},
+  );
   let resolvedWorkspaceId = args.workspaceId || process.env.THOUGHTBOX_PROJECT || "default";
   const durablePeerWorkspaceId = resolvedWorkspaceId === "default" ? undefined : resolvedWorkspaceId;
   const peerNotebookRepository =

--- a/supabase/migrations/20260612120000_add_runbook_tables.sql
+++ b/supabase/migrations/20260612120000_add_runbook_tables.sql
@@ -1,0 +1,184 @@
+-- Durable runbook tables (SPEC-AGX-SUBSTRATE unit B4b — claim c3 instance
+-- half + claim c7 fitness ledger).
+--
+-- Copies the proven hub-table pattern (20260611000000) and the claim-graph
+-- shape: tenant_workspace_id FK on every table (tenant isolation from day
+-- one), service_role full-access policies (server enforces tenant scope in
+-- queries), and workspace-membership SELECT policies for authenticated
+-- (future Realtime/web anon-key access).
+--
+-- Version note: open PRs carry 20260612000000 (claim graph) and
+-- 20260612090000 on other branches; this file is deliberately
+-- 20260612120000 (strictly greater) so merge order cannot collide.
+--
+-- Append-only model (spec §5: "Re-running a cell appends; nothing mutates"):
+--   * runbook_templates       — immutable (template_id, version) records;
+--                               a new cell set is a new version row.
+--   * runbook_instances       — pin (template_id, template_version) at
+--                               creation; status is DERIVED from execution
+--                               records, never stored.
+--   * runbook_cell_executions — append-only rows keyed (instance_id, seq).
+--   * runbook_fitness_ledger  — append-only hypothesis-vs-actual rows (§7).
+-- Enforcement: UPDATE and DELETE are REVOKED from anon/authenticated/
+-- service_role on all four tables (privilege checks bind even roles that
+-- bypass RLS, unlike RLS policies). Workspace-cascade cleanup still works
+-- because referential cascade actions run with the table owner's rights.
+--
+-- Idempotent: IF NOT EXISTS guards on tables and indexes; policies are
+-- dropped before creation so double-apply is safe (REVOKE is idempotent).
+
+CREATE TABLE IF NOT EXISTS public.runbook_templates (
+  template_id text NOT NULL,
+  version integer NOT NULL CHECK (version >= 1),
+  tenant_workspace_id uuid NOT NULL REFERENCES public.workspaces(id) ON DELETE CASCADE,
+  -- Executable cell snapshots incl. compiled outcome contract + contractHash
+  -- so contracts survive persistence and are hash re-verified on load.
+  cells jsonb NOT NULL,
+  cells_hash text NOT NULL,
+  created_by text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (template_id, version)
+);
+
+CREATE TABLE IF NOT EXISTS public.runbook_instances (
+  id text PRIMARY KEY,
+  template_id text NOT NULL,
+  template_version integer NOT NULL,
+  tenant_workspace_id uuid NOT NULL REFERENCES public.workspaces(id) ON DELETE CASCADE,
+  created_by text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  FOREIGN KEY (template_id, template_version)
+    REFERENCES public.runbook_templates(template_id, version) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS public.runbook_cell_executions (
+  instance_id text NOT NULL REFERENCES public.runbook_instances(id) ON DELETE CASCADE,
+  seq integer NOT NULL CHECK (seq >= 1),
+  cell_id text NOT NULL,
+  tenant_workspace_id uuid NOT NULL REFERENCES public.workspaces(id) ON DELETE CASCADE,
+  started_at timestamptz NOT NULL,
+  agent_id text NOT NULL,
+  inputs_digest text NOT NULL,
+  outputs_ref text,
+  status text NOT NULL CHECK (status IN ('completed', 'failed', 'skipped')),
+  -- Per-expectation records: (cellId, tier, expectation, result,
+  -- expected, actual-or-error) — the §5.1 record model, persisted verbatim.
+  expectations jsonb NOT NULL DEFAULT '[]',
+  recorded_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (instance_id, seq)
+);
+
+CREATE TABLE IF NOT EXISTS public.runbook_fitness_ledger (
+  id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  template_id text NOT NULL,
+  template_version integer NOT NULL,
+  instance_id text NOT NULL REFERENCES public.runbook_instances(id) ON DELETE CASCADE,
+  cell_id text NOT NULL,
+  tenant_workspace_id uuid NOT NULL REFERENCES public.workspaces(id) ON DELETE CASCADE,
+  tier integer NOT NULL CHECK (tier IN (1, 2)),
+  result text NOT NULL CHECK (result IN ('pass', 'fail', 'error', 'skipped')),
+  -- Only an evaluated-true expectation is ever a pass (§5.1 result semantics).
+  pass boolean NOT NULL,
+  expected jsonb NOT NULL,
+  actual jsonb,
+  error text,
+  agent_id text NOT NULL,
+  ts timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT runbook_fitness_pass_consistent CHECK (pass = (result = 'pass'))
+);
+
+-- ---------------------------------------------------------------------------
+-- Indexes
+-- ---------------------------------------------------------------------------
+
+CREATE INDEX IF NOT EXISTS idx_runbook_templates_tenant
+  ON public.runbook_templates(tenant_workspace_id);
+CREATE INDEX IF NOT EXISTS idx_runbook_instances_tenant
+  ON public.runbook_instances(tenant_workspace_id);
+CREATE INDEX IF NOT EXISTS idx_runbook_instances_template
+  ON public.runbook_instances(template_id, template_version);
+CREATE INDEX IF NOT EXISTS idx_runbook_cell_executions_tenant
+  ON public.runbook_cell_executions(tenant_workspace_id);
+CREATE INDEX IF NOT EXISTS idx_runbook_fitness_ledger_tenant
+  ON public.runbook_fitness_ledger(tenant_workspace_id);
+-- Fitness aggregates are keyed per template version (§7).
+CREATE INDEX IF NOT EXISTS idx_runbook_fitness_ledger_template
+  ON public.runbook_fitness_ledger(template_id, template_version);
+
+-- ---------------------------------------------------------------------------
+-- Append-only enforcement: revoke UPDATE/DELETE/TRUNCATE from every API role.
+-- Grants bind even bypassrls roles; cascade cleanup from workspaces still
+-- works (RI actions execute with the table owner's privileges).
+-- ---------------------------------------------------------------------------
+
+REVOKE UPDATE, DELETE, TRUNCATE ON public.runbook_templates
+  FROM anon, authenticated, service_role;
+REVOKE UPDATE, DELETE, TRUNCATE ON public.runbook_instances
+  FROM anon, authenticated, service_role;
+REVOKE UPDATE, DELETE, TRUNCATE ON public.runbook_cell_executions
+  FROM anon, authenticated, service_role;
+REVOKE UPDATE, DELETE, TRUNCATE ON public.runbook_fitness_ledger
+  FROM anon, authenticated, service_role;
+
+-- ---------------------------------------------------------------------------
+-- RLS — server uses service_role (bypasses RLS; tenant scope enforced in
+-- queries); workspace-membership SELECT policies exist for future
+-- Realtime/web anon-key access, matching the hub/claims pattern.
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE public.runbook_templates ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.runbook_instances ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.runbook_cell_executions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.runbook_fitness_ledger ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "service_role_full_access_runbook_templates" ON public.runbook_templates;
+CREATE POLICY "service_role_full_access_runbook_templates" ON public.runbook_templates
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+DROP POLICY IF EXISTS "workspace_member_read_runbook_templates" ON public.runbook_templates;
+CREATE POLICY "workspace_member_read_runbook_templates" ON public.runbook_templates
+  FOR SELECT TO authenticated
+  USING (
+    tenant_workspace_id IN (
+      SELECT workspace_id FROM public.workspace_memberships
+      WHERE user_id = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS "service_role_full_access_runbook_instances" ON public.runbook_instances;
+CREATE POLICY "service_role_full_access_runbook_instances" ON public.runbook_instances
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+DROP POLICY IF EXISTS "workspace_member_read_runbook_instances" ON public.runbook_instances;
+CREATE POLICY "workspace_member_read_runbook_instances" ON public.runbook_instances
+  FOR SELECT TO authenticated
+  USING (
+    tenant_workspace_id IN (
+      SELECT workspace_id FROM public.workspace_memberships
+      WHERE user_id = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS "service_role_full_access_runbook_cell_executions" ON public.runbook_cell_executions;
+CREATE POLICY "service_role_full_access_runbook_cell_executions" ON public.runbook_cell_executions
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+DROP POLICY IF EXISTS "workspace_member_read_runbook_cell_executions" ON public.runbook_cell_executions;
+CREATE POLICY "workspace_member_read_runbook_cell_executions" ON public.runbook_cell_executions
+  FOR SELECT TO authenticated
+  USING (
+    tenant_workspace_id IN (
+      SELECT workspace_id FROM public.workspace_memberships
+      WHERE user_id = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS "service_role_full_access_runbook_fitness_ledger" ON public.runbook_fitness_ledger;
+CREATE POLICY "service_role_full_access_runbook_fitness_ledger" ON public.runbook_fitness_ledger
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+DROP POLICY IF EXISTS "workspace_member_read_runbook_fitness_ledger" ON public.runbook_fitness_ledger;
+CREATE POLICY "workspace_member_read_runbook_fitness_ledger" ON public.runbook_fitness_ledger
+  FOR SELECT TO authenticated
+  USING (
+    tenant_workspace_id IN (
+      SELECT workspace_id FROM public.workspace_memberships
+      WHERE user_id = auth.uid()
+    )
+  );

--- a/supabase/migrations/20260612130000_add_runbook_fitness_pinning_fk.sql
+++ b/supabase/migrations/20260612130000_add_runbook_fitness_pinning_fk.sql
@@ -1,0 +1,49 @@
+-- Enforce that runbook_fitness_ledger's denormalized (template_id,
+-- template_version) columns match the owning instance's template pinning
+-- (Greptile review of PR #401, P1: the aggregate key §7 had no DB-level
+-- enforcement — a buggy write path or direct insert could store mismatched
+-- values and silently poison getFitnessAggregate results).
+--
+-- A direct composite FK to runbook_templates(template_id, version) would
+-- only prove the referenced template version EXISTS; it would not prevent a
+-- ledger row from carrying a different (existing) version than its instance
+-- pins. The stronger constraint references the instance row itself on
+-- (id, template_id, template_version): the match is enforced directly, and
+-- template existence follows transitively through runbook_instances' own
+-- composite FK to runbook_templates.
+--
+-- This is a NEW migration (not an edit of 20260612120000, which may already
+-- be applied). Version note: strictly greater than 20260612120000 and the
+-- open-PR versions 20260612000000 / 20260612090000 on the claims branches.
+--
+-- Idempotent: both constraint additions are guarded by pg_constraint
+-- lookups, so double-apply is safe. DDL runs as the table owner, so the
+-- revoked UPDATE/DELETE grants on the runbook tables do not interfere, and
+-- FK cascade actions keep executing with owner rights.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'runbook_instances_id_template_version_key'
+      AND conrelid = 'public.runbook_instances'::regclass
+  ) THEN
+    -- Superkey of the primary key (id); exists only as the FK target below.
+    ALTER TABLE public.runbook_instances
+      ADD CONSTRAINT runbook_instances_id_template_version_key
+      UNIQUE (id, template_id, template_version);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'runbook_fitness_ledger_instance_pinning_fkey'
+      AND conrelid = 'public.runbook_fitness_ledger'::regclass
+  ) THEN
+    ALTER TABLE public.runbook_fitness_ledger
+      ADD CONSTRAINT runbook_fitness_ledger_instance_pinning_fkey
+      FOREIGN KEY (instance_id, template_id, template_version)
+      REFERENCES public.runbook_instances(id, template_id, template_version)
+      ON DELETE CASCADE;
+  END IF;
+END
+$$;

--- a/supabase/migrations/20260613020000_runbook_tenant_scoped_instance_fks.sql
+++ b/supabase/migrations/20260613020000_runbook_tenant_scoped_instance_fks.sql
@@ -1,0 +1,88 @@
+-- Tenant-scope the runbook child→instance foreign keys (Greptile review of
+-- PR #401, P1: cross-tenant FK attachment).
+--
+-- runbook_cell_executions and runbook_fitness_ledger reference their owning
+-- instance on instance_id alone, while tenant_workspace_id is accepted
+-- independently. A service-role write (or a buggy write path) can therefore
+-- attach a child row carrying workspace B's tenant_workspace_id to an
+-- instance owned by workspace A: the single-column FK only proves the
+-- instance exists globally, so the row is readable under B's RLS yet points
+-- at A's instance. Tenant isolation must be enforced structurally, not left
+-- to the write path.
+--
+-- Fix: make tenant_workspace_id part of the referenced instance key and each
+-- child instance FK, so a child row can only attach to an instance in the
+-- same tenant. Mirrors the (id, template_id, template_version) pinning FK
+-- added in 20260612130000; that template-pinning FK is left intact (it
+-- enforces a different invariant).
+--
+-- This is a NEW migration (not an edit of 20260612120000, which may already
+-- be applied), following the same convention as 20260612130000. Version
+-- note: strictly greater than 20260612130000 and the merged claims-branch
+-- versions (…612090000 / …613000000 / …613010000).
+--
+-- Idempotent: the unique-key add and each FK swap are guarded by
+-- pg_constraint lookups, so double-apply is safe. DDL runs as the table
+-- owner, so the revoked UPDATE/DELETE grants on the runbook tables do not
+-- interfere, and FK cascade actions keep executing with owner rights.
+
+DO $$
+BEGIN
+  -- Referenceable superkey of the primary key (id), scoped by tenant; exists
+  -- only as the FK target for the tenant-composite child FKs below.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'runbook_instances_id_tenant_key'
+      AND conrelid = 'public.runbook_instances'::regclass
+  ) THEN
+    ALTER TABLE public.runbook_instances
+      ADD CONSTRAINT runbook_instances_id_tenant_key
+      UNIQUE (id, tenant_workspace_id);
+  END IF;
+
+  -- runbook_cell_executions: replace the instance-only FK with a
+  -- tenant-composite one.
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'runbook_cell_executions_instance_id_fkey'
+      AND conrelid = 'public.runbook_cell_executions'::regclass
+  ) THEN
+    ALTER TABLE public.runbook_cell_executions
+      DROP CONSTRAINT runbook_cell_executions_instance_id_fkey;
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'runbook_cell_executions_instance_tenant_fkey'
+      AND conrelid = 'public.runbook_cell_executions'::regclass
+  ) THEN
+    ALTER TABLE public.runbook_cell_executions
+      ADD CONSTRAINT runbook_cell_executions_instance_tenant_fkey
+      FOREIGN KEY (instance_id, tenant_workspace_id)
+      REFERENCES public.runbook_instances(id, tenant_workspace_id)
+      ON DELETE CASCADE;
+  END IF;
+
+  -- runbook_fitness_ledger: replace the instance-only FK with a
+  -- tenant-composite one. The (id, template_id, template_version) pinning FK
+  -- from 20260612130000 stays.
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'runbook_fitness_ledger_instance_id_fkey'
+      AND conrelid = 'public.runbook_fitness_ledger'::regclass
+  ) THEN
+    ALTER TABLE public.runbook_fitness_ledger
+      DROP CONSTRAINT runbook_fitness_ledger_instance_id_fkey;
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'runbook_fitness_ledger_instance_tenant_fkey'
+      AND conrelid = 'public.runbook_fitness_ledger'::regclass
+  ) THEN
+    ALTER TABLE public.runbook_fitness_ledger
+      ADD CONSTRAINT runbook_fitness_ledger_instance_tenant_fkey
+      FOREIGN KEY (instance_id, tenant_workspace_id)
+      REFERENCES public.runbook_instances(id, tenant_workspace_id)
+      ON DELETE CASCADE;
+  END IF;
+END
+$$;

--- a/supabase/migrations/20260613030000_runbook_templates_tenant_scoped_key.sql
+++ b/supabase/migrations/20260613030000_runbook_templates_tenant_scoped_key.sql
@@ -1,0 +1,68 @@
+-- Tenant-scope the runbook_templates key and the instance→template FK
+-- (Greptile review of PR #401, P1: template keys not tenant-scoped).
+--
+-- runbook_templates' PRIMARY KEY is (template_id, version) — global. The
+-- runtime sets template_id to the notebook id, so two tenants using the same
+-- notebook id collide: the second tenant's saveTemplate hits the global PK
+-- (surfaced as a spurious TemplateVersionConflictError) even though its own
+-- tenant-scoped view holds no such template. Worse, runbook_instances'
+-- template FK is (template_id, template_version) → templates(template_id,
+-- version), omitting tenant — so a tenant's instance can satisfy its FK from
+-- ANOTHER tenant's immutable template row and pin to a workspace it cannot
+-- read.
+--
+-- Fix: put tenant_workspace_id into the template key and the referencing FK,
+-- so templates and the instances that pin them are isolated per tenant.
+-- Same family as the child-FK scoping in 20260613020000.
+--
+-- This is a NEW migration (not an edit of the already-applied 20260612120000),
+-- following the 20260612130000 / 20260613020000 convention. Version note:
+-- strictly greater than 20260613020000.
+--
+-- Idempotent: the PK swap is gated on the old (template_id, version) shape and
+-- the FK swap on constraint-name lookups, so double-apply is safe. DDL runs as
+-- the table owner, so the revoked UPDATE/DELETE grants on the runbook tables
+-- do not interfere, and FK cascade actions keep executing with owner rights.
+
+DO $$
+BEGIN
+  -- Drop the instance→template FK first: it depends on the (template_id,
+  -- version) PK as its unique target, so the PK cannot be dropped while it
+  -- exists.
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'runbook_instances_template_id_template_version_fkey'
+      AND conrelid = 'public.runbook_instances'::regclass
+  ) THEN
+    ALTER TABLE public.runbook_instances
+      DROP CONSTRAINT runbook_instances_template_id_template_version_fkey;
+  END IF;
+
+  -- Swap the template PK to include tenant_workspace_id. Gated on the old
+  -- two-column shape so a re-run (PK already tenant-scoped) is a no-op.
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'public.runbook_templates'::regclass
+      AND contype = 'p'
+      AND pg_get_constraintdef(oid) = 'PRIMARY KEY (template_id, version)'
+  ) THEN
+    ALTER TABLE public.runbook_templates DROP CONSTRAINT runbook_templates_pkey;
+    ALTER TABLE public.runbook_templates
+      ADD CONSTRAINT runbook_templates_pkey
+      PRIMARY KEY (tenant_workspace_id, template_id, version);
+  END IF;
+
+  -- Re-add the instance→template FK, now tenant-composite.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'runbook_instances_template_tenant_fkey'
+      AND conrelid = 'public.runbook_instances'::regclass
+  ) THEN
+    ALTER TABLE public.runbook_instances
+      ADD CONSTRAINT runbook_instances_template_tenant_fkey
+      FOREIGN KEY (tenant_workspace_id, template_id, template_version)
+      REFERENCES public.runbook_templates(tenant_workspace_id, template_id, version)
+      ON DELETE CASCADE;
+  END IF;
+END
+$$;


### PR DESCRIPTION
Implements **SPEC-AGX-SUBSTRATE:c3 (instance half) + c7** — unit B4b. Stacked on #399 (outcome contracts + honest verdicts); auto-retargets to `main` when #399 merges.

## What

**Template model** (`src/notebook/runbook/types.ts`)
- A runbook template is versioned like code: immutable `(templateId, version)` records persisting cells (incl. compiled outcome contract + contractHash), createdBy, createdAt. Identity scheme: `templateId` is stable across versions (the notebook id in the engine wiring); a changed cells-hash appends a new 1-based monotonic version. No in-place mutation — re-saving an existing version throws.

**Instance model (append-only)**
- An instance pins `(templateId, templateVersion)` at creation (instanceId = runId). Cell executions append records `(instanceId, cellId, seq, startedAt, agentId, inputsDigest, outputsRef, per-expectation results incl. tier/expected/actual-or-error, status)`. Re-execution appends a fresh seq; duplicate `(instanceId, seq)` throws. Instance status is **derived** from the records via `deriveInstanceStatus` (latest record per cell wins) — never stored mutably.

**Fitness ledger (§7)**
- Rows keyed `(template id, template version, instance id, cell id)` with tier, result, pass, expected, actual-or-error, agentId, ts — written for every machine-checked expectation evaluation (tier 1 declarative + tier 2 validator, provenance carried). `error`/`skipped` rows are recorded with their state but excluded from pass-rates. Aggregate query per template version: n instances, evaluated/passed, pass rate, error rate, distinct agents (`aggregateFitness`, shared by both backends).

**Persistence**
- `RunbookStorage` interface + `SupabaseRunbookStorage` + `InMemoryRunbookStorage` behind a shared contract suite (the hub/claims pattern). FS backend explicitly deferred per §11.5.
- **Migration `20260612120000_add_runbook_tables.sql`** — version-collision check done: strictly greater than open-PR versions `20260612000000` and `20260612090000`, so merge order cannot collide. Tables: `runbook_templates`, `runbook_instances`, `runbook_cell_executions`, `runbook_fitness_ledger`, each with `tenant_workspace_id` + workspace-membership RLS per the hub pattern. Append-only is enforced at the database by **revoking UPDATE/DELETE/TRUNCATE from anon/authenticated/service_role** (grants bind even bypassrls roles, unlike RLS; workspace cascade cleanup still works because RI actions run with owner rights). Applied to the **local stack only**.

**Runtime wiring**
- `InMemoryNotebookEngineRuntime` gains a storage port (default `InMemoryRunbookStorage` — existing tests unchanged). Each runbook run persists template version → instance → execution records → ledger rows; verdict + per-expectation records flow from `buildRunbookVerdict` without re-evaluation. A durable-persistence failure transitions the run to `FailedRun`.
- Contracts survive the persistence round-trip: `NotebookHandler` feeds the runtime a template-cell snapshot incl. compiled contracts; `verifyTemplateContracts` hash re-verifies on load (closes B4a's "contracts don't survive export" gap at the durable-template layer; `.src.md` encoding not in scope).

**Not in scope**: advancer (B8), await cells (B6), ordering/halt-rule changes (B5), claims integration.

## Tests

- `vitest src/notebook` — 77 passed (5 files), incl. all pre-existing engine/contract/validator suites.
- New contract suite (`runbook-storage.test.ts`, 15 tests) ran against **both** backends — Supabase tests executed for real against the running local stack (no skips), incl. DB-level append-only denial via raw service-role client and tenant isolation.
- Round-trip (`runbook-durability.test.ts`, 4 tests): create template v1 → instance → execute cells → restart storage (new class instance) → load instance → records intact, contract hash verifies, ledger aggregates correct — on InMemory (shared state) and Supabase. Plus template re-versioning on cell change and run-fails-when-storage-fails.
- `pnpm check:types`, `pnpm check:lint` clean. Adjacent suites (peer-notebook, code-mode execute-tool, e2e-workflow) green.

## Spec

§8 already records B4b; no §5.1 amendment was required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)