### PR TITLE
fix: quote argument-hint values in SKILL.md frontmatter (Copilot CLI 1.0.65)

### DIFF
--- a/.agents/skills/capture-learning/SKILL.md
+++ b/.agents/skills/capture-learning/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: capture-learning
 description: Capture significant learnings from the current work session. Structures insights for future sessions and updates agent memory.
-argument-hint: [optional topic or context]
+argument-hint: "[optional topic or context]"
 user-invocable: true
 ---
 

--- a/.agents/skills/claude-prompt/SKILL.md
+++ b/.agents/skills/claude-prompt/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: Codex-prompt
 description: Write or improve prompts for Codex using Anthropic's official best practices. Creates system prompts, agent prompts, tool descriptions, and MCP resource templates. Pass an existing prompt to improve it, or describe what you need to create one from scratch.
-argument-hint: [existing prompt to improve, OR description of what prompt to create]
+argument-hint: "[existing prompt to improve, OR description of what prompt to create]"
 user-invocable: true
 ---
 

--- a/.agents/skills/diagram/SKILL.md
+++ b/.agents/skills/diagram/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: diagram
 description: Generate architecture diagrams for a codebase subsystem or module. Explores source files and produces Mermaid diagrams in docs/.
-argument-hint: [subsystem or module path, e.g. "observatory", "hub", "persistence"]
+argument-hint: '[subsystem or module path, e.g. "observatory", "hub", "persistence"]'
 user-invocable: true
 allowed-tools: Read, Glob, Grep, Bash, Write, Task
 ---

--- a/.agents/skills/distill/SKILL.md
+++ b/.agents/skills/distill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: distill
 description: Extract reusable principles and decision frameworks from accumulated experience. Use after significant work sessions, project milestones, or when you notice recurring patterns worth codifying.
-argument-hint: [domain or topic to distill]
+argument-hint: "[domain or topic to distill]"
 user-invocable: true
 allowed-tools: Read, Glob, Grep, Bash
 ---

--- a/.agents/skills/escalate/SKILL.md
+++ b/.agents/skills/escalate/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: escalate
 description: Format a structured escalation to the human decision-maker (Chief Agentic). Use when hitting an escalation threshold.
-argument-hint: [situation summary]
+argument-hint: "[situation summary]"
 user-invocable: true
 ---
 

--- a/.agents/skills/experiment/SKILL.md
+++ b/.agents/skills/experiment/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: experiment
 description: Run parallel experiments across git worktrees. Define competing approaches to the same problem, dispatch sub-agents to implement each in isolation, then compare results. Use when you have 2-5 alternatives and want to test all of them before committing to one.
-argument-hint: [source document or description of alternatives to test]
+argument-hint: "[source document or description of alternatives to test]"
 user-invocable: true
 ---
 

--- a/.agents/skills/implement/SKILL.md
+++ b/.agents/skills/implement/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: implement
 description: Implement a specification using a TDD-oriented workflow. Extracts requirements, generates tests first, then implements to pass the tests. Includes spiral detection and acceptance gates.
-argument-hint: [spec file or description]
+argument-hint: "[spec file or description]"
 user-invocable: true
 allowed-tools: Read, Glob, Grep, Bash, Edit, Write
 ---

--- a/.agents/skills/research-task/SKILL.md
+++ b/.agents/skills/research-task/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: research-task
 description: Execute a research task using compositional workflow planning. Characterizes the task, selects an approach from a library of research strategies, executes it, and self-evaluates output quality.
-argument-hint: [research question or topic]
+argument-hint: "[research question or topic]"
 user-invocable: true
 allowed-tools: Read, Glob, Grep, Bash, WebFetch, WebSearch
 ---

--- a/.agents/skills/session-review/SKILL.md
+++ b/.agents/skills/session-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: session-review
 description: Generate a structured session summary for cross-session continuity. Captures key decisions, hypotheses, partial work, and knowledge references. Output is written to .Codex/session-handoff.json for the next session to load automatically.
