### PR TITLE
fix(ci): probe streamable-HTTP server in MCP diff workflow

### DIFF
--- a/.github/workflows/mcp-diff.yml
+++ b/.github/workflows/mcp-diff.yml
@@ -22,13 +22,27 @@ jobs:
         with:
           version: 9.15.4
 
+      # Diffs the public MCP surface (thoughtbox_search/execute/peer_notebook)
+      # exposed by the streamable-HTTP server (src/index.ts -> dist/index.js).
+      # THOUGHTBOX_STORAGE=memory keeps the server in local mode: no Supabase
+      # env required, /mcp serves unauthenticated, nothing persists.
       - uses: SamMorrowDrums/mcp-server-diff@v2
         with:
           setup_node: true
+          node_version: "22"
           install_command: pnpm install --frozen-lockfile
           build_command: pnpm build
-          start_command: node dist/channel/hub-channel.js
-        env:
-          THOUGHTBOX_AGENT_NAME: ci-diff
-          THOUGHTBOX_AGENT_PROFILE: REVIEWER
-          THOUGHTBOX_WORKSPACE_ID: ci-workspace
+          server_timeout: "20"
+          env_vars: |
+            THOUGHTBOX_STORAGE=memory
+            PORT=1731
+          configurations: |
+            [
+              {
+                "name": "streamable-http",
+                "transport": "streamable-http",
+                "start_command": "node dist/index.js",
+                "server_url": "http://localhost:1731/mcp",
+                "startup_wait_ms": 10000
+              }
+            ]


### PR DESCRIPTION
## What

The **MCP Server Diff** check has been red on every commit. Its `start_command` pointed at `node dist/channel/hub-channel.js` — a stdio server that moved to the plugin artifact (`plugins/thoughtbox-claude-code/`). That file doesn't exist in this repo, so the probe died with `MODULE_NOT_FOUND` and failed the action before it could diff anything.

This repoints the action at the server this repo actually ships — the streamable-HTTP server (`src/index.ts` → `dist/index.js`) — and probes it over HTTP via the action's `configurations` lifecycle (spawn → probe → kill).

## Details

- `transport: streamable-http`, `server_url: http://localhost:1731/mcp`, started with `node dist/index.js`.
- `THOUGHTBOX_STORAGE=memory` keeps the server in local mode: no Supabase env required, `/mcp` serves unauthenticated, nothing persists.
- `node_version: "22"` to match `engines` (`>=22`).
- The check now guards the public MCP surface (`thoughtbox_search`/`execute`/`peer_notebook`) — the deployed interface. It does **not** cover the plugin's separate stdio `thoughtbox-channel` (own package/build).

## Verification

Built and ran locally in memory mode: `/health` is `ok` and the MCP `initialize` handshake on `/mcp` returns the public tool surface unauthenticated. `actionlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)