### PR TITLE
feat(notebook): ordered execution and expected-failure halt rules

### DIFF
--- a/.specs/agx/SPEC-AGX-SUBSTRATE.md
+++ b/.specs/agx/SPEC-AGX-SUBSTRATE.md
@@ -235,7 +235,11 @@ verify ledger" manually from prose JSON, leaving no durable record. As a runbook
 
 1. **Per-cell contracts, document verdict derived.** An exec/code cell may declare an outcome
    contract. The document verdict passes iff every declared expectation was evaluated and
-   passed (a procedurally failed cell still fails the run). A runbook with zero declared
+   passed (an uncontracted procedurally failed cell still fails the run). Expected-failure
+   rule (adopted 2026-06-12, B5): a cell that exits nonzero but whose every declared
+   expectation passes is *expectation-satisfied* — a predicted failure that neither fails
+   nor halts the run; uncontracted failures and failed/errored expectations still halt
+   it. A runbook with zero declared
    contracts keeps its procedural verdict but carries `contractCoverage: 0` and a reason
    stating "procedural completion only — no outcome contracts declared", so fitness (B9)
    excludes contract-less runs from pass-rates.

--- a/src/code-mode/sdk-types.ts
+++ b/src/code-mode/sdk-types.ts
@@ -75,7 +75,8 @@ interface TB {
     load(args: { path?: string; content?: string }): Promise<unknown>;
     addCell(args: { notebookId: string; cellType: "title" | "markdown" | "code"; content: string; filename?: string; position?: number }): Promise<unknown>;
     updateCell(args: { notebookId: string; cellId: string; content: string }): Promise<unknown>;
-    runCell(args: { notebookId: string; cellId: string }): Promise<unknown>;
+    /** With instanceId, execution is instance-aware and ordered (only the next unsatisfied cell may run). */
+    runCell(args: { notebookId: string; cellId: string; instanceId?: string }): Promise<unknown>;
     listCells(args: { notebookId: string }): Promise<unknown>;
     getCell(args: { notebookId: string; cellId: string }): Promise<unknown>;
     installDeps(args: { notebookId: string }): Promise<unknown>;

--- a/src/notebook/__tests__/ordered-execution.test.ts
+++ b/src/notebook/__tests__/ordered-execution.test.ts
@@ -1,0 +1,610 @@
+/**
+ * Ordered execution and expected-failure halt rules
+ * (SPEC-AGX-SUBSTRATE B5 — spec §5 "Ordering" + §5.1 expected-failure rule).
+ *
+ * Covers, against the real subprocess execution path:
+ * - expected-failure continue: a cell that exits nonzero but whose every
+ *   declared expectation passes is expectation-satisfied and the run
+ *   continues;
+ * - halt when a predicted failure's expectation fails, and (unchanged) when
+ *   an uncontracted cell fails;
+ * - out-of-order rejection on the instance-aware single-cell path: a typed
+ *   error names the expected next cell;
+ * - partial-run durability: records persist as each cell completes, so a
+ *   halted run leaves durable records for every cell that executed, the
+ *   instance exists from run start, and the derived status reflects the
+ *   halt. Runs against InMemoryRunbookStorage always and against
+ *   SupabaseRunbookStorage when the local stack is up.
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { randomUUID } from "node:crypto";
+import { NotebookHandler } from "../index.js";
+import {
+  InMemoryRunbookStorage,
+  createRunbookMemoryState,
+} from "../runbook/in-memory-runbook-storage.js";
+import { SupabaseRunbookStorage } from "../runbook/supabase-runbook-storage.js";
+import {
+  hashTemplateCells,
+  templateCellsFromNotebook,
+  type CellExecutionRecord,
+  type RunbookStorage,
+  type RunbookTemplate,
+  type RunbookTemplateCell,
+} from "../runbook/types.js";
+import {
+  OutOfOrderExecutionError,
+  assertCellExecutable,
+  deriveInstanceStatus,
+  isExecutionSatisfied,
+  nextUnsatisfiedCell,
+} from "../runbook/ordering.js";
+import type { ExpectationRecord } from "../contracts.js";
+import {
+  ensureTestWorkspace,
+  isSupabaseAvailable,
+  SUPABASE_TEST_URL,
+  SUPABASE_TEST_SERVICE_ROLE_KEY,
+  TEST_WORKSPACE_ID,
+} from "../../__tests__/supabase-test-helpers.js";
+
+// =============================================================================
+// Pure ordering/halt rules
+// =============================================================================
+
+function templateCell(cellId: string): RunbookTemplateCell {
+  return { cellId, cellType: "code", filename: `${cellId}.js`, source: "" };
+}
+
+const TEMPLATE: RunbookTemplate = {
+  templateId: "rbt-ordering",
+  version: 1,
+  cells: [templateCell("a"), templateCell("b"), templateCell("c")],
+  cellsHash: "sha256:test",
+  createdBy: "tester",
+  createdAt: "2026-06-12T00:00:00.000Z",
+};
+
+function expectation(cellId: string, result: ExpectationRecord["result"]): ExpectationRecord {
+  return {
+    cellId,
+    tier: 1,
+    expectation: "exitCode eq 1",
+    result,
+    expected: { source: { kind: "exitCode" }, op: "eq", value: 1 },
+  };
+}
+
+function execution(
+  cellId: string,
+  seq: number,
+  status: CellExecutionRecord["status"],
+  expectations: ExpectationRecord[] = [],
+): CellExecutionRecord {
+  return {
+    instanceId: "rbi-ordering",
+    seq,
+    cellId,
+    startedAt: "2026-06-12T00:00:00.000Z",
+    agentId: "tester",
+    inputsDigest: "sha256:inputs",
+    status,
+    expectations,
+  };
+}
+
+describe("B5 satisfaction rule (isExecutionSatisfied)", () => {
+  it("derives satisfaction from expectations when declared, else procedural status", () => {
+    expect(isExecutionSatisfied(execution("a", 1, "completed"))).toBe(true);
+    expect(isExecutionSatisfied(execution("a", 1, "failed"))).toBe(false);
+    expect(isExecutionSatisfied(execution("a", 1, "skipped"))).toBe(false);
+    // Expectation-satisfied predicted failure counts as satisfied.
+    expect(
+      isExecutionSatisfied(execution("a", 1, "failed", [expectation("a", "pass")])),
+    ).toBe(true);
+    expect(
+      isExecutionSatisfied(execution("a", 1, "failed", [expectation("a", "fail")])),
+    ).toBe(false);
+    // Declared expectations beat procedural completion in both directions.
+    expect(
+      isExecutionSatisfied(execution("a", 1, "completed", [expectation("a", "fail")])),
+    ).toBe(false);
+    expect(
+      isExecutionSatisfied(execution("a", 1, "completed", [expectation("a", "error")])),
+    ).toBe(false);
+    expect(
+      isExecutionSatisfied(
+        execution("a", 1, "completed", [expectation("a", "pass"), expectation("a", "fail")]),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("B5 ordering (nextUnsatisfiedCell / assertCellExecutable)", () => {
+  it("walks template order and tolerates re-execution appends", () => {
+    expect(nextUnsatisfiedCell(TEMPLATE, [])).toBe("a");
+    expect(nextUnsatisfiedCell(TEMPLATE, [execution("a", 1, "completed")])).toBe("b");
+    // A failed attempt keeps the cell next; a later re-execution supersedes it.
+    expect(
+      nextUnsatisfiedCell(TEMPLATE, [
+        execution("a", 1, "completed"),
+        execution("b", 2, "failed"),
+      ]),
+    ).toBe("b");
+    expect(
+      nextUnsatisfiedCell(TEMPLATE, [
+        execution("a", 1, "completed"),
+        execution("b", 2, "failed"),
+        execution("b", 3, "completed"),
+      ]),
+    ).toBe("c");
+    expect(
+      nextUnsatisfiedCell(TEMPLATE, [
+        execution("a", 1, "completed"),
+        execution("b", 2, "failed", [expectation("b", "pass")]),
+        execution("c", 3, "completed"),
+      ]),
+    ).toBeNull();
+  });
+
+  it("rejects out-of-order execution with a typed error naming the next cell", () => {
+    const executions = [execution("a", 1, "completed")];
+    expect(() => assertCellExecutable(TEMPLATE, executions, "b")).not.toThrow();
+    let caught: unknown;
+    try {
+      assertCellExecutable(TEMPLATE, executions, "c");
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(OutOfOrderExecutionError);
+    const typed = caught as OutOfOrderExecutionError;
+    expect(typed.name).toBe("OutOfOrderExecutionError");
+    expect(typed.attemptedCellId).toBe("c");
+    expect(typed.expectedNextCellId).toBe("b");
+    expect(typed.message).toContain("b");
+    // Re-running an earlier satisfied cell is also rejected while an
+    // unsatisfied cell exists.
+    expect(() => assertCellExecutable(TEMPLATE, executions, "a")).toThrow(
+      OutOfOrderExecutionError,
+    );
+    expect(() => assertCellExecutable(TEMPLATE, executions, "nope")).toThrow(
+      /not part of template/,
+    );
+    // A fully satisfied instance allows re-execution of any cell (appends).
+    const satisfied = [
+      execution("a", 1, "completed"),
+      execution("b", 2, "completed"),
+      execution("c", 3, "completed"),
+    ];
+    expect(() => assertCellExecutable(TEMPLATE, satisfied, "a")).not.toThrow();
+    expect(() => assertCellExecutable(TEMPLATE, satisfied, "c")).not.toThrow();
+  });
+
+  it("derives instance status with predicted failures counting as satisfied", () => {
+    const predicted = execution("b", 2, "failed", [expectation("b", "pass")]);
+    expect(
+      deriveInstanceStatus(TEMPLATE, [
+        execution("a", 1, "completed"),
+        predicted,
+        execution("c", 3, "completed"),
+      ]),
+    ).toBe("completed");
+    expect(
+      deriveInstanceStatus(TEMPLATE, [execution("a", 1, "completed"), predicted]),
+    ).toBe("in_progress");
+    expect(
+      deriveInstanceStatus(TEMPLATE, [
+        execution("a", 1, "completed"),
+        execution("b", 2, "failed", [expectation("b", "fail")]),
+      ]),
+    ).toBe("failed");
+    expect(
+      deriveInstanceStatus(TEMPLATE, [
+        execution("a", 1, "completed"),
+        execution("b", 2, "failed"),
+      ]),
+    ).toBe("failed");
+  });
+});
+
+// =============================================================================
+// Real execution — halt rules and partial-run durability
+// =============================================================================
+
+const EXIT_1_SOURCE = 'console.error("predicted failure"); process.exit(1);';
+
+const EXIT_CODE_CONTRACT = (value: number) => ({
+  schemaVersion: "outcome-contract.v0",
+  expectations: [{ source: { kind: "exitCode" }, op: "eq", value }],
+});
+
+async function newHandler(storage: RunbookStorage): Promise<NotebookHandler> {
+  const handler = new NotebookHandler(undefined, {
+    runbookStorage: storage,
+    agentId: "agent-b5",
+  });
+  await handler.init();
+  return handler;
+}
+
+async function createRunbook(handler: NotebookHandler, title: string): Promise<string> {
+  const created = await handler.handleCreateNotebook({ title, language: "javascript" });
+  return created.notebook.id as string;
+}
+
+describe("Expected-failure halt rule (B5, real execution)", () => {
+  it("continues past a predicted failure and passes the run", async () => {
+    const storage = new InMemoryRunbookStorage();
+    const handler = await newHandler(storage);
+    const notebookId = await createRunbook(handler, `Predicted failure ${randomUUID()}`);
+
+    const predicted = await handler.handleAddCell({
+      notebookId,
+      cellType: "code",
+      filename: "predicted.js",
+      content: EXIT_1_SOURCE,
+      contract: EXIT_CODE_CONTRACT(1),
+    });
+    const after = await handler.handleAddCell({
+      notebookId,
+      cellType: "code",
+      filename: "after.js",
+      content: 'console.log("after ran");',
+    });
+
+    const runResult = await handler.handleStartRun({ notebookId, mode: "runbook" });
+    expect(runResult.run.status).toBe("completed");
+    const verdict = runResult.run.outputs[0];
+    expect(verdict.pass).toBe(true);
+    const evidence = verdict.evidence as Array<Record<string, unknown>>;
+    const predictedCell = evidence.find((cell) => cell.filename === "predicted.js")!;
+    expect(predictedCell.status).toBe("failed");
+    expect(predictedCell.exitCode).toBe(1);
+    const records = predictedCell.expectations as ExpectationRecord[];
+    expect(records).toHaveLength(1);
+    expect(records[0]!.result).toBe("pass");
+    const afterCell = evidence.find((cell) => cell.filename === "after.js")!;
+    expect(afterCell.status).toBe("completed");
+
+    // Durable record: all three executed cells recorded, instance satisfied.
+    const executions = await storage.listCellExecutions(runResult.run.runId);
+    expect(executions.map((record) => record.seq)).toEqual([1, 2, 3]);
+    expect(
+      executions.map((record) => record.cellId).slice(1),
+    ).toEqual([predicted.cell.id, after.cell.id]);
+    const template = (await storage.getTemplate(notebookId, 1))!;
+    expect(deriveInstanceStatus(template, executions)).toBe("completed");
+    const rows = await storage.listFitnessRows(notebookId, 1);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ cellId: predicted.cell.id, result: "pass", pass: true });
+  }, 180_000);
+
+  it("halts when a predicted failure's expectation fails", async () => {
+    const storage = new InMemoryRunbookStorage();
+    const handler = await newHandler(storage);
+    const notebookId = await createRunbook(handler, `Wrong prediction ${randomUUID()}`);
+
+    await handler.handleAddCell({
+      notebookId,
+      cellType: "code",
+      filename: "wrong.js",
+      content: 'console.error("unexpected code"); process.exit(2);',
+      contract: EXIT_CODE_CONTRACT(1),
+    });
+    await handler.handleAddCell({
+      notebookId,
+      cellType: "code",
+      filename: "never.js",
+      content: 'console.log("should not run");',
+    });
+
+    const runResult = await handler.handleStartRun({ notebookId, mode: "runbook" });
+    expect(runResult.run.status).toBe("completed");
+    const verdict = runResult.run.outputs[0];
+    expect(verdict.pass).toBe(false);
+    const evidence = verdict.evidence as Array<Record<string, unknown>>;
+    const wrong = evidence.find((cell) => cell.filename === "wrong.js")!;
+    expect((wrong.expectations as ExpectationRecord[])[0]!.result).toBe("fail");
+    expect(evidence.find((cell) => cell.filename === "never.js")!.status).toBe("skipped");
+
+    // Only the executed cells (install + wrong.js) leave records; the halt
+    // is visible in the derived status.
+    const executions = await storage.listCellExecutions(runResult.run.runId);
+    expect(executions).toHaveLength(2);
+    const template = (await storage.getTemplate(notebookId, 1))!;
+    expect(deriveInstanceStatus(template, executions)).toBe("failed");
+  }, 180_000);
+});
+
+/**
+ * Shared partial-run scenario (B5 known-gap closure): 4 code cells, the
+ * uncontracted 2nd one fails → the run halts there, leaving durable records
+ * for exactly the cells that executed and ledger rows for every evaluated
+ * expectation (including the skipped 4th cell's).
+ */
+async function runPartialHaltScenario(storage: RunbookStorage): Promise<void> {
+  const handler = await newHandler(storage);
+  const notebookId = await createRunbook(handler, `Partial halt ${randomUUID()}`);
+
+  const c1 = await handler.handleAddCell({
+    notebookId,
+    cellType: "code",
+    filename: "c1.js",
+    content: 'console.log("c1 ran");',
+    contract: EXIT_CODE_CONTRACT(0),
+  });
+  const c2 = await handler.handleAddCell({
+    notebookId,
+    cellType: "code",
+    filename: "c2.js",
+    content: 'console.error("uncontracted boom"); process.exit(1);',
+  });
+  await handler.handleAddCell({
+    notebookId,
+    cellType: "code",
+    filename: "c3.js",
+    content: 'console.log("c3 never runs");',
+  });
+  const c4 = await handler.handleAddCell({
+    notebookId,
+    cellType: "code",
+    filename: "c4.js",
+    content: 'console.log("c4 never runs");',
+    contract: EXIT_CODE_CONTRACT(0),
+  });
+
+  const runResult = await handler.handleStartRun({ notebookId, mode: "runbook" });
+  expect(runResult.run.status).toBe("completed");
+  const verdict = runResult.run.outputs[0];
+  expect(verdict.pass).toBe(false);
+  expect(verdict.reason).toContain("c2.js");
+
+  // The instance exists and shows exactly the executed cells: the dependency
+  // install, c1, and the halting c2 — nothing for c3/c4.
+  const instance = await storage.getInstance(runResult.run.runId);
+  expect(instance).not.toBeNull();
+  const executions = await storage.listCellExecutions(runResult.run.runId);
+  expect(executions).toHaveLength(3);
+  expect(executions.map((record) => record.seq)).toEqual([1, 2, 3]);
+  expect(executions[1]!.cellId).toBe(c1.cell.id);
+  expect(executions[1]!.status).toBe("completed");
+  expect(executions[2]!.cellId).toBe(c2.cell.id);
+  expect(executions[2]!.status).toBe("failed");
+
+  const template = (await storage.getTemplate(notebookId, 1))!;
+  expect(deriveInstanceStatus(template, executions)).toBe("failed");
+
+  // Ledger rows exist for every evaluated expectation: c1's pass (written as
+  // the cell completed) and c4's skipped (written at run end).
+  const rows = await storage.listFitnessRows(notebookId, 1);
+  expect(rows).toHaveLength(2);
+  expect(rows.find((row) => row.cellId === c1.cell.id)).toMatchObject({
+    result: "pass",
+    pass: true,
+  });
+  expect(rows.find((row) => row.cellId === c4.cell.id)).toMatchObject({
+    result: "skipped",
+    pass: false,
+  });
+}
+
+describe("Partial-run durability (B5) — InMemory storage", () => {
+  it("a run halting at cell 2 of 4 leaves records for executed cells only", async () => {
+    await runPartialHaltScenario(new InMemoryRunbookStorage(createRunbookMemoryState()));
+  }, 180_000);
+
+  it("a storage outage on a later cell keeps earlier cells' records durable", async () => {
+    const storage = new InMemoryRunbookStorage(createRunbookMemoryState());
+    let appends = 0;
+    const append = storage.appendCellExecution.bind(storage);
+    storage.appendCellExecution = async (record) => {
+      appends += 1;
+      if (appends === 3) throw new Error("substrate offline");
+      return append(record);
+    };
+    const handler = await newHandler(storage);
+    const notebookId = await createRunbook(handler, `Outage ${randomUUID()}`);
+    await handler.handleAddCell({
+      notebookId,
+      cellType: "code",
+      filename: "c1.js",
+      content: 'console.log("c1 ran");',
+    });
+    await handler.handleAddCell({
+      notebookId,
+      cellType: "code",
+      filename: "c2.js",
+      content: 'console.log("c2 ran");',
+    });
+
+    await expect(handler.handleStartRun({ notebookId, mode: "runbook" })).rejects.toThrow();
+    const listed = await handler.handleListRuns({ notebookId });
+    expect(listed.runs).toHaveLength(1);
+    expect(listed.runs[0].status).toBe("failed");
+    expect(listed.runs[0].error).toContain("durable runbook persistence failed");
+    expect(listed.runs[0].error).toContain("substrate offline");
+
+    // The instance was created at run start and the first two appends
+    // (install + c1) survived the outage on the third.
+    const runId = listed.runs[0].runId as string;
+    expect(await storage.getInstance(runId)).not.toBeNull();
+    const executions = await storage.listCellExecutions(runId);
+    expect(executions).toHaveLength(2);
+    const template = (await storage.getTemplate(notebookId, 1))!;
+    expect(deriveInstanceStatus(template, executions)).toBe("in_progress");
+  }, 180_000);
+});
+
+describe("Partial-run durability (B5) — Supabase storage (local stack)", () => {
+  let available = false;
+
+  beforeAll(async () => {
+    available = await isSupabaseAvailable();
+    if (!available) return;
+    await ensureTestWorkspace();
+  });
+
+  it("a run halting at cell 2 of 4 leaves records for executed cells only", async ({
+    skip,
+  }) => {
+    if (!available) skip();
+    await runPartialHaltScenario(
+      new SupabaseRunbookStorage({
+        supabaseUrl: SUPABASE_TEST_URL,
+        serviceRoleKey: SUPABASE_TEST_SERVICE_ROLE_KEY,
+        tenantWorkspaceId: TEST_WORKSPACE_ID,
+      }),
+    );
+  }, 180_000);
+});
+
+// =============================================================================
+// Instance-aware single-cell path — out-of-order rejection (B5)
+// =============================================================================
+
+describe("Out-of-order rejection on the instance-aware single-cell path (B5)", () => {
+  it("only the next unsatisfied cell may execute; later cells are rejected", async () => {
+    const storage = new InMemoryRunbookStorage(createRunbookMemoryState());
+    const handler = await newHandler(storage);
+    const notebookId = await createRunbook(handler, `Ordered advance ${randomUUID()}`);
+
+    const c1 = await handler.handleAddCell({
+      notebookId,
+      cellType: "code",
+      filename: "c1.js",
+      content: 'console.log("c1 ran");',
+    });
+    const c2 = await handler.handleAddCell({
+      notebookId,
+      cellType: "code",
+      filename: "c2.js",
+      content: EXIT_1_SOURCE,
+      contract: EXIT_CODE_CONTRACT(1),
+    });
+
+    const notebook = handler.getNotebook(notebookId)!;
+    const pkgCellId = notebook.cells.find((cell) => cell.type === "package.json")!.id;
+    const cells = templateCellsFromNotebook(notebook);
+    await storage.saveTemplate({
+      templateId: notebookId,
+      version: 1,
+      cells,
+      cellsHash: hashTemplateCells(cells),
+      createdBy: "tester",
+      createdAt: new Date().toISOString(),
+    });
+    const instanceId = `rbi-${randomUUID()}`;
+    await storage.createInstance({
+      instanceId,
+      templateId: notebookId,
+      templateVersion: 1,
+      createdBy: "tester",
+      createdAt: new Date().toISOString(),
+    });
+
+    // Fresh instance: the expected next cell is the dependency install.
+    await expect(
+      handler.handleRunCell({ notebookId, cellId: c2.cell.id, instanceId }),
+    ).rejects.toMatchObject({
+      name: "OutOfOrderExecutionError",
+      attemptedCellId: c2.cell.id,
+      expectedNextCellId: pkgCellId,
+    });
+    await expect(
+      handler.handleRunCell({ notebookId, cellId: c2.cell.id, instanceId }),
+    ).rejects.toThrow(pkgCellId);
+
+    const pkgResult = await handler.handleRunCell({
+      notebookId,
+      cellId: pkgCellId,
+      instanceId,
+    });
+    expect(pkgResult.success).toBe(true);
+    expect(pkgResult.instance.seq).toBe(1);
+    expect(pkgResult.instance.nextCellId).toBe(c1.cell.id);
+
+    // c2 is still later than the next unsatisfied cell (c1).
+    await expect(
+      handler.handleRunCell({ notebookId, cellId: c2.cell.id, instanceId }),
+    ).rejects.toMatchObject({ expectedNextCellId: c1.cell.id });
+
+    const c1Result = await handler.handleRunCell({
+      notebookId,
+      cellId: c1.cell.id,
+      instanceId,
+    });
+    expect(c1Result.instance.seq).toBe(2);
+    expect(c1Result.instance.status).toBe("in_progress");
+    expect(c1Result.instance.nextCellId).toBe(c2.cell.id);
+
+    // Re-running the satisfied c1 while c2 is unsatisfied is out of order.
+    await expect(
+      handler.handleRunCell({ notebookId, cellId: c1.cell.id, instanceId }),
+    ).rejects.toMatchObject({ expectedNextCellId: c2.cell.id });
+
+    // c2 is an expectation-satisfied predicted failure on this path too.
+    const c2Result = await handler.handleRunCell({
+      notebookId,
+      cellId: c2.cell.id,
+      instanceId,
+    });
+    expect(c2Result.success).toBe(true);
+    expect(c2Result.execution.success).toBe(false);
+    expect(c2Result.instance.satisfied).toBe(true);
+    expect(c2Result.instance.expectations[0]).toMatchObject({ result: "pass" });
+    expect(c2Result.instance.status).toBe("completed");
+    expect(c2Result.instance.nextCellId).toBeNull();
+
+    // A fully satisfied instance allows re-execution; it appends a new seq.
+    const again = await handler.handleRunCell({
+      notebookId,
+      cellId: c1.cell.id,
+      instanceId,
+    });
+    expect(again.instance.seq).toBe(4);
+    const executions = await storage.listCellExecutions(instanceId);
+    expect(executions.map((record) => record.seq)).toEqual([1, 2, 3, 4]);
+  }, 240_000);
+
+  it("rejects execution when the live notebook drifted from the pinned template", async () => {
+    const storage = new InMemoryRunbookStorage(createRunbookMemoryState());
+    const handler = await newHandler(storage);
+    const notebookId = await createRunbook(handler, `Drifted ${randomUUID()}`);
+    const c1 = await handler.handleAddCell({
+      notebookId,
+      cellType: "code",
+      filename: "c1.js",
+      content: 'console.log("v1");',
+    });
+
+    const notebook = handler.getNotebook(notebookId)!;
+    const cells = templateCellsFromNotebook(notebook);
+    await storage.saveTemplate({
+      templateId: notebookId,
+      version: 1,
+      cells,
+      cellsHash: hashTemplateCells(cells),
+      createdBy: "tester",
+      createdAt: new Date().toISOString(),
+    });
+    const instanceId = `rbi-${randomUUID()}`;
+    await storage.createInstance({
+      instanceId,
+      templateId: notebookId,
+      templateVersion: 1,
+      createdBy: "tester",
+      createdAt: new Date().toISOString(),
+    });
+
+    await handler.handleUpdateCell({
+      notebookId,
+      cellId: c1.cell.id,
+      content: 'console.log("v2 — drifted");',
+    });
+
+    await expect(
+      handler.handleRunCell({ notebookId, cellId: c1.cell.id, instanceId }),
+    ).rejects.toThrow(/drifted/);
+  }, 120_000);
+});

--- a/src/notebook/__tests__/ordered-execution.test.ts
+++ b/src/notebook/__tests__/ordered-execution.test.ts
@@ -19,7 +19,12 @@
 
 import { describe, it, expect, beforeAll } from "vitest";
 import { randomUUID } from "node:crypto";
+import { Effect } from "effect";
 import { NotebookHandler } from "../index.js";
+import {
+  InMemoryNotebookEngineRuntime,
+  type CellExecutionEvidence,
+} from "../engine/runtime.js";
 import {
   InMemoryRunbookStorage,
   createRunbookMemoryState,
@@ -278,6 +283,14 @@ describe("Expected-failure halt rule (B5, real execution)", () => {
     const rows = await storage.listFitnessRows(notebookId, 1);
     expect(rows).toHaveLength(1);
     expect(rows[0]).toMatchObject({ cellId: predicted.cell.id, result: "pass", pass: true });
+
+    // Sequential cells carry distinct, ordered execution start times —
+    // startedAt is captured when each cell BEGINS executing, not when the
+    // gate persists its record afterwards.
+    const startTimes = executions.map((record) => Date.parse(record.startedAt));
+    expect(startTimes.every((time) => Number.isFinite(time))).toBe(true);
+    expect(startTimes[0]!).toBeLessThan(startTimes[1]!);
+    expect(startTimes[1]!).toBeLessThan(startTimes[2]!);
   }, 180_000);
 
   it("halts when a predicted failure's expectation fails", async () => {
@@ -607,4 +620,140 @@ describe("Out-of-order rejection on the instance-aware single-cell path (B5)", (
       handler.handleRunCell({ notebookId, cellId: c1.cell.id, instanceId }),
     ).rejects.toThrow(/drifted/);
   }, 120_000);
+});
+
+// =============================================================================
+// Gate seam residuals (PR #402): startedAt provenance, pre-execution ordering
+// assertion, explicit max seq derivation
+// =============================================================================
+
+function gateEvidence(cellId: string, startedAt?: string): CellExecutionEvidence {
+  return {
+    cellId,
+    cellType: "code",
+    filename: `${cellId}.js`,
+    status: "completed",
+    exitCode: 0,
+    output: "ok",
+    error: "",
+    ...(startedAt !== undefined ? { startedAt } : {}),
+  };
+}
+
+const GATE_TEMPLATE_CELLS: RunbookTemplateCell[] = [
+  templateCell("a"),
+  templateCell("b"),
+];
+
+describe("Per-cell gate timing and seq derivation (PR #402 residuals)", () => {
+  it("persists the executor-captured startedAt, not the gate call time", async () => {
+    const storage = new InMemoryRunbookStorage(createRunbookMemoryState());
+    const startedAts = ["2026-06-12T00:00:00.000Z", "2026-06-12T00:00:01.000Z"];
+    const runtime = new InMemoryNotebookEngineRuntime(
+      async (_notebookId, gate) => {
+        const out: CellExecutionEvidence[] = [];
+        for (const [index, cellId] of ["a", "b"].entries()) {
+          gate?.assertExecutable(cellId);
+          const cell = gateEvidence(cellId, startedAts[index]);
+          out.push(cell);
+          if (gate) await gate.record(cell);
+        }
+        return out;
+      },
+      undefined,
+      {
+        storage,
+        templateCellSource: () => GATE_TEMPLATE_CELLS,
+        agentId: "tester",
+      },
+    );
+
+    const result = await Effect.runPromise(
+      runtime.startRun({ notebookId: "nb_started_at", mode: "runbook" }),
+    );
+    expect(result.run.status).toBe("completed");
+    const records = await storage.listCellExecutions(result.run.runId);
+    expect(records.map((record) => record.startedAt)).toEqual(startedAts);
+  });
+
+  it("rejects an out-of-order cell BEFORE it executes; earlier records survive", async () => {
+    const storage = new InMemoryRunbookStorage(createRunbookMemoryState());
+    let executedAfterRejection = false;
+    const runtime = new InMemoryNotebookEngineRuntime(
+      async (_notebookId, gate) => {
+        gate!.assertExecutable("a");
+        const a = gateEvidence("a");
+        await gate!.record(a);
+        // Misbehaving executor: re-runs "a" while "b" is still unsatisfied.
+        gate!.assertExecutable("a");
+        executedAfterRejection = true;
+        return [a];
+      },
+      undefined,
+      {
+        storage,
+        templateCellSource: () => GATE_TEMPLATE_CELLS,
+        agentId: "tester",
+      },
+    );
+
+    await expect(
+      Effect.runPromise(runtime.startRun({ notebookId: "nb_pre_exec", mode: "runbook" })),
+    ).rejects.toThrow();
+    // The rejection fired pre-execution: the out-of-order cell never ran.
+    expect(executedAfterRejection).toBe(false);
+    const failedRun = runtime.listRuns("nb_pre_exec")[0]!;
+    expect(failedRun).toMatchObject({
+      status: "failed",
+      error: expect.stringContaining("out-of-order"),
+    });
+    // And the rejection dropped no durable record: cell a's record, written
+    // by the gate before the violation, survived.
+    const records = await storage.listCellExecutions(failedRun.runId);
+    expect(records).toHaveLength(1);
+    expect(records[0]!.cellId).toBe("a");
+  });
+
+  it("re-execution seq increments from the max recorded seq, not storage order", async () => {
+    const storage = new InMemoryRunbookStorage(createRunbookMemoryState());
+    await storage.saveTemplate(TEMPLATE);
+    await storage.createInstance({
+      instanceId: "rbi-ordering",
+      templateId: TEMPLATE.templateId,
+      templateVersion: TEMPLATE.version,
+      createdBy: "tester",
+      createdAt: "2026-06-12T00:00:00.000Z",
+    });
+    // Out-of-order history: b failed at seq 2 and was re-run at seq 3.
+    await storage.appendCellExecution(execution("a", 1, "completed"));
+    await storage.appendCellExecution(execution("b", 2, "failed"));
+    await storage.appendCellExecution(execution("b", 3, "completed"));
+    await storage.appendCellExecution(execution("c", 4, "completed"));
+    // Adversarial backend: returns records in DESCENDING seq order, so a
+    // last-element read would derive seq 2 and collide with the existing
+    // append — the runtime must take the explicit max instead.
+    const list = storage.listCellExecutions.bind(storage);
+    storage.listCellExecutions = async (instanceId) =>
+      (await list(instanceId)).reverse();
+
+    const runtime = new InMemoryNotebookEngineRuntime(async () => [], undefined, {
+      storage,
+      agentId: "tester",
+    });
+    const result = await runtime.executeInstanceCell({
+      instanceId: "rbi-ordering",
+      // The instance is fully satisfied, so re-executing any cell is allowed.
+      cellId: "a",
+      executeCell: async () => ({
+        status: "completed",
+        exitCode: 0,
+        stdout: "ok",
+        stderr: "",
+      }),
+    });
+
+    expect(result.seq).toBe(5);
+    const persisted = await list("rbi-ordering");
+    expect(persisted.map((record) => record.seq)).toEqual([1, 2, 3, 4, 5]);
+  });
 });

--- a/src/notebook/__tests__/runbook-durability.test.ts
+++ b/src/notebook/__tests__/runbook-durability.test.ts
@@ -229,6 +229,60 @@ describe("Durable runbook round-trip — InMemory storage (shared state restart)
     expect(await storage.listTemplateVersions(notebookId)).toEqual([]);
     expect(await storage.listInstances(notebookId)).toEqual([]);
   });