-argument-hint: [optional: focus area or notes]
+argument-hint: "[optional: focus area or notes]"
 user-invocable: true
 allowed-tools: Read, Glob, Grep, Bash, Write
 ---

--- a/.agents/skills/synthesize/SKILL.md
+++ b/.agents/skills/synthesize/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: synthesize
 description: Fuse insights from multiple knowledge sources (code, docs, memory, research, web) into coherent understanding. Use when you have scattered information that needs integration.
-argument-hint: [topic to synthesize]
+argument-hint: "[topic to synthesize]"
 user-invocable: true
 allowed-tools: Read, Glob, Grep, Bash, WebFetch, WebSearch
 ---

--- a/.agents/skills/taste/SKILL.md
+++ b/.agents/skills/taste/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: taste
 description: Run a taste evaluation on a research proposal or technical direction. Determines whether to proceed, simplify, defer, or kill before committing research effort.
-argument-hint: [proposal or question to evaluate]
+argument-hint: "[proposal or question to evaluate]"
 user-invocable: true
 ---
 

--- a/.agents/skills/thoughtbox-debug/SKILL.md
+++ b/.agents/skills/thoughtbox-debug/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: thoughtbox:debug
 description: Trigger when debugging something unexpected — a test failure, surprising behavior, production incident, or any situation where initial attempts aren't working. Prevents the common agent failure mode of trying random things when stuck. Use when "the first fix didn't work", "this is behaving unexpectedly", "I'm stuck", "why is this happening", or after 2+ failed attempts to fix something.
-argument-hint: [problem description]
+argument-hint: "[problem description]"
 user-invocable: true
 allowed-tools: Read, Glob, Grep, Bash, Edit, Write, mcp__thoughtbox-cloud-run__thoughtbox_execute, mcp__thoughtbox-cloud-run__thoughtbox_search
 ---

--- a/.agents/skills/thoughtbox-decision/SKILL.md
+++ b/.agents/skills/thoughtbox-decision/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Structure decisions with parallel hypothesis exploration and knowledge graph
   persistence. Triggers on: "decide", "choose between", "which approach",
   "compare options", "evaluate alternatives", "tradeoff analysis".
-argument-hint: [decision to make or options to evaluate]
+argument-hint: "[decision to make or options to evaluate]"
 user-invocable: true
 allowed-tools: Read, Glob, Grep, Bash, ToolSearch
 ---

--- a/.agents/skills/thoughtbox-evolution/SKILL.md
+++ b/.agents/skills/thoughtbox-evolution/SKILL.md
@@ -2,7 +2,7 @@
 name: thoughtbox:evolution
 description: A-Mem thought evolution — check which prior thoughts should be updated when a significant new insight arrives. Spawns a lightweight subagent to classify prior thoughts as UPDATE or NO_UPDATE, then applies revisions. Use during long reasoning sessions when you reach a synthesis, make a decision, or discover something that changes earlier assumptions. Triggers on "this changes what I thought earlier", "update prior reasoning", "evolve thoughts", or automatically on conclusion/synthesis thoughts in sessions >10 thoughts.
 user-invocable: true
-argument-hint: [the new insight that may require updating prior thoughts]
+argument-hint: "[the new insight that may require updating prior thoughts]"
 ---
 
 # Thought Evolution (A-Mem Pattern)

--- a/.agents/skills/thoughtbox-knowledge-query/SKILL.md
+++ b/.agents/skills/thoughtbox-knowledge-query/SKILL.md
@@ -2,7 +2,7 @@
 name: thoughtbox:knowledge-query
 description: Cross-session knowledge retrieval from the Thoughtbox knowledge graph. Searches entities, traverses relations, retrieves observations, and synthesizes findings from past sessions. Use when you need to recall prior decisions, check what's already known about a topic, find related insights, or build on past work. Triggers on "what do we know about", "have we seen this before", "recall", "prior decisions about", "knowledge graph", or when starting work that might have prior context.
 user-invocable: true
