### PR TITLE
fix(ci): pin COLLATE "C" on text sort keys in parity fingerprint

### DIFF
--- a/supabase/snippets/parity-fingerprint.sql
+++ b/supabase/snippets/parity-fingerprint.sql
@@ -9,6 +9,14 @@
 --     level (e.g. pg_net, wrappers, rls_auto_enable). These vary by project
 --     creation date and are outside our control plane.
 --
+-- IMPORTANT: every ORDER BY over a text-typed sort key MUST pin COLLATE "C".
+-- Catalog `name` / `sql_identifier` columns always sort in C order, but text
+-- expressions (e.g. conrelid::regclass::text) sort under the database default
+-- collation, which differs across Postgres builds (staging PG17 uses C.UTF-8;
+-- the CLI's PG15 local stack uses en_US.UTF-8 — they disagree on
+-- 'claims' vs 'claim_subscriptions'). An unpinned text sort makes the hash
+-- environment-dependent even when the schema is byte-identical.
+--
 -- Re-runnable from the Supabase SQL editor or any psql session.
 
 WITH
@@ -41,7 +49,7 @@ constraints AS (
       'name', conname,
       'def', pg_get_constraintdef(oid)
     )
-    ORDER BY conrelid::regclass::text, conname
+    ORDER BY conrelid::regclass::text COLLATE "C", conname
   ) AS j
   FROM pg_constraint
   WHERE connamespace = 'public'::regnamespace
@@ -78,7 +86,7 @@ app_functions AS (
       'name', p.proname,
       'sig', pg_get_function_identity_arguments(p.oid)
     )
-    ORDER BY n.nspname, p.proname, pg_get_function_identity_arguments(p.oid)
+    ORDER BY n.nspname, p.proname, pg_get_function_identity_arguments(p.oid) COLLATE "C"
   ) AS j
   FROM pg_proc p
   JOIN pg_namespace n ON p.pronamespace = n.oid


### PR DESCRIPTION
## Problem

The `db-parity` workflow has failed every run since **2026-06-12** (last green: 2026-06-11). Every failure is the same single hash: `constraints_md5` differs between staging (pyyabzaitqvdbaneanip) and a fresh migrations-applied local stack, while the other six surfaces match and the migration ledgers are identical (34/34).

## Root cause — no schema drift exists

- Staging and migrations hold **byte-identical constraint content**: 171/171 constraints, and per-table `json_agg(... ORDER BY conname)` md5s are equal for every table. A `supabase db diff` (shadow DB) against staging-equivalent local state confirms zero constraint DDL difference.
- The fingerprint's constraints CTE sorts by `conrelid::regclass::text` — a **text-typed key that follows the database default collation**. Staging runs **PG 17.6 (C.UTF-8)**; the CI local stack runs **PG 15.8 (en_US.UTF-8)**. These collations disagree on `'claims'` vs `'claim_subscriptions'` (`_` < `s` in C; punctuation is secondary in en_US).
- Those tables were introduced by `20260612000000_add_claim_graph_tables` — the exact day the workflow went red.
- Every other CTE sorts `name`/`sql_identifier` catalog columns, which always sort in C order regardless of database collation — which is why only `constraints_md5` tripped.

So the hash was environment-dependent, not schema-dependent: identical schemas, different sort order, different md5.

## Fix

Pin `COLLATE "C"` on both text-typed sort keys in `supabase/snippets/parity-fingerprint.sql` (constraints table name; function identity arguments, which had the same latent bug).

## Verification (run before writing the fix)

- Staging, patched snippet (read-only via Management API SQL): all seven hashes returned — `tables 64a5f59e…`, `columns 7db0466b…`, `constraints 1cb5e2da…`, `indexes 0969ee3e…`, `policies 591acea9…`, `functions 203a318c…`, `rls 4ee0b8f9…`.
- Local PG 15.8 stack (migrations state, branch-local `protocol_events` table excluded), patched constraints/functions CTEs: `constraints 1cb5e2da…`, `functions 203a318c…` — **identical to staging**.
- Six of those values already matched in run 28790438531 today; the seventh (`constraints_md5`) now agrees on both sides. The push-to-main run of this PR (the snippet path is a workflow trigger) will confirm end-to-end.

Also audited `.github/workflows/` and `scripts/` for vitest `--reporter=basic` (removed in vitest 4): zero occurrences, nothing to fix.

## Gates

`pnpm check:types` / `pnpm check:lint` / `pnpm build:local` pass. `npx vitest run`: 865 passed, 3 failed — the 3 known pre-existing environmental failures (branch-workers ×2, intelligence-pipeline ×1, local edge-runtime 503).

🤖 Generated with [Claude Code](https://claude.com/claude-code)