+
+  async function runArtifactExpectationCell(
+    op: "matches" | "eq",
+    value: string,
+  ): Promise<{ run: Awaited<ReturnType<NotebookHandler["handleStartRun"]>>; cellExpectationCount: number }> {
+    const storage = new InMemoryRunbookStorage(createRunbookMemoryState());
+    const handler = new NotebookHandler(undefined, {
+      runbookStorage: storage,
+      agentId: "agent-session-1",
+    });
+    await handler.init();
+    const created = await handler.handleCreateNotebook({
+      title: "Artifact-backed expectation",
+      language: "javascript",
+    });
+    const notebookId = created.notebook.id as string;
+    await handler.handleAddCell({
+      notebookId,
+      cellType: "code",
+      filename: "step.js",
+      content: 'console.log("ok");',
+      contract: {
+        schemaVersion: "outcome-contract.v0",
+        expectations: [
+          { source: { kind: "exitCode" }, op: "eq", value: 0 },
+          // Reads the post-run cell-results artifact — only resolvable after
+          // execution, so the gate must defer it (not error) to the verdict.
+          { source: { kind: "artifact", name: "cell-results.json", pointer: "/0/status" }, op, value },
+        ],
+      },
+    });
+    const run = await handler.handleStartRun({ notebookId, mode: "runbook" });
+    const executions = await storage.listCellExecutions(run.run.runId as string);
+    const contracted = executions.find((r) => r.expectations.length > 0)!;
+    return { run, cellExpectationCount: contracted.expectations.length };
+  }
+
+  it("defers a post-run artifact expectation to the verdict — valid runbook passes, gate persists only non-artifact records", async () => {
+    // status matches /.+/ at verdict (cell-results.json exists by then).
+    const { run, cellExpectationCount } = await runArtifactExpectationCell("matches", ".+");
+    expect(run.run.status).toBe("completed");
+    expect(run.run.outputs[0].pass).toBe(true);
+    // Gate persisted only the exitCode expectation; the artifact one deferred.
+    expect(cellExpectationCount).toBe(1);
+  });
+
+  it("evaluates the deferred artifact expectation at the verdict (a real mismatch still fails the run)", async () => {
+    // status never equals "nope" — proves the artifact expectation is
+    // evaluated at the verdict, not silently dropped, and not a not-found error.
+    const { run } = await runArtifactExpectationCell("eq", "nope");
+    expect(run.run.outputs[0].pass).toBe(false);
+    expect(run.run.outputs[0].reason).toMatch(/artifact|status/i);
+    expect(run.run.outputs[0].reason).not.toMatch(/not found/i);
+  });
 });
 
 describe("Durable runbook round-trip — Supabase storage (local stack)", () => {

--- a/src/notebook/__tests__/runbook-durability.test.ts
+++ b/src/notebook/__tests__/runbook-durability.test.ts
@@ -26,11 +26,8 @@ import {
   createRunbookMemoryState,
 } from "../runbook/in-memory-runbook-storage.js";
 import { SupabaseRunbookStorage } from "../runbook/supabase-runbook-storage.js";
-import {
-  deriveInstanceStatus,
-  verifyTemplateContracts,
-  type RunbookStorage,
-} from "../runbook/types.js";
+import { verifyTemplateContracts, type RunbookStorage } from "../runbook/types.js";
+import { deriveInstanceStatus } from "../runbook/ordering.js";
 import {
   ensureTestWorkspace,
   isSupabaseAvailable,

--- a/src/notebook/__tests__/runbook-durability.test.ts
+++ b/src/notebook/__tests__/runbook-durability.test.ts
@@ -183,6 +183,52 @@ describe("Durable runbook round-trip — InMemory storage (shared state restart)
     expect((await storage.getInstance(run3.run.runId))!.templateVersion).toBe(2);
     expect(await storage.listInstances(notebookId)).toHaveLength(3);
   }, 180_000);
+
+  it("rejects a post-attach tampered contract before persisting a template version or instance", async () => {
+    const state = createRunbookMemoryState();
+    const storage = new InMemoryRunbookStorage(state);
+    const handler = new NotebookHandler(undefined, {
+      runbookStorage: storage,
+      agentId: "agent-session-1",
+    });
+    await handler.init();
+
+    const created = await handler.handleCreateNotebook({
+      title: "Tampered durable runbook",
+      language: "javascript",
+    });
+    const notebookId = created.notebook.id as string;
+    const added = await handler.handleAddCell({
+      notebookId,
+      cellType: "code",
+      filename: "step.js",
+      content: 'console.log("ok");',
+      contract: {
+        schemaVersion: "outcome-contract.v0",
+        expectations: [{ source: { kind: "exitCode" }, op: "eq", value: 0 }],
+      },
+    });
+
+    // Tamper the stored contract without recompiling its hash.
+    const notebook = handler.getNotebook(notebookId)!;
+    const cell = notebook.cells.find((c) => c.id === added.cell.id)!;
+    if (cell.type !== "code" || cell.contract === undefined) throw new Error("setup broke");
+    (cell.contract.contract.expectations[0] as { value: unknown }).value = 1;
+
+    await expect(
+      handler.handleStartRun({ notebookId, mode: "runbook" }),
+    ).rejects.toThrow();
+
+    const listed = await handler.handleListRuns({ notebookId });
+    const failed = listed.runs[0] as { status: string; error: string };
+    expect(failed.status).toBe("failed");
+    expect(failed.error).toContain("hash mismatch");
+
+    // Verification gates beginDurableRun: durable storage stays clean — no
+    // template version, no instance (Codex PR #402, P2).
+    expect(await storage.listTemplateVersions(notebookId)).toEqual([]);
+    expect(await storage.listInstances(notebookId)).toEqual([]);
+  });
 });
 
 describe("Durable runbook round-trip — Supabase storage (local stack)", () => {

--- a/src/notebook/__tests__/runbook-storage.test.ts
+++ b/src/notebook/__tests__/runbook-storage.test.ts
@@ -23,7 +23,6 @@ import {
 import { SupabaseRunbookStorage } from "../runbook/supabase-runbook-storage.js";
 import {
   aggregateFitness,
-  deriveInstanceStatus,
   hashTemplateCells,
   verifyTemplateContracts,
   type CellExecutionRecord,
@@ -33,6 +32,7 @@ import {
   type RunbookTemplate,
   type RunbookTemplateCell,
 } from "../runbook/types.js";
+import { deriveInstanceStatus } from "../runbook/ordering.js";
 import { compileOutcomeContract } from "../contracts.js";
 import {
   createServiceClient,
@@ -246,7 +246,12 @@ function runRunbookStorageContract(
     await storage.createInstance(instance);
 
     const first = makeExecution(instance.instanceId, 1, { cellId: "pkg" });
-    const second = makeExecution(instance.instanceId, 2, { status: "failed" });
+    // An uncontracted procedural failure: no declared expectations, so the
+    // B5 satisfaction rule derives "failed" from the procedural status.
+    const second = makeExecution(instance.instanceId, 2, {
+      status: "failed",
+      expectations: [],
+    });
     await storage.appendCellExecution(first);
     await storage.appendCellExecution(second);
 

--- a/src/notebook/__tests__/template-versioning.test.ts
+++ b/src/notebook/__tests__/template-versioning.test.ts
@@ -246,7 +246,10 @@ describe("Engine runtime — concurrent gated first runs of the same notebook", 
       new InMemoryNotebookEngineRuntime(
         async (_notebookId, gate) => {
           for (const cell of evidence) {
-            if (gate) await gate(cell);
+            if (gate) {
+              gate.assertExecutable(cell.cellId);
+              await gate.record(cell);
+            }
           }
           return evidence;
         },

--- a/src/notebook/__tests__/template-versioning.test.ts
+++ b/src/notebook/__tests__/template-versioning.test.ts
@@ -224,6 +224,64 @@ describe("Engine runtime — concurrent first runs of the same notebook", () => 
   });
 });
 
+describe("Engine runtime — concurrent gated first runs of the same notebook", () => {
+  it("both gated runs pin the single template version and proceed", async () => {
+    const evidence: CellExecutionEvidence[] = [
+      {
+        cellId: "step",
+        cellType: "code",
+        filename: "step.js",
+        status: "completed",
+        exitCode: 0,
+        output: "ok",
+        error: "",
+      },
+    ];
+    const state = createRunbookMemoryState();
+    const arrive = makeBarrier(2);
+    // templateCellSource wired: run-start beginDurableRun resolves the
+    // template version and creates the instance BEFORE any cell executes,
+    // and the executor consults the per-cell gate like the real handler.
+    const makeRuntime = (agentId: string) =>
+      new InMemoryNotebookEngineRuntime(
+        async (_notebookId, gate) => {
+          for (const cell of evidence) {
+            if (gate) await gate(cell);
+          }
+          return evidence;
+        },
+        undefined,
+        {
+          storage: withFirstReadBarrier(new InMemoryRunbookStorage(state), arrive),
+          templateCellSource: () => makeCells(),
+          agentId,
+        },
+      );
+
+    const notebookId = "nb_gated_version_race";
+    const [a, b] = await Promise.all([
+      Effect.runPromise(makeRuntime("agent-a").startRun({ notebookId, mode: "runbook" })),
+      Effect.runPromise(makeRuntime("agent-b").startRun({ notebookId, mode: "runbook" })),
+    ]);
+
+    // Before delegating to the shared resolver the loser's run-start
+    // saveTemplate surfaced "already exists" and failed the whole run.
+    expect(a.run.status).toBe("completed");
+    expect(b.run.status).toBe("completed");
+
+    const storage = new InMemoryRunbookStorage(state);
+    expect(await storage.listTemplateVersions(notebookId)).toEqual([1]);
+    const instances = await storage.listInstances(notebookId);
+    expect(instances).toHaveLength(2);
+    expect(instances.every((instance) => instance.templateVersion === 1)).toBe(true);
+    for (const instance of instances) {
+      const executions = await storage.listCellExecutions(instance.instanceId);
+      expect(executions).toHaveLength(1);
+      expect(executions[0]?.cellId).toBe("step");
+    }
+  });
+});
+
 describe("SupabaseRunbookStorage — version conflicts (local stack)", () => {
   let available = false;
 

--- a/src/notebook/engine/runtime.ts
+++ b/src/notebook/engine/runtime.ts
@@ -24,6 +24,7 @@ import {
 } from "../contracts.js";
 import {
   hashTemplateCells,
+  verifyCellContracts,
   verifyTemplateContracts,
   type CellExecutionRecord,
   type FitnessLedgerRow,
@@ -368,6 +369,22 @@ export class InMemoryNotebookEngineRuntime {
       );
 
       const templateCells = this.templateCellSource?.(notebookId);
+      // Verify attached contract hashes BEFORE persisting a template version:
+      // a post-attach tampered contract is rejected here instead of saving a
+      // template + instance that executeAllCells would only later reject,
+      // leaving durable storage polluted with an unloadable version (Codex
+      // PR #402, P2).
+      if (templateCells !== undefined) {
+        yield* Effect.try({
+          try: () => verifyCellContracts(templateCells),
+          catch: (cause) =>
+            cause instanceof ContractHashMismatchError
+              ? new SnapshotMismatch({ expected: cause.expected, actual: cause.actual })
+              : new InvalidNotebookShape({
+                  reason: `Contract verification failed: ${errorMessage(cause)}`,
+                }),
+        });
+      }
       const durable =
         templateCells !== undefined
           ? yield* Effect.tryPromise({
@@ -508,6 +525,16 @@ export class InMemoryNotebookEngineRuntime {
       );
     }
 
+    // CONCURRENCY (v0): instance advance is single-writer per instance. This
+    // read -> executeCell -> append sequence is not atomic, so two concurrent
+    // advances of the SAME instance+cell would both run the cell's side
+    // effects before either appends; the loser then fails on the
+    // (instance_id, seq) unique constraint. That constraint is the durable
+    // backstop (never two rows at one seq), but it does not prevent the double
+    // side effect. v0 assumes one advancer per instance (an agent holding it,
+    // or a single cron tick); cross-replica concurrent same-instance advance
+    // is unsupported and is resolved with the advancer (B6/B8), where
+    // contention originates. Tracked in GH #403.
     const executions = await this.storage.listCellExecutions(input.instanceId);
     assertCellExecutable(template, executions, input.cellId);
     const templateCell = template.cells.find((cell) => cell.cellId === input.cellId)!;

--- a/src/notebook/engine/runtime.ts
+++ b/src/notebook/engine/runtime.ts
@@ -24,10 +24,20 @@ import {
 } from "../contracts.js";
 import {
   hashTemplateCells,
+  verifyTemplateContracts,
+  type CellExecutionRecord,
   type FitnessLedgerRow,
+  type RunbookInstanceStatus,
   type RunbookStorage,
+  type RunbookTemplate,
   type RunbookTemplateCell,
 } from "../runbook/types.js";
+import {
+  assertCellExecutable,
+  deriveInstanceStatus,
+  isExecutionSatisfied,
+  nextUnsatisfiedCell,
+} from "../runbook/ordering.js";
 import { InMemoryRunbookStorage } from "../runbook/in-memory-runbook-storage.js";
 import { hashJson } from "../../peer-notebook/manifest.js";
 
@@ -50,8 +60,8 @@ export interface NotebookRunRuntimeResult {
 
 /**
  * Per-cell result of a real notebook execution, as reported by the
- * NotebookCellExecutor. `skipped` means an earlier cell failed and this
- * cell was never run.
+ * NotebookCellExecutor. `skipped` means an earlier cell halted the run and
+ * this cell was never run.
  */
 export interface CellExecutionEvidence {
   cellId: string;
@@ -71,16 +81,44 @@ export interface CellExecutionEvidence {
   expectations?: ExpectationRecord[];
 }
 
+export type CellGateDisposition = "continue" | "halt";
+
+export interface CellGateResult {
+  /** Every evaluated expectation record for the cell (tier 2 then tier 1). */
+  records: ExpectationRecord[];
+  disposition: CellGateDisposition;
+}
+
+/**
+ * Per-cell gate the runtime hands to the executor (SPEC-AGX-SUBSTRATE B5).
+ * Called once after each cell actually executes (never for skipped cells).
+ * It enforces document-order execution, evaluates the cell's declared
+ * expectations, persists the durable execution record and its ledger rows
+ * immediately (partial-run durability), and decides whether the run
+ * continues: an expectation-satisfied predicted failure continues; an
+ * uncontracted failure or failed/errored expectations halt.
+ */
+export type CellExecutionGate = (
+  evidence: CellExecutionEvidence,
+) => Promise<CellGateResult>;
+
 /**
  * Executes a notebook's executable cells in document order and reports
- * per-cell evidence. Implemented by NotebookHandler over the real
- * NotebookStateManager subprocess execution path. Throws
+ * per-cell evidence, consulting the gate (when provided) after each cell
+ * for the continue/halt disposition. Implemented by NotebookHandler over
+ * the real NotebookStateManager subprocess execution path. Throws
  * ContractHashMismatchError when an attached outcome contract fails its
  * run-time hash re-verification (tampering — the run is rejected).
  */
 export type NotebookCellExecutor = (
   notebookId: string,
+  gate?: CellExecutionGate,
 ) => Promise<CellExecutionEvidence[]>;
+
+/** Distinguishes durable-storage failures raised inside the cell gate. */
+export class RunbookPersistenceError extends Error {
+  override readonly name = "RunbookPersistenceError";
+}
 
 /**
  * Durable persistence wiring for the engine runtime (SPEC-AGX-SUBSTRATE B4b).
@@ -92,13 +130,62 @@ export interface NotebookEngineRuntimeOptions {
   storage?: RunbookStorage;
   /**
    * Snapshot of a notebook's executable cells (including compiled contracts)
-   * for durable template versioning. When absent, a degenerate template is
-   * derived from execution evidence (cell ids/types/contracts; source
-   * unavailable at that layer).
+   * for durable template versioning. When wired, the instance is created at
+   * run start and cell execution records persist as each cell completes
+   * (B5 partial-run durability). When absent, a degenerate template is
+   * derived from execution evidence after the run (cell ids/types/contracts;
+   * source unavailable at that layer) and persistence happens at run end.
    */
   templateCellSource?: (notebookId: string) => RunbookTemplateCell[] | undefined;
   /** Executing agent identity recorded on instances/executions/ledger rows. */
   agentId?: string;
+}
+
+/** Mutable per-run context threading the gate's durable writes (B5). */
+interface DurableRunContext {
+  instanceId: string;
+  template: RunbookTemplate;
+  inputsDigest: string;
+  nextSeq: number;
+  executions: CellExecutionRecord[];
+  /** Gate-evaluated records, authoritative for the verdict derivation. */
+  recordsByCell: Map<string, ExpectationRecord[]>;
+  /** Cells whose ledger rows the gate already wrote. */
+  gatedCellIds: Set<string>;
+}
+
+/** Input for the instance-aware single-cell execution path (B5 ordering). */
+export interface InstanceCellExecutionInput {
+  instanceId: string;
+  cellId: string;
+  /** Guard: the instance must belong to this template (the notebook id). */
+  expectedTemplateId?: string;
+  /** Live notebook cell snapshot, hash-checked against the pinned template version. */
+  liveCells?: RunbookTemplateCell[];
+  /** Executes exactly one cell through the real execution path. */
+  executeCell: (cellId: string) => Promise<InstanceCellExecution>;
+}
+
+export interface InstanceCellExecution {
+  status: "completed" | "failed";
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  structuredOutput?: string;
+}
+
+export interface InstanceCellExecutionResult {
+  instanceId: string;
+  cellId: string;
+  seq: number;
+  status: "completed" | "failed";
+  /** B5 satisfaction: declared expectations decide; else procedural completion. */
+  satisfied: boolean;
+  expectations: ExpectationRecord[];
+  instanceStatus: RunbookInstanceStatus;
+  /** Next unsatisfied cell after this execution; null = all satisfied. */
+  nextCellId: string | null;
+  execution: { exitCode: number | null; stdout: string; stderr: string };
 }
 
 export class InMemoryNotebookEngineRuntime {
@@ -188,56 +275,11 @@ export class InMemoryNotebookEngineRuntime {
       // shares one error handler: any failure (execution, contract integrity,
       // or artifact persistence) must transition the run to FailedRun — a run
       // may never be left in RunningRun forever.
-      const runBody = Effect.gen(this, function* () {
-        const evidence = yield* Effect.tryPromise({
-          try: () => this.executeNotebook(input.notebookId),
-          catch: (cause) =>
-            cause instanceof ContractHashMismatchError
-              ? new SnapshotMismatch({
-                  expected: cause.expected,
-                  actual: cause.actual,
-                })
-              : new InvalidNotebookShape({
-                  reason: `Notebook execution failed: ${cause instanceof Error ? cause.message : String(cause)}`,
-                }),
-        });
-        const inputsArtifact = yield* this.putArtifact(
-          `${runId}-inputs.json`,
-          "application/json",
-          JSON.stringify(input.inputs ?? {}, null, 2),
-        );
-        const evidenceArtifact = yield* this.putArtifact(
-          `${runId}-cell-results.json`,
-          "application/json",
-          JSON.stringify(evidence, null, 2),
-        );
-        const runArtifacts = [inputsArtifact, evidenceArtifact];
-        const { verdict, records } = buildRunbookVerdict(evidence, {
-          readArtifact: (name) => this.readRunArtifact(runArtifacts, name),
-          claimResolver: this.claimResolver,
-        });
-        // Durable persistence (SPEC-AGX-SUBSTRATE B4b): template version,
-        // instance pinning it, append-only cell executions, and fitness
-        // ledger rows. A persistence failure fails the run — durable records
-        // are part of the run's contract, not a best-effort side channel.
-        yield* Effect.tryPromise({
-          try: () =>
-            this.persistDurableRecords({
-              runId,
-              notebookId: input.notebookId,
-              startedAt,
-              inputs: input.inputs ?? {},
-              evidence,
-              records,
-              outputsRef: evidenceArtifact.artifactId,
-            }),
-          catch: (cause) =>
-            new StoreUnavailable({
-              store: "runbook",
-              reason: cause instanceof Error ? cause.message : String(cause),
-            }),
-        });
-        return { verdict, runArtifacts };
+      const runBody = this.makeRunBody({
+        runId,
+        notebookId: input.notebookId,
+        startedAt,
+        inputs: input.inputs ?? {},
       });
 
       const { verdict, runArtifacts } = yield* runBody.pipe(
@@ -290,6 +332,85 @@ export class InMemoryNotebookEngineRuntime {
     });
   }
 
+  /**
+   * The run body shared by every runbook run. With a templateCellSource
+   * wired (the real handler path), the durable instance is created BEFORE
+   * any cell executes and the gate persists each cell's record as it
+   * completes — a run that dies mid-way leaves durable records for every
+   * cell that did execute (B5 partial-run durability). Without one (raw
+   * runtime usage), the legacy run-end persistence applies.
+   */
+  private makeRunBody(args: {
+    runId: string;
+    notebookId: string;
+    startedAt: string;
+    inputs: Record<string, unknown>;
+  }) {
+    const { runId, notebookId, startedAt, inputs } = args;
+    return Effect.gen(this, function* () {
+      const inputsArtifact = yield* this.putArtifact(
+        `${runId}-inputs.json`,
+        "application/json",
+        JSON.stringify(inputs, null, 2),
+      );
+
+      const templateCells = this.templateCellSource?.(notebookId);
+      const durable =
+        templateCells !== undefined
+          ? yield* Effect.tryPromise({
+              try: () =>
+                this.beginDurableRun({ runId, notebookId, startedAt, inputs, cells: templateCells }),
+              catch: (cause) =>
+                new StoreUnavailable({ store: "runbook", reason: errorMessage(cause) }),
+            })
+          : undefined;
+      const gate =
+        durable !== undefined ? this.createCellGate(durable, [inputsArtifact]) : undefined;
+
+      const evidence = yield* Effect.tryPromise({
+        try: () => this.executeNotebook(notebookId, gate),
+        catch: (cause) =>
+          cause instanceof ContractHashMismatchError
+            ? new SnapshotMismatch({ expected: cause.expected, actual: cause.actual })
+            : cause instanceof RunbookPersistenceError
+              ? new StoreUnavailable({ store: "runbook", reason: cause.message })
+              : new InvalidNotebookShape({
+                  reason: `Notebook execution failed: ${errorMessage(cause)}`,
+                }),
+      });
+
+      const evidenceArtifact = yield* this.putArtifact(
+        `${runId}-cell-results.json`,
+        "application/json",
+        JSON.stringify(evidence, null, 2),
+      );
+      const runArtifacts = [inputsArtifact, evidenceArtifact];
+      const { verdict, records } = buildRunbookVerdict(evidence, {
+        readArtifact: (name) => this.readRunArtifact(runArtifacts, name),
+        claimResolver: this.claimResolver,
+        ...(durable !== undefined ? { precomputedRecords: durable.recordsByCell } : {}),
+      });
+
+      yield* Effect.tryPromise({
+        try: () =>
+          durable !== undefined
+            ? this.finishDurableRun(durable, records)
+            : this.persistDurableRecords({
+                runId,
+                notebookId,
+                startedAt,
+                inputs,
+                evidence,
+                records,
+                outputsRef: evidenceArtifact.artifactId,
+              }),
+        catch: (cause) =>
+          new StoreUnavailable({ store: "runbook", reason: errorMessage(cause) }),
+      });
+      return { verdict, runArtifacts };
+    });
+  }
+
   getRun(runId: string): NotebookRun | null {
     return this.runs.get(runId) ?? null;
   }
@@ -326,16 +447,242 @@ export class InMemoryNotebookEngineRuntime {
   }
 
   /**
-   * Persist the durable record of one run (SPEC-AGX-SUBSTRATE B4b):
-   * 1. Template version — the notebook id is the stable templateId; a new
-   *    immutable version is appended when the canonical cells hash changes,
-   *    otherwise the latest version is reused.
-   * 2. Instance — pins (templateId, version) at creation; instanceId = runId.
-   * 3. Cell executions — one append-only record per evidence cell
-   *    (seq = document order), carrying the per-expectation results.
-   * 4. Fitness ledger — one row per machine-checked expectation evaluation
-   *    (tier carried; error/skipped recorded with their state and excluded
-   *    from pass-rate aggregates by `aggregateFitness`).
+   * Instance-aware single-cell execution (SPEC-AGX-SUBSTRATE B5 — spec §5
+   * "Ordering"). Given an instance, ONLY the next unsatisfied cell (per
+   * template order and the instance's append-only execution records) may
+   * execute; any other cell is rejected with OutOfOrderExecutionError naming
+   * the expected next cell. The execution appends a fresh record (seq) and
+   * its ledger rows. Artifact-sourced expectations have no run artifacts on
+   * this path and evaluate to `error`; tier-2 validator cells are rejected —
+   * they evaluate during batch runs, which retain the target cell's
+   * structured output.
+   */
+  async executeInstanceCell(
+    input: InstanceCellExecutionInput,
+  ): Promise<InstanceCellExecutionResult> {
+    const instance = await this.storage.getInstance(input.instanceId);
+    if (!instance) {
+      throw new Error(`Runbook instance ${input.instanceId} not found`);
+    }
+    if (
+      input.expectedTemplateId !== undefined &&
+      instance.templateId !== input.expectedTemplateId
+    ) {
+      throw new Error(
+        `instance ${input.instanceId} belongs to template ${instance.templateId}, ` +
+          `not ${input.expectedTemplateId}`,
+      );
+    }
+    const template = await this.storage.getTemplate(
+      instance.templateId,
+      instance.templateVersion,
+    );
+    if (!template) {
+      throw new Error(
+        `template ${instance.templateId} version ${instance.templateVersion} ` +
+          `not found for instance ${input.instanceId}`,
+      );
+    }
+    verifyTemplateContracts(template);
+    if (
+      input.liveCells !== undefined &&
+      hashTemplateCells(input.liveCells) !== template.cellsHash
+    ) {
+      throw new Error(
+        `notebook cells have drifted from template ${template.templateId} ` +
+          `version ${template.version} pinned by instance ${input.instanceId}; ` +
+          `start a new run to version the current cells`,
+      );
+    }
+
+    const executions = await this.storage.listCellExecutions(input.instanceId);
+    assertCellExecutable(template, executions, input.cellId);
+    const templateCell = template.cells.find((cell) => cell.cellId === input.cellId)!;
+    if (templateCell.validatorFor !== undefined) {
+      throw new Error(
+        `cell ${input.cellId} is a tier-2 validator for ${templateCell.validatorFor}; ` +
+          `validator cells evaluate during batch runs (notebook_start_run) — ` +
+          `single-cell instance execution does not retain the target's structured output`,
+      );
+    }
+
+    const startedAt = new Date().toISOString();
+    const result = await input.executeCell(input.cellId);
+    const records: ExpectationRecord[] =
+      templateCell.contract !== undefined
+        ? templateCell.contract.contract.expectations.map((expectation) =>
+            evaluateExpectation(expectation, {
+              cellId: input.cellId,
+              cellStatus: result.status,
+              exitCode: result.exitCode,
+              ...(result.structuredOutput !== undefined
+                ? { structuredOutputRaw: result.structuredOutput }
+                : {}),
+              ...(this.claimResolver !== undefined
+                ? { claimResolver: this.claimResolver }
+                : {}),
+            }),
+          )
+        : [];
+    const record: CellExecutionRecord = {
+      instanceId: input.instanceId,
+      seq: (executions[executions.length - 1]?.seq ?? 0) + 1,
+      cellId: input.cellId,
+      startedAt,
+      agentId: this.agentId,
+      // Single-cell advances carry no run inputs; the digest pins that fact.
+      inputsDigest: hashJson({}),
+      status: result.status,
+      expectations: records,
+    };
+    await this.storage.appendCellExecution(record);
+    await this.storage.appendFitnessRows(
+      this.ledgerRowsFromRecords(template, input.instanceId, records),
+    );
+
+    const after = [...executions, record];
+    return {
+      instanceId: input.instanceId,
+      cellId: input.cellId,
+      seq: record.seq,
+      status: result.status,
+      satisfied: isExecutionSatisfied(record),
+      expectations: records,
+      instanceStatus: deriveInstanceStatus(template, after),
+      nextCellId: nextUnsatisfiedCell(template, after),
+      execution: {
+        exitCode: result.exitCode,
+        stdout: result.stdout,
+        stderr: result.stderr,
+      },
+    };
+  }
+
+  /**
+   * Run-start durable persistence (B5): resolve the template version for the
+   * current cells (reuse when the canonical hash matches, append otherwise)
+   * and create the instance pinning it — BEFORE any cell executes, so the
+   * instance exists even when the run dies mid-way.
+   */
+  private async beginDurableRun(args: {
+    runId: string;
+    notebookId: string;
+    startedAt: string;
+    inputs: Record<string, unknown>;
+    cells: RunbookTemplateCell[];
+  }): Promise<DurableRunContext> {
+    const { runId, notebookId, startedAt, inputs, cells } = args;
+    const template = await this.ensureTemplateVersion(notebookId, cells);
+    await this.storage.createInstance({
+      instanceId: runId,
+      templateId: notebookId,
+      templateVersion: template.version,
+      createdBy: this.agentId,
+      createdAt: startedAt,
+    });
+    return {
+      instanceId: runId,
+      template,
+      inputsDigest: hashJson(inputs),
+      nextSeq: 1,
+      executions: [],
+      recordsByCell: new Map(),
+      gatedCellIds: new Set(),
+    };
+  }
+
+  private async ensureTemplateVersion(
+    templateId: string,
+    cells: RunbookTemplateCell[],
+  ): Promise<RunbookTemplate> {
+    const cellsHash = hashTemplateCells(cells);
+    const latest = await this.storage.getLatestTemplate(templateId);
+    if (latest && latest.cellsHash === cellsHash) return latest;
+    const template: RunbookTemplate = {
+      templateId,
+      version: (latest?.version ?? 0) + 1,
+      cells,
+      cellsHash,
+      createdBy: this.agentId,
+      createdAt: new Date().toISOString(),
+    };
+    await this.storage.saveTemplate(template);
+    return template;
+  }
+
+  /**
+   * The per-cell gate (B5): enforces document-order execution against the
+   * accumulating instance records, evaluates the cell's declared
+   * expectations (tier 2 from the executor, tier 1 from the attached
+   * contract), persists the execution record and its ledger rows
+   * immediately, and derives the continue/halt disposition from the B5
+   * satisfaction rule. Gated records omit `outputsRef` — the cell-results
+   * artifact does not exist yet when a record is appended.
+   */
+  private createCellGate(
+    durable: DurableRunContext,
+    preArtifacts: ArtifactRef[],
+  ): CellExecutionGate {
+    return async (evidence) => {
+      assertCellExecutable(durable.template, durable.executions, evidence.cellId);
+      const records = evaluateEvidenceExpectations(evidence, {
+        readArtifact: (name) => this.readRunArtifact(preArtifacts, name),
+        claimResolver: this.claimResolver,
+      });
+      const record: CellExecutionRecord = {
+        instanceId: durable.instanceId,
+        seq: durable.nextSeq,
+        cellId: evidence.cellId,
+        startedAt: new Date().toISOString(),
+        agentId: this.agentId,
+        inputsDigest: durable.inputsDigest,
+        status: evidence.status,
+        expectations: records,
+      };
+      try {
+        await this.storage.appendCellExecution(record);
+        await this.storage.appendFitnessRows(
+          this.ledgerRowsFromRecords(durable.template, durable.instanceId, records),
+        );
+      } catch (cause) {
+        throw new RunbookPersistenceError(
+          `durable cell-execution persistence failed for cell ${evidence.cellId} ` +
+            `(seq ${record.seq}): ${errorMessage(cause)}`,
+        );
+      }
+      durable.nextSeq += 1;
+      durable.executions.push(record);
+      durable.gatedCellIds.add(evidence.cellId);
+      if (records.length > 0) durable.recordsByCell.set(evidence.cellId, records);
+      return {
+        records,
+        disposition: isExecutionSatisfied(record) ? "continue" : "halt",
+      };
+    };
+  }
+
+  /**
+   * Run-end durable persistence for a gated run: the gate already wrote
+   * executed cells' records and rows, so only ledger rows for cells the run
+   * never reached (skipped expectations) remain.
+   */
+  private async finishDurableRun(
+    durable: DurableRunContext,
+    allRecords: ExpectationRecord[],
+  ): Promise<void> {
+    const remaining = allRecords.filter(
+      (record) => !durable.gatedCellIds.has(record.cellId),
+    );
+    await this.storage.appendFitnessRows(
+      this.ledgerRowsFromRecords(durable.template, durable.instanceId, remaining),
+    );
+  }
+
+  /**
+   * Legacy run-end persistence for raw runtime usage (no templateCellSource):
+   * template version derived from evidence, instance created after the run,
+   * one record per EXECUTED cell (skipped cells leave no record since B5),
+   * and all ledger rows at once.
    */
   private async persistDurableRecords(args: {
     runId: string;
@@ -347,30 +694,13 @@ export class InMemoryNotebookEngineRuntime {
     outputsRef: string;
   }): Promise<void> {
     const { runId, notebookId, startedAt, inputs, evidence, records, outputsRef } = args;
-    const cells =
-      this.templateCellSource?.(notebookId) ?? templateCellsFromEvidence(evidence);
-    const cellsHash = hashTemplateCells(cells);
-
-    const latest = await this.storage.getLatestTemplate(notebookId);
-    let templateVersion: number;
-    if (latest && latest.cellsHash === cellsHash) {
-      templateVersion = latest.version;
-    } else {
-      templateVersion = (latest?.version ?? 0) + 1;
-      await this.storage.saveTemplate({
-        templateId: notebookId,
-        version: templateVersion,
-        cells,
-        cellsHash,
-        createdBy: this.agentId,
-        createdAt: new Date().toISOString(),
-      });
-    }
+    const cells = templateCellsFromEvidence(evidence);
+    const template = await this.ensureTemplateVersion(notebookId, cells);
 
     await this.storage.createInstance({
       instanceId: runId,
       templateId: notebookId,
-      templateVersion,
+      templateVersion: template.version,
       createdBy: this.agentId,
       createdAt: startedAt,
     });
@@ -383,10 +713,13 @@ export class InMemoryNotebookEngineRuntime {
     }
 
     const inputsDigest = hashJson(inputs);
-    for (const [index, cell] of evidence.entries()) {
+    let seq = 0;
+    for (const cell of evidence) {
+      if (cell.status === "skipped") continue;
+      seq += 1;
       await this.storage.appendCellExecution({
         instanceId: runId,
-        seq: index + 1,
+        seq,
         cellId: cell.cellId,
         startedAt,
         agentId: this.agentId,
@@ -397,11 +730,22 @@ export class InMemoryNotebookEngineRuntime {
       });
     }
 
+    await this.storage.appendFitnessRows(
+      this.ledgerRowsFromRecords(template, runId, records),
+    );
+  }
+
+  /** One ledger row per machine-checked expectation evaluation (spec §7). */
+  private ledgerRowsFromRecords(
+    template: Pick<RunbookTemplate, "templateId" | "version">,
+    instanceId: string,
+    records: ExpectationRecord[],
+  ): FitnessLedgerRow[] {
     const ts = new Date().toISOString();
-    const ledgerRows: FitnessLedgerRow[] = records.map((record) => ({
-      templateId: notebookId,
-      templateVersion,
-      instanceId: runId,
+    return records.map((record) => ({
+      templateId: template.templateId,
+      templateVersion: template.version,
+      instanceId,
       cellId: record.cellId,
       tier: record.tier,
       result: record.result,
@@ -412,7 +756,6 @@ export class InMemoryNotebookEngineRuntime {
       agentId: this.agentId,
       ts,
     }));
-    await this.storage.appendFitnessRows(ledgerRows);
   }
 
   /**
@@ -442,9 +785,54 @@ export class InMemoryNotebookEngineRuntime {
   }
 }
 
+function errorMessage(cause: unknown): string {
+  return cause instanceof Error ? cause.message : String(cause);
+}
+
 interface VerdictDerivationContext {
   readArtifact: (name: string) => string | undefined;
   claimResolver?: ClaimStatusResolver;
+  /**
+   * Expectation records already evaluated (and persisted) by the per-cell
+   * gate (B5). Authoritative for those cells — the verdict derivation must
+   * not re-evaluate them, or ledger and verdict could diverge.
+   */
+  precomputedRecords?: Map<string, ExpectationRecord[]>;
+}
+
+/**
+ * Evaluate every declared expectation for one piece of cell evidence:
+ * tier-2 records pre-computed by the executor's validator machinery, then
+ * tier-1 records from the attached outcome contract. Shared by the per-cell
+ * gate (halt decisions) and the verdict derivation (ungated cells).
+ */
+function evaluateEvidenceExpectations(
+  cell: CellExecutionEvidence,
+  context: Pick<VerdictDerivationContext, "readArtifact" | "claimResolver">,
+): ExpectationRecord[] {
+  const records: ExpectationRecord[] = [];
+  if (cell.expectations) {
+    records.push(...cell.expectations);
+  }
+  if (cell.contract) {
+    for (const expectation of cell.contract.contract.expectations) {
+      records.push(
+        evaluateExpectation(expectation, {
+          cellId: cell.cellId,
+          cellStatus: cell.status,
+          exitCode: cell.exitCode,
+          ...(cell.structuredOutput !== undefined
+            ? { structuredOutputRaw: cell.structuredOutput }
+            : {}),
+          readArtifact: context.readArtifact,
+          ...(context.claimResolver !== undefined
+            ? { claimResolver: context.claimResolver }
+            : {}),
+        }),
+      );
+    }
+  }
+  return records;
 }
 
 /**
@@ -453,8 +841,11 @@ interface VerdictDerivationContext {
  *
  * With declared expectations (tier-1 contracts or tier-2 validators), the
  * verdict passes iff every declared expectation was evaluated and passed AND
- * no cell failed procedurally — `skipped` and `error` expectations are never
- * pass, and a crashed cell still fails the run.
+ * no cell failed procedurally without being expectation-satisfied — a cell
+ * that exits nonzero but whose every declared expectation passes is a
+ * predicted failure and does not fail the run (§5.1 expected-failure rule,
+ * B5); `skipped` and `error` expectations are never pass, and an
+ * uncontracted crashed cell still fails the run.
  *
  * With ZERO declared expectations, the legacy procedural derivation applies
  * unchanged, but the verdict carries contractCoverage 0 and a reason marking
@@ -476,30 +867,14 @@ function buildRunbookVerdict(
   const coveredCellIds = new Set<string>();
 
   for (const cell of evidence) {
-    const cellRecords: ExpectationRecord[] = [];
-    if (cell.expectations) {
-      // Tier 2 — pre-computed by the executor's validator machinery.
-      cellRecords.push(...cell.expectations);
-      if (cell.validatorFor !== undefined) coveredCellIds.add(cell.validatorFor);
+    const cellRecords =
+      context.precomputedRecords?.get(cell.cellId) ??
+      evaluateEvidenceExpectations(cell, context);
+    if (cell.expectations && cell.validatorFor !== undefined) {
+      coveredCellIds.add(cell.validatorFor);
     }
     if (cell.contract) {
       coveredCellIds.add(cell.cellId);
-      for (const expectation of cell.contract.contract.expectations) {
-        cellRecords.push(
-          evaluateExpectation(expectation, {
-            cellId: cell.cellId,
-            cellStatus: cell.status,
-            exitCode: cell.exitCode,
-            ...(cell.structuredOutput !== undefined
-              ? { structuredOutputRaw: cell.structuredOutput }
-              : {}),
-            readArtifact: context.readArtifact,
-            ...(context.claimResolver !== undefined
-              ? { claimResolver: context.claimResolver }
-              : {}),
-          }),
-        );
-      }
     }
     if (cellRecords.length > 0) {
       recordsByCell.set(cell.cellId, cellRecords);
@@ -516,7 +891,20 @@ function buildRunbookVerdict(
       : subjectCodeCells.filter((cell) => coveredCellIds.has(cell.cellId)).length /
         subjectCodeCells.length;
 
-  const failed = evidence.filter((cell) => cell.status === "failed");
+  // §5.1 expected-failure rule (B5): a failed cell whose every declared
+  // expectation passed is expectation-satisfied and does not fail the run.
+  const isPredictedFailure = (cell: CellExecutionEvidence): boolean => {
+    if (cell.status !== "failed") return false;
+    const cellRecords = recordsByCell.get(cell.cellId);
+    return (
+      cellRecords !== undefined &&
+      cellRecords.length > 0 &&
+      cellRecords.every((record) => record.result === "pass")
+    );
+  };
+  const failed = evidence.filter(
+    (cell) => cell.status === "failed" && !isPredictedFailure(cell),
+  );
   const completedCode = evidence.filter(
     (cell) => cell.status === "completed" && cell.cellType === "code",
   );

--- a/src/notebook/engine/runtime.ts
+++ b/src/notebook/engine/runtime.ts
@@ -68,6 +68,8 @@ export interface CellExecutionEvidence {
   cellId: string;
   cellType: "code" | "package.json";
   filename: string;
+  /** ISO timestamp captured when the cell's execution began; absent for skipped cells. */
+  startedAt?: string;
   status: "completed" | "failed" | "skipped";
   exitCode: number | null;
   output: string;
@@ -92,16 +94,26 @@ export interface CellGateResult {
 
 /**
  * Per-cell gate the runtime hands to the executor (SPEC-AGX-SUBSTRATE B5).
- * Called once after each cell actually executes (never for skipped cells).
- * It enforces document-order execution, evaluates the cell's declared
- * expectations, persists the durable execution record and its ledger rows
- * immediately (partial-run durability), and decides whether the run
- * continues: an expectation-satisfied predicted failure continues; an
- * uncontracted failure or failed/errored expectations halt.
+ *
+ * The executor calls `assertExecutable` BEFORE a cell runs — document-order
+ * enforcement happens pre-execution, so a rejected cell never executes and
+ * an ordering failure can never drop an already-executed cell's durable
+ * record — and `record` once after the cell actually executes (never for
+ * skipped cells). `record` evaluates the cell's declared expectations,
+ * persists the durable execution record and its ledger rows immediately
+ * (partial-run durability), and decides whether the run continues: an
+ * expectation-satisfied predicted failure continues; an uncontracted
+ * failure or failed/errored expectations halt.
  */
-export type CellExecutionGate = (
-  evidence: CellExecutionEvidence,
-) => Promise<CellGateResult>;
+export interface CellExecutionGate {
+  /**
+   * Pre-execution ordering check (spec §5): throws OutOfOrderExecutionError
+   * naming the expected next cell, or a plain Error when the cell is not
+   * part of the pinned template.
+   */
+  assertExecutable(cellId: string): void;
+  record(evidence: CellExecutionEvidence): Promise<CellGateResult>;
+}
 
 /**
  * Executes a notebook's executable cells in document order and reports
@@ -527,7 +539,9 @@ export class InMemoryNotebookEngineRuntime {
         : [];
     const record: CellExecutionRecord = {
       instanceId: input.instanceId,
-      seq: (executions[executions.length - 1]?.seq ?? 0) + 1,
+      // Explicit max over recorded seqs — never an implicit dependency on
+      // the storage backend's sort order.
+      seq: executions.reduce((max, prior) => Math.max(max, prior.seq), 0) + 1,
       cellId: input.cellId,
       startedAt,
       agentId: this.agentId,
@@ -600,53 +614,61 @@ export class InMemoryNotebookEngineRuntime {
   }
 
   /**
-   * The per-cell gate (B5): enforces document-order execution against the
-   * accumulating instance records, evaluates the cell's declared
-   * expectations (tier 2 from the executor, tier 1 from the attached
-   * contract), persists the execution record and its ledger rows
-   * immediately, and derives the continue/halt disposition from the B5
-   * satisfaction rule. Gated records omit `outputsRef` — the cell-results
-   * artifact does not exist yet when a record is appended.
+   * The per-cell gate (B5). `assertExecutable` enforces document-order
+   * execution against the accumulating instance records BEFORE a cell runs
+   * (a rejection can therefore never drop an executed cell's record).
+   * `record` evaluates the cell's declared expectations (tier 2 from the
+   * executor, tier 1 from the attached contract), persists the execution
+   * record and its ledger rows immediately, and derives the continue/halt
+   * disposition from the B5 satisfaction rule. Gated records omit
+   * `outputsRef` — the cell-results artifact does not exist yet when a
+   * record is appended.
    */
   private createCellGate(
     durable: DurableRunContext,
     preArtifacts: ArtifactRef[],
   ): CellExecutionGate {
-    return async (evidence) => {
-      assertCellExecutable(durable.template, durable.executions, evidence.cellId);
-      const records = evaluateEvidenceExpectations(evidence, {
-        readArtifact: (name) => this.readRunArtifact(preArtifacts, name),
-        claimResolver: this.claimResolver,
-      });
-      const record: CellExecutionRecord = {
-        instanceId: durable.instanceId,
-        seq: durable.nextSeq,
-        cellId: evidence.cellId,
-        startedAt: new Date().toISOString(),
-        agentId: this.agentId,
-        inputsDigest: durable.inputsDigest,
-        status: evidence.status,
-        expectations: records,
-      };
-      try {
-        await this.storage.appendCellExecution(record);
-        await this.storage.appendFitnessRows(
-          this.ledgerRowsFromRecords(durable.template, durable.instanceId, records),
-        );
-      } catch (cause) {
-        throw new RunbookPersistenceError(
-          `durable cell-execution persistence failed for cell ${evidence.cellId} ` +
-            `(seq ${record.seq}): ${errorMessage(cause)}`,
-        );
-      }
-      durable.nextSeq += 1;
-      durable.executions.push(record);
-      durable.gatedCellIds.add(evidence.cellId);
-      if (records.length > 0) durable.recordsByCell.set(evidence.cellId, records);
-      return {
-        records,
-        disposition: isExecutionSatisfied(record) ? "continue" : "halt",
-      };
+    return {
+      assertExecutable: (cellId) => {
+        assertCellExecutable(durable.template, durable.executions, cellId);
+      },
+      record: async (evidence) => {
+        const records = evaluateEvidenceExpectations(evidence, {
+          readArtifact: (name) => this.readRunArtifact(preArtifacts, name),
+          claimResolver: this.claimResolver,
+        });
+        const record: CellExecutionRecord = {
+          instanceId: durable.instanceId,
+          seq: durable.nextSeq,
+          cellId: evidence.cellId,
+          // Executor-captured execution start; the gate-time fallback covers
+          // executors that report no startedAt (it post-dates the execution).
+          startedAt: evidence.startedAt ?? new Date().toISOString(),
+          agentId: this.agentId,
+          inputsDigest: durable.inputsDigest,
+          status: evidence.status,
+          expectations: records,
+        };
+        try {
+          await this.storage.appendCellExecution(record);
+          await this.storage.appendFitnessRows(
+            this.ledgerRowsFromRecords(durable.template, durable.instanceId, records),
+          );
+        } catch (cause) {
+          throw new RunbookPersistenceError(
+            `durable cell-execution persistence failed for cell ${evidence.cellId} ` +
+              `(seq ${record.seq}): ${errorMessage(cause)}`,
+          );
+        }
+        durable.nextSeq += 1;
+        durable.executions.push(record);
+        durable.gatedCellIds.add(evidence.cellId);
+        if (records.length > 0) durable.recordsByCell.set(evidence.cellId, records);
+        return {
+          records,
+          disposition: isExecutionSatisfied(record) ? "continue" : "halt",
+        };
+      },
     };
   }
 
@@ -719,7 +741,9 @@ export class InMemoryNotebookEngineRuntime {
         instanceId: runId,
         seq,
         cellId: cell.cellId,
-        startedAt,
+        // Per-cell execution start when the executor reported one; the run
+        // start is the legacy-path fallback.
+        startedAt: cell.startedAt ?? startedAt,
         agentId: this.agentId,
         inputsDigest,
         outputsRef,

--- a/src/notebook/engine/runtime.ts
+++ b/src/notebook/engine/runtime.ts
@@ -21,6 +21,7 @@ import {
   type AttachedContract,
   type ClaimStatusResolver,
   type ExpectationRecord,
+  type OutcomeExpectation,
 } from "../contracts.js";
 import {
   hashTemplateCells,
@@ -660,10 +661,21 @@ export class InMemoryNotebookEngineRuntime {
         assertCellExecutable(durable.template, durable.executions, cellId);
       },
       record: async (evidence) => {
-        const records = evaluateEvidenceExpectations(evidence, {
-          readArtifact: (name) => this.readRunArtifact(preArtifacts, name),
-          claimResolver: this.claimResolver,
-        });
+        // The gate runs mid-execution with only pre-run artifacts (inputs).
+        // Defer artifact-backed expectations to the verdict, where the
+        // post-run cell-results artifact exists — evaluating them here would
+        // always error ("run artifact not found") and wrongly halt/fail an
+        // otherwise valid run (Codex PR #402, P2). They do not gate the
+        // mid-run halt decision and are not persisted to the durable record
+        // or the fitness ledger; they contribute to the final verdict only.
+        const records = evaluateEvidenceExpectations(
+          evidence,
+          {
+            readArtifact: (name) => this.readRunArtifact(preArtifacts, name),
+            claimResolver: this.claimResolver,
+          },
+          { tier1Filter: (expectation) => expectation.source.kind !== "artifact" },
+        );
         const record: CellExecutionRecord = {
           instanceId: durable.instanceId,
           seq: durable.nextSeq,
@@ -843,8 +855,11 @@ interface VerdictDerivationContext {
   claimResolver?: ClaimStatusResolver;
   /**
    * Expectation records already evaluated (and persisted) by the per-cell
-   * gate (B5). Authoritative for those cells — the verdict derivation must
-   * not re-evaluate them, or ledger and verdict could diverge.
+   * gate (B5): tier-2 and non-artifact tier-1. Authoritative for those —
+   * the verdict must not re-evaluate them, or ledger and verdict could
+   * diverge. The gate could not see post-run artifacts, so artifact-backed
+   * tier-1 expectations are deferred; the verdict evaluates those alone (with
+   * the full run artifacts) and appends them to the precomputed set.
    */
   precomputedRecords?: Map<string, ExpectationRecord[]>;
 }
@@ -858,13 +873,20 @@ interface VerdictDerivationContext {
 function evaluateEvidenceExpectations(
   cell: CellExecutionEvidence,
   context: Pick<VerdictDerivationContext, "readArtifact" | "claimResolver">,
+  options?: {
+    /** Only tier-1 contract expectations matching this predicate are evaluated. */
+    tier1Filter?: (expectation: OutcomeExpectation) => boolean;
+    /** Include tier-2 validator records (default true). */
+    includeTier2?: boolean;
+  },
 ): ExpectationRecord[] {
   const records: ExpectationRecord[] = [];
-  if (cell.expectations) {
+  if (cell.expectations && options?.includeTier2 !== false) {
     records.push(...cell.expectations);
   }
   if (cell.contract) {
     for (const expectation of cell.contract.contract.expectations) {
+      if (options?.tier1Filter && !options.tier1Filter(expectation)) continue;
       records.push(
         evaluateExpectation(expectation, {
           cellId: cell.cellId,
@@ -916,9 +938,23 @@ function buildRunbookVerdict(
   const coveredCellIds = new Set<string>();
 
   for (const cell of evidence) {
+    const precomputed = context.precomputedRecords?.get(cell.cellId);
+    // Precomputed gate records cover tier-2 and non-artifact tier-1 (the gate
+    // could not see post-run artifacts). Evaluate the deferred artifact-backed
+    // expectations now, with the full run artifacts available, and merge —
+    // so an artifact assertion participates in the verdict instead of erroring
+    // (Codex PR #402, P2). Cells without precomputed records (non-durable
+    // runs) are evaluated whole here, where every artifact already exists.
     const cellRecords =
-      context.precomputedRecords?.get(cell.cellId) ??
-      evaluateEvidenceExpectations(cell, context);
+      precomputed !== undefined
+        ? [
+            ...precomputed,
+            ...evaluateEvidenceExpectations(cell, context, {
+              tier1Filter: (expectation) => expectation.source.kind === "artifact",
+              includeTier2: false,
+            }),
+          ]
+        : evaluateEvidenceExpectations(cell, context);
     if (cell.expectations && cell.validatorFor !== undefined) {
       coveredCellIds.add(cell.validatorFor);
     }

--- a/src/notebook/engine/runtime.ts
+++ b/src/notebook/engine/runtime.ts
@@ -573,7 +573,14 @@ export class InMemoryNotebookEngineRuntime {
     cells: RunbookTemplateCell[];
   }): Promise<DurableRunContext> {
     const { runId, notebookId, startedAt, inputs, cells } = args;
-    const template = await this.ensureTemplateVersion(notebookId, cells);
+    // Concurrency-safe: a lost saveTemplate race against a concurrent run of
+    // the same notebook reuses the winner's just-written version instead of
+    // failing this run (Greptile PR #401 — TOCTOU in template versioning).
+    const template = await ensureTemplateVersion(this.storage, {
+      templateId: notebookId,
+      cells,
+      createdBy: this.agentId,
+    });
     await this.storage.createInstance({
       instanceId: runId,
       templateId: notebookId,
@@ -590,25 +597,6 @@ export class InMemoryNotebookEngineRuntime {
       recordsByCell: new Map(),
       gatedCellIds: new Set(),
     };
-  }
-
-  private async ensureTemplateVersion(
-    templateId: string,
-    cells: RunbookTemplateCell[],
-  ): Promise<RunbookTemplate> {
-    const cellsHash = hashTemplateCells(cells);
-    const latest = await this.storage.getLatestTemplate(templateId);
-    if (latest && latest.cellsHash === cellsHash) return latest;
-    const template: RunbookTemplate = {
-      templateId,
-      version: (latest?.version ?? 0) + 1,
-      cells,
-      cellsHash,
-      createdBy: this.agentId,
-      createdAt: new Date().toISOString(),
-    };
-    await this.storage.saveTemplate(template);
-    return template;
   }
 
   /**

--- a/src/notebook/index.ts
+++ b/src/notebook/index.ts
@@ -13,6 +13,7 @@ import {
 import {
   InMemoryNotebookEngineRuntime,
   type CellExecutionEvidence,
+  type CellExecutionGate,
 } from "./engine/runtime.js";
 import { templateCellsFromNotebook, type RunbookStorage } from "./runbook/types.js";
 import { getNotebookCapabilitiesJson } from "./engine/registry.js";
@@ -51,7 +52,7 @@ export class NotebookHandler {
     this.stateManager = new NotebookStateManager(tempDir);
     this.validatorService = new ValidatorService(this.stateManager);
     this.engineRuntime = new InMemoryNotebookEngineRuntime(
-      (notebookId) => this.executeAllCells(notebookId),
+      (notebookId, gate) => this.executeAllCells(notebookId, gate),
       undefined,
       {
         ...(options.runbookStorage !== undefined
@@ -73,19 +74,25 @@ export class NotebookHandler {
 
   /**
    * Execute every executable cell (package.json installs and code cells) in
-   * document order through the real subprocess execution path, stopping at
-   * the first failure; remaining executable cells are reported as skipped.
+   * document order through the real subprocess execution path, halting per
+   * the B5 rule; cells after the halt are reported as skipped.
    *
-   * Outcome-contract integration (SPEC-AGX-SUBSTRATE B4a):
+   * Outcome-contract integration (SPEC-AGX-SUBSTRATE B4a + B5):
    * - Before anything executes, every attached tier-1 contract hash is
    *   re-verified (Ulysses pattern); a mismatch throws and rejects the run.
    * - Cells with `validatorFor` are tier-2 assertion cells: they run through
    *   the existing ValidatorService (snapshot+hash, sidecar verdict) against
    *   the target cell's structured output instead of executing as steps.
-   *   Assertion cells record verdicts but never halt later cells.
+   * - After each executed cell, the runtime's gate evaluates its declared
+   *   expectations, persists the durable record, and decides the halt: an
+   *   expectation-satisfied predicted failure (nonzero exit, every declared
+   *   expectation passes) CONTINUES; uncontracted failures and cells whose
+   *   expectations fail or error halt — including unsatisfied assertion
+   *   cells (§5 ordering: later cells cannot run past an unsatisfied cell).
    */
   private async executeAllCells(
     notebookId: string,
+    gate?: CellExecutionGate,
   ): Promise<CellExecutionEvidence[]> {
     const notebook = this.stateManager.getNotebook(notebookId);
     if (!notebook) {
@@ -105,10 +112,10 @@ export class NotebookHandler {
 
     const evidence: CellExecutionEvidence[] = [];
     const structuredOutputByCell = new Map<string, string>();
-    let failed = false;
+    let halted = false;
     for (const cell of executable) {
       const validatorFor = cell.type === "code" ? cell.validatorFor : undefined;
-      if (failed) {
+      if (halted) {
         evidence.push({
           cellId: cell.id,
           cellType: cell.type,
@@ -129,32 +136,42 @@ export class NotebookHandler {
         });
         continue;
       }
+      let cellEvidence: CellExecutionEvidence;
       if (cell.type === "code" && validatorFor !== undefined) {
-        evidence.push(
-          await this.runValidatorCell(notebookId, cell, structuredOutputByCell),
+        cellEvidence = await this.runValidatorCell(
+          notebookId,
+          cell,
+          structuredOutputByCell,
         );
-        continue;
+      } else {
+        const result = await this.stateManager.executeCell(notebookId, cell.id);
+        if (cell.type === "code" && result.structuredOutput !== undefined) {
+          structuredOutputByCell.set(cell.id, result.structuredOutput);
+        }
+        cellEvidence = {
+          cellId: cell.id,
+          cellType: cell.type,
+          filename: cell.filename,
+          status: result.success ? "completed" : "failed",
+          exitCode: result.exitCode,
+          output: result.stdout,
+          error: result.stderr,
+          ...(result.structuredOutput !== undefined
+            ? { structuredOutput: result.structuredOutput }
+            : {}),
+          ...(cell.type === "code" && cell.contract !== undefined
+            ? { contract: cell.contract }
+            : {}),
+        };
       }
-      const result = await this.stateManager.executeCell(notebookId, cell.id);
-      if (cell.type === "code" && result.structuredOutput !== undefined) {
-        structuredOutputByCell.set(cell.id, result.structuredOutput);
+      evidence.push(cellEvidence);
+      if (gate) {
+        const { disposition } = await gate(cellEvidence);
+        if (disposition === "halt") halted = true;
+      } else if (validatorFor === undefined && cellEvidence.status === "failed") {
+        // Ungated fallback (raw runtime usage): halt on procedural failure.
+        halted = true;
       }
-      evidence.push({
-        cellId: cell.id,
-        cellType: cell.type,
-        filename: cell.filename,
-        status: result.success ? "completed" : "failed",
-        exitCode: result.exitCode,
-        output: result.stdout,
-        error: result.stderr,
-        ...(result.structuredOutput !== undefined
-          ? { structuredOutput: result.structuredOutput }
-          : {}),
-        ...(cell.type === "code" && cell.contract !== undefined
-          ? { contract: cell.contract }
-          : {}),
-      });
-      if (!result.success) failed = true;
     }
     return evidence;
   }
@@ -525,10 +542,11 @@ export class NotebookHandler {
   }
 
   /**
-   * Handle notebook_run_cell tool call
+   * Handle notebook_run_cell tool call. With `instanceId`, execution is
+   * instance-aware: ordered per the pinned template (B5).
    */
   async handleRunCell(args: any): Promise<any> {
-    const { notebookId, cellId } = args;
+    const { notebookId, cellId, instanceId } = args;
 
     if (!notebookId || typeof notebookId !== "string") {
       throw new Error("notebookId is required and must be a string");
@@ -536,6 +554,13 @@ export class NotebookHandler {
 
     if (!cellId || typeof cellId !== "string") {
       throw new Error("cellId is required and must be a string");
+    }
+
+    if (instanceId !== undefined) {
+      if (typeof instanceId !== "string" || instanceId.length === 0) {
+        throw new Error("instanceId must be a non-empty string if provided");
+      }
+      return await this.runInstanceCell(notebookId, cellId, instanceId);
     }
 
     const result = await this.stateManager.executeCell(notebookId, cellId);
@@ -547,6 +572,61 @@ export class NotebookHandler {
         stderr: result.stderr,
         exitCode: result.exitCode,
         success: result.success,
+      },
+    };
+  }
+
+  /**
+   * Instance-aware single-cell execution (SPEC-AGX-SUBSTRATE B5 — spec §5
+   * "Ordering"). Only the next unsatisfied cell of the pinned template may
+   * execute; out-of-order attempts throw OutOfOrderExecutionError naming the
+   * expected next cell. The execution appends an immutable record and its
+   * ledger rows; `success` reports B5 satisfaction, so an expectation-
+   * satisfied predicted failure is a success.
+   */
+  private async runInstanceCell(
+    notebookId: string,
+    cellId: string,
+    instanceId: string,
+  ): Promise<any> {
+    const notebook = this.stateManager.getNotebook(notebookId);
+    if (!notebook) {
+      throw new Error(`Notebook ${notebookId} not found`);
+    }
+    const result = await this.engineRuntime.executeInstanceCell({
+      instanceId,
+      cellId,
+      expectedTemplateId: notebookId,
+      liveCells: templateCellsFromNotebook(notebook),
+      executeCell: async (id) => {
+        const execution = await this.stateManager.executeCell(notebookId, id);
+        return {
+          status: execution.success ? ("completed" as const) : ("failed" as const),
+          exitCode: execution.exitCode,
+          stdout: execution.stdout,
+          stderr: execution.stderr,
+          ...(execution.structuredOutput !== undefined
+            ? { structuredOutput: execution.structuredOutput }
+            : {}),
+        };
+      },
+    });
+    return {
+      success: result.satisfied,
+      execution: {
+        stdout: result.execution.stdout,
+        stderr: result.execution.stderr,
+        exitCode: result.execution.exitCode,
+        success: result.status === "completed",
+      },
+      instance: {
+        instanceId: result.instanceId,
+        seq: result.seq,
+        cellId: result.cellId,
+        satisfied: result.satisfied,
+        status: result.instanceStatus,
+        nextCellId: result.nextCellId,
+        expectations: result.expectations,
       },
     };
   }

--- a/src/notebook/index.ts
+++ b/src/notebook/index.ts
@@ -83,6 +83,9 @@ export class NotebookHandler {
    * - Cells with `validatorFor` are tier-2 assertion cells: they run through
    *   the existing ValidatorService (snapshot+hash, sidecar verdict) against
    *   the target cell's structured output instead of executing as steps.
+   * - Before each cell runs, the runtime gate's ordering assertion fires
+   *   (§5: a rejected cell never executes) and the execution start time is
+   *   captured onto the evidence for the durable record.
    * - After each executed cell, the runtime's gate evaluates its declared
    *   expectations, persists the durable record, and decides the halt: an
    *   expectation-satisfied predicted failure (nonzero exit, every declared
@@ -136,13 +139,17 @@ export class NotebookHandler {
         });
         continue;
       }
+      // Ordering is enforced BEFORE the cell runs (spec §5): a rejected cell
+      // never executes, so an ordering failure cannot drop the durable
+      // record of a cell that already ran.
+      gate?.assertExecutable(cell.id);
+      const startedAt = new Date().toISOString();
       let cellEvidence: CellExecutionEvidence;
       if (cell.type === "code" && validatorFor !== undefined) {
-        cellEvidence = await this.runValidatorCell(
-          notebookId,
-          cell,
-          structuredOutputByCell,
-        );
+        cellEvidence = {
+          ...(await this.runValidatorCell(notebookId, cell, structuredOutputByCell)),
+          startedAt,
+        };
       } else {
         const result = await this.stateManager.executeCell(notebookId, cell.id);
         if (cell.type === "code" && result.structuredOutput !== undefined) {
@@ -152,6 +159,7 @@ export class NotebookHandler {
           cellId: cell.id,
           cellType: cell.type,
           filename: cell.filename,
+          startedAt,
           status: result.success ? "completed" : "failed",
           exitCode: result.exitCode,
           output: result.stdout,
@@ -166,7 +174,7 @@ export class NotebookHandler {
       }
       evidence.push(cellEvidence);
       if (gate) {
-        const { disposition } = await gate(cellEvidence);
+        const { disposition } = await gate.record(cellEvidence);
         if (disposition === "halt") halted = true;
       } else if (validatorFor === undefined && cellEvidence.status === "failed") {
         // Ungated fallback (raw runtime usage): halt on procedural failure.

--- a/src/notebook/operations.ts
+++ b/src/notebook/operations.ts
@@ -184,7 +184,12 @@ Both approaches create an identical in-memory notebook.`,
   {
     name: "notebook_run_cell",
     title: "Run Cell",
-    description: "Execute a code cell and capture output (stdout, stderr, exit code)",
+    description:
+      "Execute a code cell and capture output (stdout, stderr, exit code). " +
+      "With instanceId, execution is instance-aware and ordered: only the next " +
+      "unsatisfied cell of the pinned runbook template may run (out-of-order " +
+      "execution is rejected naming the expected next cell), and the execution " +
+      "appends an immutable record plus fitness ledger rows.",
     category: "execution",
     inputSchema: {
       type: "object",
@@ -196,6 +201,12 @@ Both approaches create an identical in-memory notebook.`,
         cellId: {
           type: "string",
           description: "Cell ID to execute",
+        },
+        instanceId: {
+          type: "string",
+          description:
+            "Optional runbook instance ID. Enforces document-order execution " +
+            "against the instance's append-only records (SPEC-AGX-SUBSTRATE §5).",
         },
       },
       required: ["notebookId", "cellId"],

--- a/src/notebook/runbook/ordering.ts
+++ b/src/notebook/runbook/ordering.ts
@@ -1,0 +1,135 @@
+/**
+ * Ordered execution and halt rules (SPEC-AGX-SUBSTRATE B5 — spec §5
+ * "Ordering" + §5.1 expected-failure rule, adopted 2026-06-12).
+ *
+ * Pure rules shared by the batch run path (engine runtime gate) and the
+ * instance-aware single-cell path (`executeInstanceCell`):
+ *
+ * - **Satisfied** (per executed cell, latest record wins): the cell ran
+ *   (not skipped) AND — when it declares expectations (tier-1 contract or
+ *   tier-2 validator) — every declared expectation passed; when it declares
+ *   none, it completed procedurally. A cell that exits nonzero but whose
+ *   every declared expectation passes is *expectation-satisfied* (a
+ *   predicted failure) and counts as satisfied.
+ * - **Halt**: an unsatisfied execution halts the run — uncontracted
+ *   procedural failures, and contracted cells whose expectations fail or
+ *   error. Expectation-satisfied predicted failures continue.
+ * - **Ordering**: cells execute in document (template) order; only the next
+ *   unsatisfied cell may execute. Out-of-order execution is rejected with a
+ *   typed error naming the expected next cell — never warned. When every
+ *   cell is satisfied, re-execution of any cell is allowed (re-running
+ *   appends; all prior cells are trivially satisfied).
+ */
+
+import type {
+  CellExecutionRecord,
+  RunbookInstanceStatus,
+  RunbookTemplate,
+} from "./types.js";
+
+/** Out-of-order execution is rejected, not warned (spec §5 "Ordering"). */
+export class OutOfOrderExecutionError extends Error {
+  override readonly name = "OutOfOrderExecutionError";
+
+  constructor(
+    readonly attemptedCellId: string,
+    readonly expectedNextCellId: string,
+  ) {
+    super(
+      `out-of-order execution rejected: cell ${attemptedCellId} cannot run before all ` +
+        `prior cells are satisfied — the next unsatisfied cell is ${expectedNextCellId}`,
+    );
+  }
+}
+
+/**
+ * Whether one execution record satisfies its cell (B5 satisfaction rule):
+ * declared expectations decide when present (all must pass — this is what
+ * makes a predicted failure satisfiable); otherwise procedural completion
+ * decides. Skipped records never satisfy.
+ */
+export function isExecutionSatisfied(
+  record: Pick<CellExecutionRecord, "status" | "expectations">,
+): boolean {
+  if (record.status === "skipped") return false;
+  if (record.expectations.length > 0) {
+    return record.expectations.every((expectation) => expectation.result === "pass");
+  }
+  return record.status === "completed";
+}
+
+/** Latest execution record per cell — re-execution appends, latest seq wins. */
+export function latestExecutionsByCell(
+  executions: CellExecutionRecord[],
+): Map<string, CellExecutionRecord> {
+  const latest = new Map<string, CellExecutionRecord>();
+  for (const record of [...executions].sort((a, b) => a.seq - b.seq)) {
+    latest.set(record.cellId, record);
+  }
+  return latest;
+}
+
+/**
+ * The first template cell (in document order) without a satisfying latest
+ * execution record, or null when every cell is satisfied.
+ */
+export function nextUnsatisfiedCell(
+  template: Pick<RunbookTemplate, "cells">,
+  executions: CellExecutionRecord[],
+): string | null {
+  const latest = latestExecutionsByCell(executions);
+  for (const cell of template.cells) {
+    const record = latest.get(cell.cellId);
+    if (record === undefined || !isExecutionSatisfied(record)) return cell.cellId;
+  }
+  return null;
+}
+
+/**
+ * Enforce document-order execution against an instance's append-only
+ * records: only the next unsatisfied cell may execute. Throws
+ * OutOfOrderExecutionError naming the expected next cell, or a plain Error
+ * when the cell is not part of the template. When all cells are satisfied,
+ * any cell may re-execute (appends a fresh record).
+ */
+export function assertCellExecutable(
+  template: Pick<RunbookTemplate, "templateId" | "version" | "cells">,
+  executions: CellExecutionRecord[],
+  cellId: string,
+): void {
+  if (!template.cells.some((cell) => cell.cellId === cellId)) {
+    throw new Error(
+      `cell ${cellId} is not part of template ${template.templateId} ` +
+        `version ${template.version}`,
+    );
+  }
+  const next = nextUnsatisfiedCell(template, executions);
+  if (next !== null && next !== cellId) {
+    throw new OutOfOrderExecutionError(cellId, next);
+  }
+}
+
+/**
+ * Derive an instance's status from its append-only execution records —
+ * the latest record per cell wins (decided design: derived, never stored).
+ * An executed-but-unsatisfied latest record (uncontracted failure, or
+ * failed/errored expectations) means the instance halted: "failed". An
+ * expectation-satisfied predicted failure counts as satisfied, so partial
+ * progress with only satisfied records derives "in_progress" and full
+ * satisfaction derives "completed".
+ */
+export function deriveInstanceStatus(
+  template: RunbookTemplate,
+  executions: CellExecutionRecord[],
+): RunbookInstanceStatus {
+  if (executions.length === 0) return "created";
+  const latest = latestExecutionsByCell(executions);
+  for (const record of latest.values()) {
+    if (record.status !== "skipped" && !isExecutionSatisfied(record)) return "failed";
+  }
+  const allSatisfied = template.cells.every((cell) => {
+    const record = latest.get(cell.cellId);
+    return record !== undefined && isExecutionSatisfied(record);
+  });
+  return allSatisfied ? "completed" : "in_progress";
+}

--- a/src/notebook/runbook/types.ts
+++ b/src/notebook/runbook/types.ts
@@ -226,16 +226,26 @@ export function templateCellsFromNotebook(
 }
 
 /**
- * Re-verify every attached contract hash on a template loaded from storage
+ * Re-verify every attached contract hash on a list of template cells
  * (Ulysses pattern at the durable layer). Throws ContractHashMismatchError
- * on tampering.
+ * on tampering. Used both to gate a notebook's cells before they are
+ * persisted as a template version and to re-check a template loaded from
+ * storage.
  */
-export function verifyTemplateContracts(template: RunbookTemplate): void {
-  for (const cell of template.cells) {
+export function verifyCellContracts(cells: RunbookTemplateCell[]): void {
+  for (const cell of cells) {
     if (cell.contract !== undefined) {
       verifyAttachedContract(cell.cellId, cell.contract);
     }
   }
+}
+
+/**
+ * Re-verify every attached contract hash on a template loaded from storage.
+ * Throws ContractHashMismatchError on tampering.
+ */
+export function verifyTemplateContracts(template: RunbookTemplate): void {
+  verifyCellContracts(template.cells);
 }
 
 /**

--- a/src/notebook/runbook/types.ts
+++ b/src/notebook/runbook/types.ts
@@ -11,7 +11,7 @@
  *   ever mutated in place.
  * - An instance pins `(templateId, templateVersion)` at creation and never
  *   changes it. Instance status is DERIVED from its append-only execution
- *   records via `deriveInstanceStatus` — it is never stored mutably.
+ *   records via `deriveInstanceStatus` (ordering.ts) — never stored mutably.
  * - Cell executions are append-only rows keyed by `(instanceId, seq)`;
  *   re-executing a cell appends a new record with a fresh seq. There is no
  *   update operation anywhere in the storage contract — that absence is the
@@ -76,6 +76,13 @@ export interface RunbookInstance {
   createdAt: string;
 }
 
+/**
+ * Since B5, the engine records only cells that actually executed —
+ * "completed" or "failed". Cells a halted run never reached leave NO record
+ * (their skipped expectations still produce ledger rows). "skipped" remains
+ * accepted by the storage contract and database for callers that record
+ * explicit skips.
+ */
 export type CellExecutionStatus = "completed" | "failed" | "skipped";
 
 export interface CellExecutionRecord {
@@ -229,28 +236,6 @@ export function verifyTemplateContracts(template: RunbookTemplate): void {
       verifyAttachedContract(cell.cellId, cell.contract);
     }
   }
-}
-
-/**
- * Derive an instance's status from its append-only execution records —
- * the latest record per cell wins (decided design: derived, never stored).
- */
-export function deriveInstanceStatus(
-  template: RunbookTemplate,
-  executions: CellExecutionRecord[],
-): RunbookInstanceStatus {
-  if (executions.length === 0) return "created";
-  const latestByCell = new Map<string, CellExecutionRecord>();
-  for (const record of [...executions].sort((a, b) => a.seq - b.seq)) {
-    latestByCell.set(record.cellId, record);
-  }
-  for (const record of latestByCell.values()) {
-    if (record.status === "failed") return "failed";
-  }
-  const allCompleted = template.cells.every(
-    (cell) => latestByCell.get(cell.cellId)?.status === "completed",
-  );
-  return allCompleted ? "completed" : "in_progress";
 }
 
 /**


### PR DESCRIPTION
Implements SPEC-AGX-SUBSTRATE:c3/§5 ordering semantics (unit B5). Stacked on #401 (durable templates/instances/ledger), which stacks on #399 (outcome contracts).

## What

**Expected-failure halt rule (§5.1 amendment, adopted 2026-06-12, rides in this PR).** When a cell exits nonzero, its declared expectations are evaluated first; if every one passes, the cell is *expectation-satisfied* (a predicted failure — e.g. `{ source: exitCode, op: eq, value: 1 }` for "this grep should find nothing") and the run continues. Halt remains the rule for uncontracted cells that fail and for contracted cells whose expectations fail or error. The §5.1 safety conjunct stays intact for uncontracted procedural failures; the spec parenthetical now reads "an *uncontracted* procedurally failed cell still fails the run" with the rule documented alongside.

**Out-of-order rejection (§5 "Ordering").** `notebook_run_cell` gains an optional `instanceId`. Given an instance, only the next unsatisfied cell — per template order and the instance's append-only execution records — may execute; any other cell throws `OutOfOrderExecutionError` naming the expected next cell. "Satisfied" is defined in `src/notebook/runbook/ordering.ts`: the cell executed (not skipped) and, when it declares expectations (tier-1 contract or tier-2 validator), every one passed; otherwise procedural completion. An expectation-satisfied predicted failure counts as satisfied. The batch path (`notebook_start_run`) runs the same assertion through the per-cell gate; a fully satisfied instance allows re-execution of any cell (re-running appends).

**Partial-run recording (closes the B4b gap).** The instance is created at run start, and cell execution records + their fitness ledger rows persist as each cell completes via a per-cell gate. A run that dies mid-way (halt rule, executor throw, storage outage on a later cell) leaves durable records for every cell that did execute, and `deriveInstanceStatus` reflects the partial progress. Skipped cells no longer leave execution records; their skipped expectations still produce ledger rows at run end.

`deriveInstanceStatus` moved from `runbook/types.ts` to `runbook/ordering.ts` and now derives from the satisfaction rule.

## Not in scope

Advancer/cron (B8), await cells/claims (B6), broker (B7). Tier-2 validator cells are rejected on the single-cell instance path (batch-only) — the target cell's structured output is not retained across single-cell calls.

## Existing-test changes

- `runbook-storage.test.ts`: the `status: "failed"` fixture now carries `expectations: []` — under the new rule a failed record whose default fixture expectations all passed would be an expectation-satisfied predicted failure, no longer deriving "failed".
- `runbook-storage.test.ts` / `runbook-durability.test.ts`: `deriveInstanceStatus` import path updated to `runbook/ordering.js`.

## Tests run

- `vitest src/notebook` — 88 passed, 0 skipped (Supabase-backed suites ran against the local stack: storage contract, tenant isolation, append-only enforcement, durability round-trip, and the new B5 partial-halt scenario)
- `vitest src/__tests__/e2e-workflow.test.ts src/code-mode` — 66 passed
- `pnpm check:types`, `pnpm check:lint` — clean

New tests (`src/notebook/__tests__/ordered-execution.test.ts`): expected-failure continue (run passes), expected-failure whose expectation fails (halt), uncontracted failure halt with partial-run durability (halts at cell 2 of 4 → cells 1–2 recorded, derived status failed, ledger rows for evaluated + skipped expectations; InMemory and Supabase), storage-outage durability, out-of-order rejection (typed error naming the next cell), live-notebook drift rejection, and pure rule units.

🤖 Generated with [Claude Code](https://claude.com/claude-code)