-argument-hint: [topic or question to search for]
+argument-hint: "[topic or question to search for]"
 ---
 
 # Thoughtbox Knowledge Query

--- a/.agents/skills/thoughtbox-onboard/SKILL.md
+++ b/.agents/skills/thoughtbox-onboard/SKILL.md
@@ -2,7 +2,7 @@
 name: thoughtbox:onboard
 description: Gateway orientation for agents using Thoughtbox MCP for the first time. Use this skill when you connect to a Thoughtbox MCP server and need to understand what's available, how to structure reasoning sessions, or how to use the tb SDK. Also use when you're unsure which Thoughtbox operation to use for a task, or when you want to check what modules and patterns are available. Triggers on first Thoughtbox interaction, "how do I use Thoughtbox", "what can Thoughtbox do", or any confusion about Thoughtbox operations.
 user-invocable: true
-argument-hint: [optional: specific area to learn about, e.g. "branching" or "knowledge graph"]
+argument-hint: '[optional: specific area to learn about, e.g. "branching" or "knowledge graph"]'
 ---
 
 # Thoughtbox Onboarding

--- a/.agents/skills/thoughtbox-refactor/SKILL.md
+++ b/.agents/skills/thoughtbox-refactor/SKILL.md
@@ -2,7 +2,7 @@
 name: thoughtbox:refactor
 description: Friction-gated refactoring using the Theseus protocol. Prevents scope creep and refactoring fugue state by enforcing file scope boundaries, visa-based expansion, checkpoint audits, and a brittleness counter. Use when refactoring code, restructuring modules, renaming across files, or any task where "structure changes but behavior must stay the same". Triggers on "refactor", "restructure", "rename across", "extract module", "move code", or when a change touches 3+ files without adding features.
 user-invocable: true
-argument-hint: [files to refactor and description of structural change]
+argument-hint: "[files to refactor and description of structural change]"
 ---
 
 # Theseus Refactoring Protocol

--- a/.agents/skills/thoughtbox-session-review/SKILL.md
+++ b/.agents/skills/thoughtbox-session-review/SKILL.md
@@ -2,7 +2,7 @@
 name: thoughtbox:session-review
 description: Analyze completed Thoughtbox sessions to extract patterns, anti-patterns, and learnings for the knowledge graph. This is the learning loop that makes Thoughtbox improve over time. Use after completing a reasoning session, when reviewing past sessions for insights, or when you want to assess reasoning quality. Triggers on "review session", "what did I learn", "extract insights", "analyze reasoning", "session retrospective", or proactively after any significant session completes.
 user-invocable: true
-argument-hint: [session ID, or "latest" to review most recent]
+argument-hint: '[session ID, or "latest" to review most recent]'
 ---
 
 # Thoughtbox Session Review

--- a/.agents/skills/thoughtbox-team/SKILL.md
+++ b/.agents/skills/thoughtbox-team/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: thoughtbox-team
 description: Spawn an Agent Team with a background Thoughtbox analyst teammate. The analyst monitors your reasoning sessions for evolution candidates, contradictions, and generates periodic digests. Use this at the start of any deep Thoughtbox reasoning session, when you're about to record many thoughts and want background analysis. Triggers on "start thoughtbox team", "I want a session analyst", "monitor my reasoning", or at the start of any session where you plan to use Thoughtbox extensively.
-argument-hint: [optional session ID to monitor]
+argument-hint: "[optional session ID to monitor]"
 user-invocable: true
 ---
 

--- a/.agents/skills/workflow-ideation/SKILL.md
+++ b/.agents/skills/workflow-ideation/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-ideation
 description: Evaluate whether an idea is worth implementing by asking structured questions about outcomes, alignment, and opportunity cost. Stage 1 of the development workflow.
-argument-hint: [idea description]
+argument-hint: "[idea description]"
 user-invocable: true
 ---
 

--- a/.agents/skills/workflow-reflection/SKILL.md
+++ b/.agents/skills/workflow-reflection/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-reflection
 description: Finalize the workflow by reflecting on the process, moving ADRs, closing issues, and preparing for merge. Stage 8 of the development workflow.
-argument-hint: [optional reflection notes]
+argument-hint: "[optional reflection notes]"
 user-invocable: true
 ---
 

--- a/.agents/skills/workflow-revision/SKILL.md
+++ b/.agents/skills/workflow-revision/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-revision
 description: Iterate on implementation fixes surfaced by review until all claims are verified. Stage 6 of the development workflow.
-argument-hint: [review findings summary or path]
+argument-hint: "[review findings summary or path]"
 user-invocable: true
 ---
 

--- a/.agents/skills/workflow-tournament/SKILL.md
+++ b/.agents/skills/workflow-tournament/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-tournament
 description: Execute an implementation by dispatching multiple sub-agents to parallel Git worktrees. Each builds the entire feature independently, and the best implementation is selected and merged.
-argument-hint: [number of agents/worktrees]
+argument-hint: "[number of agents/worktrees]"
 user-invocable: true
 ---
 

--- a/.agents/skills/workflow/SKILL.md
+++ b/.agents/skills/workflow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow
 description: Orchestrate the full development lifecycle from ideation through merge. Sequences 8 stages with gates, dispatches to stage skills, and maintains workflow state.
-argument-hint: [idea or feature description]
+argument-hint: "[idea or feature description]"
 user-invocable: true
 ---
 

--- a/.agents/skills/workflows-compound/SKILL.md
+++ b/.agents/skills/workflows-compound/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflows-compound
 description: Capture learnings from the workflow into reusable documentation. Stage 7 of the development workflow.
-argument-hint: [optional focus area]
+argument-hint: "[optional focus area]"
 user-invocable: true
 ---
 

--- a/.agents/skills/workflows-plan/SKILL.md
+++ b/.agents/skills/workflows-plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflows-plan
 description: Transform spec (with frontmatter claims) into an implementation plan with task decomposition and sub-agent assignment. Stage 3 of the development workflow.
-argument-hint: [spec path or feature description]
+argument-hint: "[spec path or feature description]"
 user-invocable: true
 ---
 

--- a/.agents/skills/workflows-review/SKILL.md
+++ b/.agents/skills/workflows-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflows-review
 description: Verify implementation claims by dispatching review agents. Stage 5 of the development workflow.
-argument-hint: [summary paths or review scope]
+argument-hint: "[summary paths or review scope]"
 user-invocable: true
 ---
 

--- a/.agents/skills/workflows-work/SKILL.md
+++ b/.agents/skills/workflows-work/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflows-work
 description: Execute the implementation plan by dispatching sub-agents for each task. Stage 4 of the development workflow.
-argument-hint: [plan path or task selection]
+argument-hint: "[plan path or task selection]"
 user-invocable: true
 ---
 

--- a/.claude/skills/capture-learning/SKILL.md
+++ b/.claude/skills/capture-learning/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: capture-learning
 description: Capture significant learnings from the current work session. Structures insights for future sessions and updates agent memory.
-argument-hint: [optional topic or context]
+argument-hint: "[optional topic or context]"
 user-invocable: true
 ---
 

--- a/.claude/skills/claude-prompt/SKILL.md
+++ b/.claude/skills/claude-prompt/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: claude-prompt
 description: Write or improve prompts for Claude using Anthropic's official best practices. Creates system prompts, agent prompts, tool descriptions, and MCP resource templates. Pass an existing prompt to improve it, or describe what you need to create one from scratch.
-argument-hint: [existing prompt to improve, OR description of what prompt to create]
+argument-hint: "[existing prompt to improve, OR description of what prompt to create]"
 user-invocable: true
 ---
 

--- a/.claude/skills/diagram/SKILL.md
+++ b/.claude/skills/diagram/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: diagram
 description: Generate architecture diagrams for a codebase subsystem or module. Explores source files and produces Mermaid diagrams in docs/.
-argument-hint: [subsystem or module path, e.g. "observatory", "hub", "persistence"]
+argument-hint: '[subsystem or module path, e.g. "observatory", "hub", "persistence"]'
 user-invocable: true
 allowed-tools: Read, Glob, Grep, Bash, Write, Task
 ---

--- a/.claude/skills/distill/SKILL.md
+++ b/.claude/skills/distill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: distill
 description: Extract reusable principles and decision frameworks from accumulated experience. Use after significant work sessions, project milestones, or when you notice recurring patterns worth codifying.
-argument-hint: [domain or topic to distill]
+argument-hint: "[domain or topic to distill]"
 user-invocable: true
 allowed-tools: Read, Glob, Grep, Bash
 ---

--- a/.claude/skills/escalate/SKILL.md
+++ b/.claude/skills/escalate/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: escalate
 description: Format a structured escalation to the human decision-maker (Chief Agentic). Use when hitting an escalation threshold.
-argument-hint: [situation summary]
+argument-hint: "[situation summary]"
 user-invocable: true
 ---
 

--- a/.claude/skills/experiment/SKILL.md
+++ b/.claude/skills/experiment/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: experiment
 description: Run parallel experiments across git worktrees. Define competing approaches to the same problem, dispatch sub-agents to implement each in isolation, then compare results. Use when you have 2-5 alternatives and want to test all of them before committing to one.
-argument-hint: [source document or description of alternatives to test]
+argument-hint: "[source document or description of alternatives to test]"
 user-invocable: true
 ---
 

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: implement
 description: Implement a specification using a TDD-oriented workflow. Extracts requirements, generates tests first, then implements to pass the tests. Includes spiral detection and acceptance gates.
-argument-hint: [spec file or description]
+argument-hint: "[spec file or description]"
 user-invocable: true
 allowed-tools: Read, Glob, Grep, Bash, Edit, Write
 ---

--- a/.claude/skills/research-task/SKILL.md
+++ b/.claude/skills/research-task/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: research-task
 description: Execute a research task using compositional workflow planning. Characterizes the task, selects an approach from a library of research strategies, executes it, and self-evaluates output quality.
-argument-hint: [research question or topic]
+argument-hint: "[research question or topic]"
 user-invocable: true
 allowed-tools: Read, Glob, Grep, Bash, WebFetch, WebSearch
 ---

--- a/.claude/skills/session-review/SKILL.md
+++ b/.claude/skills/session-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: session-review
 description: Generate a structured session summary for cross-session continuity. Captures key decisions, hypotheses, partial work, and knowledge references. Output is written to .claude/session-handoff.json for the next session to load automatically.
-argument-hint: [optional: focus area or notes]
+argument-hint: "[optional: focus area or notes]"
 user-invocable: true
 allowed-tools: Read, Glob, Grep, Bash, Write
 ---

--- a/.claude/skills/synthesize/SKILL.md
+++ b/.claude/skills/synthesize/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: synthesize
 description: Fuse insights from multiple knowledge sources (code, docs, memory, research, web) into coherent understanding. Use when you have scattered information that needs integration.
-argument-hint: [topic to synthesize]
+argument-hint: "[topic to synthesize]"
 user-invocable: true
 allowed-tools: Read, Glob, Grep, Bash, WebFetch, WebSearch
 ---

--- a/.claude/skills/taste/SKILL.md
+++ b/.claude/skills/taste/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: taste
 description: Run a taste evaluation on a research proposal or technical direction. Determines whether to proceed, simplify, defer, or kill before committing research effort.
-argument-hint: [proposal or question to evaluate]
+argument-hint: "[proposal or question to evaluate]"
 user-invocable: true
 ---
 

--- a/.claude/skills/thoughtbox-debug/SKILL.md
+++ b/.claude/skills/thoughtbox-debug/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: thoughtbox:debug
 description: Trigger when debugging something unexpected — a test failure, surprising behavior, production incident, or any situation where initial attempts aren't working. Prevents the common agent failure mode of trying random things when stuck. Use when "the first fix didn't work", "this is behaving unexpectedly", "I'm stuck", "why is this happening", or after 2+ failed attempts to fix something.
-argument-hint: [problem description]
+argument-hint: "[problem description]"
 user-invocable: true
 allowed-tools: Read, Glob, Grep, Bash, Edit, Write, mcp__thoughtbox-cloud-run__thoughtbox_execute, mcp__thoughtbox-cloud-run__thoughtbox_search
 ---

--- a/.claude/skills/thoughtbox-decision/SKILL.md
+++ b/.claude/skills/thoughtbox-decision/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Structure decisions with parallel hypothesis exploration and knowledge graph
   persistence. Triggers on: "decide", "choose between", "which approach",
   "compare options", "evaluate alternatives", "tradeoff analysis".
-argument-hint: [decision to make or options to evaluate]
+argument-hint: "[decision to make or options to evaluate]"
 user-invocable: true
 allowed-tools: Read, Glob, Grep, Bash, ToolSearch
 ---

--- a/.claude/skills/thoughtbox-evolution/SKILL.md
+++ b/.claude/skills/thoughtbox-evolution/SKILL.md
@@ -2,7 +2,7 @@
 name: thoughtbox:evolution
 description: A-Mem thought evolution — check which prior thoughts should be updated when a significant new insight arrives. Spawns a lightweight subagent to classify prior thoughts as UPDATE or NO_UPDATE, then applies revisions. Use during long reasoning sessions when you reach a synthesis, make a decision, or discover something that changes earlier assumptions. Triggers on "this changes what I thought earlier", "update prior reasoning", "evolve thoughts", or automatically on conclusion/synthesis thoughts in sessions >10 thoughts.
 user-invocable: true
-argument-hint: [the new insight that may require updating prior thoughts]
+argument-hint: "[the new insight that may require updating prior thoughts]"
 ---
 
 # Thought Evolution (A-Mem Pattern)

--- a/.claude/skills/thoughtbox-knowledge-query/SKILL.md
+++ b/.claude/skills/thoughtbox-knowledge-query/SKILL.md
@@ -2,7 +2,7 @@
 name: thoughtbox:knowledge-query
 description: Cross-session knowledge retrieval from the Thoughtbox knowledge graph. Searches entities, traverses relations, retrieves observations, and synthesizes findings from past sessions. Use when you need to recall prior decisions, check what's already known about a topic, find related insights, or build on past work. Triggers on "what do we know about", "have we seen this before", "recall", "prior decisions about", "knowledge graph", or when starting work that might have prior context.
 user-invocable: true
-argument-hint: [topic or question to search for]
+argument-hint: "[topic or question to search for]"
 ---
 
 # Thoughtbox Knowledge Query

--- a/.claude/skills/thoughtbox-onboard/SKILL.md
+++ b/.claude/skills/thoughtbox-onboard/SKILL.md
@@ -2,7 +2,7 @@
 name: thoughtbox:onboard
 description: Gateway orientation for agents using Thoughtbox MCP for the first time. Use this skill when you connect to a Thoughtbox MCP server and need to understand what's available, how to structure reasoning sessions, or how to use the tb SDK. Also use when you're unsure which Thoughtbox operation to use for a task, or when you want to check what modules and patterns are available. Triggers on first Thoughtbox interaction, "how do I use Thoughtbox", "what can Thoughtbox do", or any confusion about Thoughtbox operations.
 user-invocable: true
-argument-hint: [optional: specific area to learn about, e.g. "branching" or "knowledge graph"]
+argument-hint: '[optional: specific area to learn about, e.g. "branching" or "knowledge graph"]'
 ---
 
 # Thoughtbox Onboarding

--- a/.claude/skills/thoughtbox-refactor/SKILL.md
+++ b/.claude/skills/thoughtbox-refactor/SKILL.md
@@ -2,7 +2,7 @@
 name: thoughtbox:refactor
 description: Friction-gated refactoring using the Theseus protocol. Prevents scope creep and refactoring fugue state by enforcing file scope boundaries, visa-based expansion, checkpoint audits, and a brittleness counter. Use when refactoring code, restructuring modules, renaming across files, or any task where "structure changes but behavior must stay the same". Triggers on "refactor", "restructure", "rename across", "extract module", "move code", or when a change touches 3+ files without adding features.
 user-invocable: true
-argument-hint: [files to refactor and description of structural change]
+argument-hint: "[files to refactor and description of structural change]"
 ---
 
 # Theseus Refactoring Protocol

--- a/.claude/skills/thoughtbox-session-review/SKILL.md
+++ b/.claude/skills/thoughtbox-session-review/SKILL.md
@@ -2,7 +2,7 @@
 name: thoughtbox:session-review
 description: Analyze completed Thoughtbox sessions to extract patterns, anti-patterns, and learnings for the knowledge graph. This is the learning loop that makes Thoughtbox improve over time. Use after completing a reasoning session, when reviewing past sessions for insights, or when you want to assess reasoning quality. Triggers on "review session", "what did I learn", "extract insights", "analyze reasoning", "session retrospective", or proactively after any significant session completes.
 user-invocable: true
-argument-hint: [session ID, or "latest" to review most recent]
+argument-hint: '[session ID, or "latest" to review most recent]'
 ---
 
 # Thoughtbox Session Review

--- a/.claude/skills/thoughtbox-team/SKILL.md
+++ b/.claude/skills/thoughtbox-team/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: thoughtbox-team
 description: Spawn an Agent Team with a background Thoughtbox analyst teammate. The analyst monitors your reasoning sessions for evolution candidates, contradictions, and generates periodic digests. Use this at the start of any deep Thoughtbox reasoning session, when you're about to record many thoughts and want background analysis. Triggers on "start thoughtbox team", "I want a session analyst", "monitor my reasoning", or at the start of any session where you plan to use Thoughtbox extensively.
-argument-hint: [optional session ID to monitor]
+argument-hint: "[optional session ID to monitor]"
 user-invocable: true
 ---
 

--- a/.claude/skills/workflow-ideation/SKILL.md
+++ b/.claude/skills/workflow-ideation/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-ideation
 description: Evaluate whether an idea is worth implementing by asking structured questions about outcomes, alignment, and opportunity cost. Stage 1 of the development workflow.
-argument-hint: [idea description]
+argument-hint: "[idea description]"
 user-invocable: true
 ---
 

--- a/.claude/skills/workflow-reflection/SKILL.md
+++ b/.claude/skills/workflow-reflection/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-reflection
 description: Finalize the workflow by reflecting on the process, moving ADRs, closing issues, and preparing for merge. Stage 8 of the development workflow.
-argument-hint: [optional reflection notes]
+argument-hint: "[optional reflection notes]"
 user-invocable: true
 ---
 

--- a/.claude/skills/workflow-revision/SKILL.md
+++ b/.claude/skills/workflow-revision/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-revision
 description: Iterate on implementation fixes surfaced by review until all claims are verified. Stage 6 of the development workflow.
-argument-hint: [review findings summary or path]
+argument-hint: "[review findings summary or path]"
 user-invocable: true
 ---
 

--- a/.claude/skills/workflow-tournament/SKILL.md
+++ b/.claude/skills/workflow-tournament/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-tournament
 description: Execute an implementation by dispatching multiple sub-agents to parallel Git worktrees. Each builds the entire feature independently, and the best implementation is selected and merged.
-argument-hint: [number of agents/worktrees]
+argument-hint: "[number of agents/worktrees]"
 user-invocable: true
 ---
 

--- a/.claude/skills/workflow/SKILL.md
+++ b/.claude/skills/workflow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow
 description: Orchestrate the full development lifecycle from ideation through merge. Sequences 8 stages with gates, dispatches to stage skills, and maintains workflow state.
-argument-hint: [idea or feature description]
+argument-hint: "[idea or feature description]"
 user-invocable: true
 ---
 

--- a/.claude/skills/workflows-compound/SKILL.md
+++ b/.claude/skills/workflows-compound/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflows-compound
 description: Capture learnings from the workflow into reusable documentation. Stage 7 of the development workflow.
-argument-hint: [optional focus area]
+argument-hint: "[optional focus area]"
 user-invocable: true
 ---
 

--- a/.claude/skills/workflows-plan/SKILL.md
+++ b/.claude/skills/workflows-plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflows-plan
 description: Transform spec (with frontmatter claims) into an implementation plan with task decomposition and sub-agent assignment. Stage 3 of the development workflow.
-argument-hint: [spec path or feature description]
+argument-hint: "[spec path or feature description]"
 user-invocable: true
 ---
 

--- a/.claude/skills/workflows-review/SKILL.md
+++ b/.claude/skills/workflows-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflows-review
 description: Verify implementation claims by dispatching review agents. Stage 5 of the development workflow.
-argument-hint: [summary paths or review scope]
+argument-hint: "[summary paths or review scope]"
 user-invocable: true
 ---
 

--- a/.claude/skills/workflows-work/SKILL.md
+++ b/.claude/skills/workflows-work/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflows-work
 description: Execute the implementation plan by dispatching sub-agents for each task. Stage 4 of the development workflow.
-argument-hint: [plan path or task selection]
+argument-hint: "[plan path or task selection]"
 user-invocable: true
 ---
 


### PR DESCRIPTION
## Summary

Copilot CLI **1.0.65** made `argument-hint` in skill frontmatter strictly a
string. The unquoted form used throughout `.claude/skills/` and
`.agents/skills/` is parsed by YAML as a **flow sequence (array)**, which
makes the CLI refuse to load the skill.

This PR quotes the value in every affected SKILL.md so it parses as a
string. No prose, semantics, or field ordering changed.

## The YAML rule

`argument-hint:` followed by an unquoted `[` is a YAML flow sequence, not
a string:

```yaml
# Before — YAML array (breaks Copilot CLI 1.0.65)
argument-hint: [optional topic or context]

# After — YAML string (correct)
argument-hint: "[optional topic or context]"
```

Where the value already contains double quotes, single quotes are used to
wrap the whole thing (e.g. `diagram`, `thoughtbox-onboard`).

## Files touched

**56 SKILL.md files** — 28 under `.agents/skills/` and 28 under
`.claude/skills/` (the two trees are duplicates of each other).

All 77 `argument-hint` occurrences across the repo now parse as YAML
strings — verified with a Python `yaml.safe_load` pass over every
SKILL.md.

Files already using `<...>` (e.g. `ulysses-protocol`, `theseus-protocol`,
`supabase`, `assumptions`, `eval`, `knowledge`, `peer-notebook-delivery-guard`,
`hdd`) were untouched — those are already strings under YAML rules.
Files already fully quoted (`ulc-loop`, `thoughtbox-research`, `status`)
were also untouched.

## Related

- anthropics/claude-code#22161 — latent equivalent bug tracked on Claude Code

## Test plan

- [x] `yaml.safe_load` over every SKILL.md in the repo — 77/77
  `argument-hint` values parse as `str`, 0 errors
- [x] Spot-checked files with embedded double quotes (`diagram`,
  `thoughtbox-onboard`) now use single quotes as the outer wrapper
- [x] Load a fixed skill under Copilot CLI 1.0.65+ and confirm the
  argument hint renders as text
