### PR TITLE
fix(protocol): enforce hosted protocol gate end to end

### DIFF
--- a/.specs/protocol-runtime-integration.md
+++ b/.specs/protocol-runtime-integration.md
@@ -48,13 +48,15 @@ The authoritative protocol tools remain:
 
 ### Hook-facing enforcement API
 
-Add a server-backed enforcement surface on the Dockerized Thoughtbox server for Claude hooks.
+Add a server-backed enforcement surface on the Thoughtbox server for Claude hooks. The route is mounted in BOTH local (single-tenant) and hosted (multi-tenant, `THOUGHTBOX_STORAGE=supabase`) modes.
 
 - Route: `POST /protocol/enforcement`
 - Purpose: return a workspace-scoped enforcement decision for a pending local mutation
+- Auth (hosted mode): requests MUST carry `Authorization: Bearer <tbx_* API key or OAuth JWT>` (or `?key=`). The enforcement workspace is resolved from the credentials; any `workspaceId` in the body is ignored. Unauthenticated or invalid-key requests get 401. Local mode requires no auth and honors a body `workspaceId` when present.
 - Request body:
   - `mutation: boolean`
   - `targetPath?: string`
+  - `workspaceId?: string` (advisory, local mode only; hosted mode derives it from credentials)
 - Response body:
   - `enforce: boolean`
   - `blocked?: boolean`
@@ -68,6 +70,8 @@ Behavior:
 - Ulysses blocks mutating work when the active session is at `S=2`, returning `required_action: "reflect"`.
 - Theseus blocks test-file edits and out-of-scope writes, returning `required_action: "visa"` for scope expansion.
 - Read-only actions are never blocked by this surface.
+- Hosted mode resolves protocol state (`protocol_sessions`, `protocol_scope`) directly from Supabase per authenticated workspace. Enforcement does NOT require a live in-process protocol handler, so decisions hold across container restarts and apply regardless of which instance served the MCP session.
+- Local mode consults every live MCP session's protocol handler and aggregates blocked-wins: a block from ANY active protocol session is returned, so a second concurrent session cannot mask an enforcement decision.
 
 ### Claude-side invoke surfaces
 
@@ -93,9 +97,11 @@ These workflows become thin adapters that:
 
 ### Claude hooks
 
-- Collapse protocol enforcement into `.claude/hooks/pre_tool_use.sh`.
+- The shipped enforcement client is the plugin PreToolUse hook `plugins/thoughtbox-claude-code/scripts/protocol_gate.sh` (matcher: `Edit|Write|NotebookEdit`).
+- Endpoint resolution order: `THOUGHTBOX_URL` env → `OTEL_EXPORTER_OTLP_ENDPOINT` env → the `thoughtbox init` config in `.claude/settings.local.json` (`env.OTEL_EXPORTER_OTLP_ENDPOINT`, else the base of `mcpServers.thoughtbox.url`). There is NO hardcoded default endpoint.
+- API key resolution order: `THOUGHTBOX_API_KEY` env → `OTEL_EXPORTER_OTLP_HEADERS` env (`Authorization=Bearer <key>`) → the same fields in `.claude/settings.local.json` (including `?key=` on the MCP URL). When a key resolves, the hook sends `Authorization: Bearer <key>`.
+- Availability posture: fail OPEN, never silently. Unreachable, unconfigured, or auth-rejected enforcement exits 1 (non-blocking) with a visible stderr warning stating protocol gates are NOT enforced for the action. Blocked decisions exit 2 with the reason.
 - Remove Ulysses-specific local surprise counting and reflect sentinels from the active runtime path.
-- Resolve the local Thoughtbox base URL from `.mcp.json`, defaulting to `http://localhost:1731/mcp`.
 
 ### Claude skills
 
@@ -107,6 +113,8 @@ These workflows become thin adapters that:
 - An explicit Ulysses run can reach `S=2`, and the local hook blocks mutating actions until `reflect` is recorded through Thoughtbox.
 - An explicit Theseus run blocks test-file edits and out-of-scope writes until a visa is recorded through Thoughtbox.
 - The hook enforcement path works against the Dockerized local Thoughtbox server without relying on local Node wrappers.
+- The hook enforcement path works against a hosted multi-tenant server (`THOUGHTBOX_STORAGE=supabase`): an authenticated `POST /protocol/enforcement` returns the decision for the API key's workspace, and a mutation during that workspace's active Ulysses `S=2` (or Theseus out-of-scope) state is blocked at the hook with no live MCP session required.
+- When enforcement is unreachable or unconfigured, the hook fails open with a visible warning — never silently.
 - Protocol completion still bridges summaries to Thoughtbox knowledge storage.
 - Ulysses reflections and Theseus audit failures produce reusable knowledge artifacts.
 - Helper-agent participation does not supersede or corrupt the coordinator-owned active protocol session.

--- a/plugins/thoughtbox-claude-code/scripts/protocol_gate.sh
+++ b/plugins/thoughtbox-claude-code/scripts/protocol_gate.sh
@@ -1,16 +1,51 @@
 #!/usr/bin/env bash
 # PreToolUse: Protocol enforcement gate.
-# Calls Thoughtbox /protocol/enforcement before allowing Edit/Write/NotebookEdit.
-# Blocks if an active Ulysses session needs REFLECT (S=2) or a Theseus scope violation.
-# Fails open on timeout/error — never blocks the agent on network issues.
+# Calls Thoughtbox POST /protocol/enforcement before allowing Edit/Write/NotebookEdit.
+# Blocks (exit 2) if an active Ulysses session needs REFLECT (S=2) or a
+# Theseus test-lock/scope violation is detected.
+#
+# Availability posture: fails OPEN when enforcement is unreachable or
+# unconfigured — but never silently. Exit 1 (non-blocking) with a stderr
+# warning makes the fail-open observable to the user.
 set -uo pipefail
 
 input_json=$(cat)
 
-endpoint="${THOUGHTBOX_URL:-https://mcp.kastalienresearch.ai}"
 target_path=$(echo "$input_json" | jq -r '.tool_input.file_path // .tool_input.notebook_path // .tool_input.path // ""')
 
 [[ -z "$target_path" || "$target_path" == "null" ]] && exit 0
+
+settings_local="${CLAUDE_PROJECT_DIR:-.}/.claude/settings.local.json"
+
+# --- Resolve endpoint: explicit env override, then the config written by
+# `thoughtbox init` (.claude/settings.local.json). No hardcoded default —
+# an unconfigured gate warns loudly instead of probing the wrong server.
+endpoint="${THOUGHTBOX_URL:-${OTEL_EXPORTER_OTLP_ENDPOINT:-}}"
+if [[ -z "$endpoint" && -f "$settings_local" ]]; then
+  endpoint=$(jq -r '.env.OTEL_EXPORTER_OTLP_ENDPOINT // empty' "$settings_local" 2>/dev/null || true)
+  if [[ -z "$endpoint" ]]; then
+    mcp_url=$(jq -r '.mcpServers.thoughtbox.url // empty' "$settings_local" 2>/dev/null || true)
+    [[ -n "$mcp_url" ]] && endpoint="${mcp_url%%/mcp*}"
+  fi
+fi
+endpoint="${endpoint%/}"
+
+if [[ -z "$endpoint" ]]; then
+  echo "thoughtbox protocol_gate: no Thoughtbox endpoint configured (set THOUGHTBOX_URL or run 'thoughtbox init'); protocol enforcement is OFF for this action — failing open" >&2
+  exit 1
+fi
+
+# --- Resolve API key: explicit env, OTLP headers env, then init config.
+api_key="${THOUGHTBOX_API_KEY:-}"
+if [[ -z "$api_key" && -n "${OTEL_EXPORTER_OTLP_HEADERS:-}" ]]; then
+  api_key=$(printf '%s' "$OTEL_EXPORTER_OTLP_HEADERS" | sed -n 's/.*Authorization=Bearer \([^,[:space:]]*\).*/\1/p')
+fi
+if [[ -z "$api_key" && -f "$settings_local" ]]; then
+  api_key=$(jq -r '.env.OTEL_EXPORTER_OTLP_HEADERS // empty' "$settings_local" 2>/dev/null | sed -n 's/.*Authorization=Bearer \([^,[:space:]]*\).*/\1/p' || true)
+  if [[ -z "$api_key" ]]; then
+    api_key=$(jq -r '.mcpServers.thoughtbox.url // empty' "$settings_local" 2>/dev/null | sed -n 's/.*[?&]key=\([^&]*\).*/\1/p' || true)
+  fi
+fi
 
 workspace_id="${THOUGHTBOX_WORKSPACE_ID:-}"
 
@@ -24,12 +59,21 @@ payload=$(jq -n \
     workspaceId: (if ($workspaceId | length) > 0 then $workspaceId else null end)
   }')
 
-response=$(curl -sS --max-time 5 \
-  -X POST "${endpoint}/protocol/enforcement" \
-  -H "Content-Type: application/json" \
-  -d "$payload" 2>/dev/null) || exit 0
+curl_args=(-sS -f --max-time 5
+  -X POST "${endpoint}/protocol/enforcement"
+  -H "Content-Type: application/json"
+  -d "$payload")
+[[ -n "$api_key" ]] && curl_args+=(-H "Authorization: Bearer ${api_key}")
 
-blocked=$(echo "$response" | jq -r '.blocked // false' 2>/dev/null || echo "false")
+if ! response=$(curl "${curl_args[@]}" 2>/dev/null); then
+  echo "thoughtbox protocol_gate: enforcement unreachable at ${endpoint}/protocol/enforcement (network error, auth rejection, or 5xx); protocol gates NOT enforced for this action — failing open" >&2
+  exit 1
+fi
+
+if ! blocked=$(echo "$response" | jq -r '.blocked // false' 2>/dev/null); then
+  echo "thoughtbox protocol_gate: unparseable enforcement response from ${endpoint}/protocol/enforcement; protocol gates NOT enforced for this action — failing open" >&2
+  exit 1
+fi
 
 if [[ "$blocked" == "true" ]]; then
   reason=$(echo "$response" | jq -r '.reason // "Protocol enforcement blocked this action."' 2>/dev/null)

--- a/src/http/__tests__/protocol-hook-integration.test.ts
+++ b/src/http/__tests__/protocol-hook-integration.test.ts
@@ -1,8 +1,16 @@
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { chmodSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import type { AddressInfo } from "node:net";
+import type { Server } from "node:http";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import express from "express";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { createProtocolHttpSurface } from "../protocol-http.js";
+import type {
+  ProtocolEnforcementInput,
+  ProtocolEnforcementResult,
+} from "../../protocol/types.js";
 
 const HOOK_PATH = path.resolve(
   process.cwd(),
@@ -20,15 +28,41 @@ function buildHookInput(
   });
 }
 
+/**
+ * Async hook runner for tests where the hook's curl must reach an
+ * in-process HTTP server: spawnSync would block the event loop the server
+ * runs on and deadlock until curl's timeout.
+ */
+function runHookAgainstLiveServer(
+  input: string,
+  env: Record<string, string>,
+): Promise<{ status: number | null; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("bash", [HOOK_PATH], {
+      env: { ...process.env, ...env },
+    });
+    let stderr = "";
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+    child.on("error", reject);
+    child.on("close", (code) => resolve({ status: code, stderr }));
+    child.stdin.write(input);
+    child.stdin.end();
+  });
+}
+
 describe("protocol_gate.sh enforcement", () => {
   let projectDir: string;
   let fakeBinDir: string;
   let curlCapturePath: string;
+  let curlHeadersPath: string;
 
   beforeEach(() => {
     projectDir = mkdtempSync(path.join(os.tmpdir(), "thoughtbox-hook-"));
     fakeBinDir = path.join(projectDir, "bin");
     curlCapturePath = path.join(projectDir, "curl-payload.json");
+    curlHeadersPath = path.join(projectDir, "curl-headers.txt");
 
     mkdirSync(path.join(projectDir, "src"), { recursive: true });
     mkdirSync(fakeBinDir, { recursive: true });
@@ -39,11 +73,24 @@ describe("protocol_gate.sh enforcement", () => {
       `#!/usr/bin/env bash
 set -euo pipefail
 payload=""
+headers=""
+url=""
 while [[ "$#" -gt 0 ]]; do
   case "$1" in
     -d)
       payload="$2"
       shift 2
+      ;;
+    -H)
+      headers+="$2"$'\\n'
+      shift 2
+      ;;
+    -X)
+      shift 2
+      ;;
+    http*)
+      url="$1"
+      shift
       ;;
     *)
       shift
@@ -52,6 +99,12 @@ while [[ "$#" -gt 0 ]]; do
 done
 if [[ -n "\${FAKE_CURL_CAPTURE:-}" && -n "$payload" ]]; then
   printf '%s' "$payload" > "$FAKE_CURL_CAPTURE"
+fi
+if [[ -n "\${FAKE_CURL_HEADERS:-}" && -n "$headers" ]]; then
+  printf '%s' "$headers" > "$FAKE_CURL_HEADERS"
+fi
+if [[ -n "\${FAKE_CURL_URL:-}" && -n "$url" ]]; then
+  printf '%s' "$url" > "$FAKE_CURL_URL"
 fi
 printf '%s' "$FAKE_CURL_RESPONSE"
 exit "$FAKE_CURL_EXIT_CODE"
@@ -77,7 +130,12 @@ exit "$FAKE_CURL_EXIT_CODE"
         PATH: `${fakeBinDir}:${process.env.PATH ?? ""}`,
         THOUGHTBOX_URL: "http://localhost:1731",
         THOUGHTBOX_WORKSPACE_ID: "",
+        THOUGHTBOX_API_KEY: "",
+        OTEL_EXPORTER_OTLP_ENDPOINT: "",
+        OTEL_EXPORTER_OTLP_HEADERS: "",
+        CLAUDE_PROJECT_DIR: projectDir,
         FAKE_CURL_CAPTURE: curlCapturePath,
+        FAKE_CURL_HEADERS: curlHeadersPath,
         FAKE_CURL_RESPONSE: JSON.stringify({ enforce: false }),
         FAKE_CURL_EXIT_CODE: "0",
         ...env,
@@ -87,6 +145,10 @@ exit "$FAKE_CURL_EXIT_CODE"
 
   function capturedPayload(): Record<string, unknown> {
     return JSON.parse(readFileSync(curlCapturePath, "utf8"));
+  }
+
+  function capturedHeaders(): string {
+    return readFileSync(curlHeadersPath, "utf8");
   }
 
   it("blocks Write when Ulysses requires reflect", () => {
@@ -177,7 +239,93 @@ exit "$FAKE_CURL_EXIT_CODE"
     expect(result.stderr).toBe("");
   });
 
-  it("fails open when curl fails", () => {
+  it("sends Authorization Bearer header from THOUGHTBOX_API_KEY", () => {
+    const result = runHook(
+      buildHookInput("Write", {
+        file_path: path.join(projectDir, "src", "widget.ts"),
+      }),
+      {
+        THOUGHTBOX_API_KEY: "tbx_abc123_secret",
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(capturedHeaders()).toContain(
+      "Authorization: Bearer tbx_abc123_secret",
+    );
+  });
+
+  it("extracts the API key from OTEL_EXPORTER_OTLP_HEADERS when set", () => {
+    const result = runHook(
+      buildHookInput("Write", {
+        file_path: path.join(projectDir, "src", "widget.ts"),
+      }),
+      {
+        OTEL_EXPORTER_OTLP_HEADERS: "Authorization=Bearer tbx_from_otel_env",
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(capturedHeaders()).toContain(
+      "Authorization: Bearer tbx_from_otel_env",
+    );
+  });
+
+  it("resolves endpoint and key from .claude/settings.local.json (thoughtbox init config)", () => {
+    const claudeDir = path.join(projectDir, ".claude");
+    mkdirSync(claudeDir, { recursive: true });
+    writeFileSync(
+      path.join(claudeDir, "settings.local.json"),
+      JSON.stringify({
+        mcpServers: {
+          thoughtbox: {
+            type: "http",
+            url: "https://hosted.example.com/mcp?key=tbx_cfg_key",
+          },
+        },
+        env: {
+          OTEL_EXPORTER_OTLP_ENDPOINT: "https://hosted.example.com",
+          OTEL_EXPORTER_OTLP_HEADERS: "Authorization=Bearer tbx_cfg_key",
+        },
+      }),
+      "utf8",
+    );
+    const urlCapturePath = path.join(projectDir, "curl-url.txt");
+
+    const result = runHook(
+      buildHookInput("Write", {
+        file_path: path.join(projectDir, "src", "widget.ts"),
+      }),
+      {
+        THOUGHTBOX_URL: "",
+        FAKE_CURL_URL: urlCapturePath,
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(readFileSync(urlCapturePath, "utf8")).toBe(
+      "https://hosted.example.com/protocol/enforcement",
+    );
+    expect(capturedHeaders()).toContain("Authorization: Bearer tbx_cfg_key");
+  });
+
+  it("fails open LOUDLY when no endpoint is configured", () => {
+    const result = runHook(
+      buildHookInput("Write", {
+        file_path: path.join(projectDir, "src", "widget.ts"),
+      }),
+      {
+        THOUGHTBOX_URL: "",
+      },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("no Thoughtbox endpoint configured");
+    expect(result.stderr).toContain("failing open");
+    expect(() => capturedPayload()).toThrow();
+  });
+
+  it("fails open LOUDLY when curl fails", () => {
     const result = runHook(
       buildHookInput("Write", {
         file_path: path.join(projectDir, "src", "widget.ts"),
@@ -187,6 +335,240 @@ exit "$FAKE_CURL_EXIT_CODE"
       },
     );
 
-    expect(result.status).toBe(0);
+    // Exit 1 = non-blocking for Claude Code hooks (tool proceeds), but
+    // stderr is surfaced to the user — the gate never fails open silently.
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("enforcement unreachable");
+    expect(result.stderr).toContain("failing open");
+  });
+
+  it("fails open LOUDLY on an unparseable enforcement response", () => {
+    const result = runHook(
+      buildHookInput("Write", {
+        file_path: path.join(projectDir, "src", "widget.ts"),
+      }),
+      {
+        FAKE_CURL_RESPONSE: "<html>gateway error</html>",
+      },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("unparseable enforcement response");
+    expect(result.stderr).toContain("failing open");
+  });
+});
+
+describe("hosted /protocol/enforcement surface", () => {
+  const WORKSPACE_A = "11111111-1111-4111-8111-111111111111";
+  const VALID_KEY = "tbx_hosted_valid";
+
+  let server: Server;
+  let baseUrl: string;
+  let seenInputs: ProtocolEnforcementInput[];
+  let decision: ProtocolEnforcementResult;
+
+  beforeAll(async () => {
+    seenInputs = [];
+    decision = { enforce: false };
+
+    const app = express();
+    app.use(express.json());
+
+    // Mirrors the multi-tenant wiring in src/index.ts: a storage-backed
+    // enforcement handler consulted with the workspace resolved from the
+    // request's credentials — never from the request body.
+    const surface = createProtocolHttpSurface({
+      getHandlers: () => [
+        {
+          checkEnforcement: async (input: ProtocolEnforcementInput) => {
+            seenInputs.push(input);
+            if (input.workspaceId === WORKSPACE_A) return decision;
+            return { enforce: false };
+          },
+        },
+      ],
+      resolveWorkspaceId: async (req) => {
+        const auth = req.headers.authorization;
+        if (auth === `Bearer ${VALID_KEY}`) return WORKSPACE_A;
+        throw new Error("Invalid API key");
+      },
+    });
+    surface.mount(app);
+
+    await new Promise<void>((resolve) => {
+      server = app.listen(0, "127.0.0.1", () => resolve());
+    });
+    const address = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  beforeEach(() => {
+    seenInputs = [];
+    decision = { enforce: false };
+  });
+
+  it("rejects unauthenticated requests with 401 and consults no handler", async () => {
+    const res = await fetch(`${baseUrl}/protocol/enforcement`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ mutation: true, targetPath: "src/x.ts" }),
+    });
+
+    expect(res.status).toBe(401);
+    expect(seenInputs).toHaveLength(0);
+  });
+
+  it("returns a workspace-scoped blocking decision for an authed request", async () => {
+    decision = {
+      enforce: true,
+      blocked: true,
+      protocol: "ulysses",
+      reason:
+        "REFLECT REQUIRED: Ulysses session is waiting for reflect before further mutation",
+      required_action: "reflect",
+    };
+
+    const res = await fetch(`${baseUrl}/protocol/enforcement`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${VALID_KEY}`,
+      },
+      body: JSON.stringify({ mutation: true, targetPath: "src/x.ts" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ProtocolEnforcementResult;
+    expect(body.blocked).toBe(true);
+    expect(body.required_action).toBe("reflect");
+    expect(seenInputs).toHaveLength(1);
+    expect(seenInputs[0]?.workspaceId).toBe(WORKSPACE_A);
+  });
+
+  it("ignores a spoofed workspaceId in the body — credentials decide scope", async () => {
+    const res = await fetch(`${baseUrl}/protocol/enforcement`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${VALID_KEY}`,
+      },
+      body: JSON.stringify({
+        mutation: true,
+        targetPath: "src/x.ts",
+        workspaceId: "attacker-chosen-workspace",
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(seenInputs).toHaveLength(1);
+    expect(seenInputs[0]?.workspaceId).toBe(WORKSPACE_A);
+  });
+
+  it("blocks a hosted Edit end-to-end through protocol_gate.sh (real curl)", async () => {
+    decision = {
+      enforce: true,
+      blocked: true,
+      protocol: "theseus",
+      reason: "VISA REQUIRED: File outside declared scope",
+      required_action: "visa",
+    };
+
+    const result = await runHookAgainstLiveServer(
+      buildHookInput("Edit", { file_path: "src/out-of-scope.ts" }),
+      {
+        THOUGHTBOX_URL: baseUrl,
+        THOUGHTBOX_API_KEY: VALID_KEY,
+        THOUGHTBOX_WORKSPACE_ID: "",
+      },
+    );
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain("VISA REQUIRED");
+    expect(seenInputs).toHaveLength(1);
+    expect(seenInputs[0]?.workspaceId).toBe(WORKSPACE_A);
+  });
+
+  it("fails open loudly through the hook when the API key is rejected", async () => {
+    const result = await runHookAgainstLiveServer(
+      buildHookInput("Edit", { file_path: "src/out-of-scope.ts" }),
+      {
+        THOUGHTBOX_URL: baseUrl,
+        THOUGHTBOX_API_KEY: "tbx_wrong_key",
+        THOUGHTBOX_WORKSPACE_ID: "",
+      },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("failing open");
+  });
+});
+
+describe("local /protocol/enforcement aggregation", () => {
+  it("a block from ANY session handler wins over earlier allows", async () => {
+    const allowHandler = {
+      checkEnforcement: async (): Promise<ProtocolEnforcementResult> => ({
+        enforce: true,
+        blocked: false,
+        protocol: "theseus" as const,
+      }),
+    };
+    const blockHandler = {
+      checkEnforcement: async (): Promise<ProtocolEnforcementResult> => ({
+        enforce: true,
+        blocked: true,
+        protocol: "ulysses" as const,
+        reason: "REFLECT REQUIRED",
+        required_action: "reflect" as const,
+      }),
+    };
+
+    const app = express();
+    app.use(express.json());
+    createProtocolHttpSurface({
+      getHandlers: () => [allowHandler, blockHandler],
+    }).mount(app);
+
+    const server: Server = await new Promise((resolve) => {
+      const s = app.listen(0, "127.0.0.1", () => resolve(s));
+    });
+    try {
+      const { port } = server.address() as AddressInfo;
+      const res = await fetch(`http://127.0.0.1:${port}/protocol/enforcement`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ mutation: true, targetPath: "src/x.ts" }),
+      });
+      const body = (await res.json()) as ProtocolEnforcementResult;
+      expect(body.blocked).toBe(true);
+      expect(body.protocol).toBe("ulysses");
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it("returns enforce:false when no session has a protocol handler", async () => {
+    const app = express();
+    app.use(express.json());
+    createProtocolHttpSurface({ getHandlers: () => [] }).mount(app);
+
+    const server: Server = await new Promise((resolve) => {
+      const s = app.listen(0, "127.0.0.1", () => resolve(s));
+    });
+    try {
+      const { port } = server.address() as AddressInfo;
+      const res = await fetch(`http://127.0.0.1:${port}/protocol/enforcement`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ mutation: true, targetPath: "src/x.ts" }),
+      });
+      const body = (await res.json()) as ProtocolEnforcementResult;
+      expect(body).toEqual({ enforce: false });
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
   });
 });

--- a/src/http/__tests__/protocol-http.test.ts
+++ b/src/http/__tests__/protocol-http.test.ts
@@ -42,12 +42,12 @@ describe("protocol HTTP surface", () => {
       checkEnforcement: vi.fn(async () => ({ enforce: false })),
     };
 
-    createProtocolHttpSurface(() => handler).mount(app);
+    createProtocolHttpSurface({ getHandlers: () => [handler] }).mount(app);
 
     expect(listRoutes(app)).toContain("/protocol/enforcement");
   });
 
-  it("returns enforcement response from the shared handler", async () => {
+  it("returns enforcement response from the session handler", async () => {
     const app = express();
     app.use(express.json());
 
@@ -60,7 +60,7 @@ describe("protocol HTTP surface", () => {
       })),
     };
 
-    createProtocolHttpSurface(() => handler).mount(app);
+    createProtocolHttpSurface({ getHandlers: () => [handler] }).mount(app);
     const routeHandler = getRouteHandler(app, "/protocol/enforcement");
     expect(routeHandler).toBeTypeOf("function");
 
@@ -88,6 +88,38 @@ describe("protocol HTTP surface", () => {
       mutation: true,
       targetPath: "src/protocol/handler.ts",
       workspaceId: undefined,
+    });
+  });
+
+  it("honors a body workspaceId in local mode (no credential resolver)", async () => {
+    const app = express();
+    app.use(express.json());
+
+    const handler = {
+      checkEnforcement: vi.fn(async () => ({ enforce: false })),
+    };
+
+    createProtocolHttpSurface({ getHandlers: () => [handler] }).mount(app);
+    const routeHandler = getRouteHandler(app, "/protocol/enforcement");
+
+    const req = {
+      body: {
+        mutation: true,
+        targetPath: "src/x.ts",
+        workspaceId: "local-workspace",
+      },
+    } as Request;
+    const res = {
+      json: vi.fn(),
+      status: vi.fn().mockReturnThis(),
+    } as unknown as Response;
+
+    await routeHandler!(req, res);
+
+    expect(handler.checkEnforcement).toHaveBeenCalledWith({
+      mutation: true,
+      targetPath: "src/x.ts",
+      workspaceId: "local-workspace",
     });
   });
 });

--- a/src/http/protocol-http.ts
+++ b/src/http/protocol-http.ts
@@ -10,38 +10,84 @@ export interface ProtocolEnforcementHandler {
   ): Promise<ProtocolEnforcementResult>;
 }
 
+export interface ProtocolHttpSurfaceOptions {
+  /**
+   * Enforcement handlers to consult for a decision.
+   *
+   * Local mode returns one handler per live MCP session (protocol state can
+   * be per-session there when the in-memory backend is active); the surface
+   * aggregates across them — a block from ANY active protocol session wins,
+   * so a second concurrent session can never mask an enforcement decision.
+   *
+   * Hosted (multi-tenant) mode returns a single storage-backed handler that
+   * resolves protocol state per-workspace from Supabase; no live in-process
+   * session handler is required for enforcement.
+   */
+  getHandlers: () => ProtocolEnforcementHandler[];
+  /**
+   * Hosted (multi-tenant) mode: resolve the workspace from the request's
+   * Authorization credentials (tbx_* API key or OAuth JWT). When provided,
+   * unauthenticated requests are rejected with 401 and any workspaceId in
+   * the request body is ignored — the caller's credentials, not its claims,
+   * decide the enforcement scope.
+   */
+  resolveWorkspaceId?: (req: Request) => Promise<string>;
+}
+
 export interface ProtocolHttpSurface {
   mount(app: Express): void;
 }
 
 export function createProtocolHttpSurface(
-  getHandler: () => ProtocolEnforcementHandler | null,
+  options: ProtocolHttpSurfaceOptions,
 ): ProtocolHttpSurface {
   function mount(app: Express): void {
     app.post("/protocol/enforcement", async (req: Request, res: Response) => {
-      try {
-        const handler = getHandler();
-        if (!handler) {
-          res.json({ enforce: false });
+      const body = (req.body ?? {}) as {
+        mutation?: unknown;
+        targetPath?: unknown;
+        workspaceId?: unknown;
+      };
+
+      let workspaceId: string | undefined;
+      if (options.resolveWorkspaceId) {
+        try {
+          workspaceId = await options.resolveWorkspaceId(req);
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : "Authentication failed";
+          res.status(401).json({ error: message });
           return;
         }
+      } else if (typeof body.workspaceId === "string" && body.workspaceId) {
+        workspaceId = body.workspaceId;
+      }
 
-        const body = (req.body ?? {}) as {
-          mutation?: unknown;
-          targetPath?: unknown;
-          workspaceId?: unknown;
-        };
+      try {
+        const handlers = options.getHandlers();
 
         const input: ProtocolEnforcementInput = {
           mutation: Boolean(body.mutation),
           targetPath:
             typeof body.targetPath === "string" ? body.targetPath : undefined,
-          workspaceId:
-            typeof body.workspaceId === "string" ? body.workspaceId : undefined,
+          workspaceId,
         };
 
-        const result = await handler.checkEnforcement(input);
-        res.json(result);
+        // Blocked-wins aggregation: the first blocking decision is returned
+        // immediately; otherwise prefer an enforcing (allow) decision over
+        // "no active protocol session".
+        let aggregate: ProtocolEnforcementResult = { enforce: false };
+        for (const handler of handlers) {
+          const result = await handler.checkEnforcement(input);
+          if (result.blocked) {
+            res.json(result);
+            return;
+          }
+          if (result.enforce && !aggregate.enforce) {
+            aggregate = result;
+          }
+        }
+        res.json(aggregate);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         res.status(500).json({ error: message });

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,7 @@ import {
   createProtocolHttpSurface,
   type ProtocolEnforcementHandler,
 } from "./http/protocol-http.js";
+import { createSupabaseProtocolHandler } from "./protocol/index.js";
 import { resolveRequestAuth } from "./auth/resolve-request-auth.js";
 import { ensureStaticWorkspace } from "./auth/static-workspace.js";
 import { mountOtlpRoutes } from "./otel/index.js";
@@ -433,6 +434,10 @@ async function startHttpServer() {
           transport,
           server,
           workspaceId: workspaceId!,
+          // Hosted enforcement never consults live session handlers: the
+          // /protocol/enforcement route below resolves protocol state
+          // per-workspace straight from Supabase, so it works even when no
+          // MCP session for that workspace is alive in this container.
           protocolHandler: null,
         });
         transport.onclose = () => {
@@ -536,15 +541,64 @@ async function startHttpServer() {
   );
 
   // ---------------------------------------------------------------------------
-  // Hub Event SSE Endpoint — pushes HubEvents to Channel subscribers
+  // Protocol enforcement surface (`POST /protocol/enforcement`) — mounted in
+  // BOTH modes. This is the hook-facing gate behind protocol_gate.sh.
+  //
+  // Hosted (multi-tenant): a single storage-backed ProtocolHandler resolves
+  // protocol_sessions/protocol_scope from Supabase per authenticated
+  // workspace. No live in-process session handler is required, so the gate
+  // holds across container restarts and for sessions served by other
+  // instances. Requests must carry a tbx_* API key or OAuth JWT; the
+  // resolved workspace — never the request body — decides the scope.
+  //
+  // Local: every live MCP session's protocol handler is consulted and a
+  // block from any of them wins (per-session in-memory protocol state means
+  // no single handler sees all active protocol sessions).
   // ---------------------------------------------------------------------------
 
-  const protocolHttpSurface = createProtocolHttpSurface(() => {
-    for (const entry of sessions.values()) {
-      if (entry.protocolHandler) return entry.protocolHandler;
+  const hostedEnforcementHandler: ProtocolEnforcementHandler | null =
+    isMultiTenant
+      ? createSupabaseProtocolHandler({
+          supabaseUrl: process.env.SUPABASE_URL!,
+          serviceRoleKey: process.env.SUPABASE_SERVICE_ROLE_KEY!,
+        })
+      : null;
+
+  const resolveEnforcementWorkspace = async (req: Request): Promise<string> => {
+    const authHeader = req.headers.authorization as string | undefined;
+    const token = authHeader?.startsWith("Bearer ")
+      ? authHeader.slice(7)
+      : undefined;
+    if (token && !token.startsWith("tbx_")) {
+      const claims = await verifyOAuthToken(token);
+      return claims.workspace_id;
     }
-    return null;
-  });
+    // tbx_* Bearer key or ?key= query param.
+    return resolveRequestAuth(req);
+  };
+
+  const protocolHttpSurface = createProtocolHttpSurface(
+    isMultiTenant
+      ? {
+          getHandlers: () =>
+            hostedEnforcementHandler ? [hostedEnforcementHandler] : [],
+          resolveWorkspaceId: resolveEnforcementWorkspace,
+        }
+      : {
+          getHandlers: () =>
+            [...sessions.values()]
+              .map((entry) => entry.protocolHandler)
+              .filter(
+                (handler): handler is ProtocolEnforcementHandler =>
+                  handler !== null,
+              ),
+        },
+  );
+  protocolHttpSurface.mount(app);
+
+  // ---------------------------------------------------------------------------
+  // Hub Event SSE Endpoint — pushes HubEvents to Channel subscribers
+  // ---------------------------------------------------------------------------
 
   // Local-mode hub HTTP surface (`POST /hub/api`). Its thought store
   // delegates to real filesystem session storage scoped to the local
@@ -560,7 +614,6 @@ async function startHttpServer() {
 
     eventStream.mount(app);
     hubApiSurface.mount(app);
-    protocolHttpSurface.mount(app);
   }
 
   // ---------------------------------------------------------------------------

--- a/src/protocol/handler.ts
+++ b/src/protocol/handler.ts
@@ -3,7 +3,7 @@
  * Uses Supabase as the persistence backend with workspace isolation (ADR-013).
  */
 
-import type { SupabaseClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 import type { Database, Json } from '../database.types.js';
 import type { ThoughtboxEvent, OnThoughtboxEvent } from '../events/types.js';
 import type { ValidatorService } from '../notebook/validator.js';
@@ -25,6 +25,27 @@ import {
   type ProtocolEnforcementInput,
   type ProtocolEnforcementResult,
 } from './types.js';
+
+/**
+ * Build a Supabase-backed ProtocolHandler for hosted enforcement lookups.
+ *
+ * Used by the multi-tenant `/protocol/enforcement` route: checkEnforcement
+ * resolves protocol_sessions/protocol_scope per `input.workspaceId` straight
+ * from storage, so no per-session in-process handler (and no validator
+ * service) is required for enforcement decisions.
+ */
+export function createSupabaseProtocolHandler(options: {
+  supabaseUrl: string;
+  serviceRoleKey: string;
+  onEvent?: OnThoughtboxEvent;
+}): ProtocolHandler {
+  const client = createClient<Database>(
+    options.supabaseUrl,
+    options.serviceRoleKey,
+    { auth: { persistSession: false, autoRefreshToken: false } },
+  );
+  return new ProtocolHandler(client, options.onEvent);
+}
 
 export class ProtocolHandler {
   private workspaceId: string | null = null;

--- a/src/protocol/index.ts
+++ b/src/protocol/index.ts
@@ -1,4 +1,4 @@
-export { ProtocolHandler } from './handler.js';
+export { ProtocolHandler, createSupabaseProtocolHandler } from './handler.js';
 export { InMemoryProtocolHandler } from './in-memory-handler.js';
 
 export {


### PR DESCRIPTION
## Problem

The protocol enforcement gate — the product's flagship "gate agents cannot bypass" — silently failed open for **every hosted install**:

1. `/protocol/enforcement` was mounted only inside the local-mode block in `src/index.ts`, so hosted POSTs 404'd.
2. `protocol_gate.sh` sent no `Authorization` header, so even a mounted hosted route could not resolve a workspace.
3. Multi-tenant sessions were created with `protocolHandler: null`, and the surface only consulted live in-process handlers.
4. Local mode picked the FIRST session with a protocol handler — wrong with multiple concurrent sessions.
5. The hook defaulted to a hardcoded endpoint and exited 0 silently on any failure.

## Changes

**Server**
- `/protocol/enforcement` is now mounted in both modes.
- Hosted mode: a storage-backed `ProtocolHandler` (`createSupabaseProtocolHandler`, keeps supabase-js inside the existing arch-debt file) resolves `protocol_sessions`/`protocol_scope` per workspace directly from Supabase — no live MCP session required, decisions survive container restarts and cross-instance routing.
- Hosted auth: `tbx_*` API key or OAuth JWT required; the resolved workspace — never the request body — decides the enforcement scope (body `workspaceId` spoofing is ignored; unauthenticated → 401).
- Local mode: blocked-wins aggregation across ALL live session handlers replaces first-handler-wins.

**Hook (`protocol_gate.sh`)**
- Endpoint resolution: `THOUGHTBOX_URL` → `OTEL_EXPORTER_OTLP_ENDPOINT` → `thoughtbox init` config in `.claude/settings.local.json`. No hardcoded default.
- Sends `Authorization: Bearer <key>` resolved from `THOUGHTBOX_API_KEY` → `OTEL_EXPORTER_OTLP_HEADERS` → init config.
- Fail-open stays the availability posture, but it is now LOUD: exit 1 (non-blocking) + visible stderr warning on unreachable/unconfigured/auth-rejected enforcement. Blocks remain exit 2.

**Spec**: `.specs/protocol-runtime-integration.md` updated in the same commit (hosted auth, storage-backed lookup, aggregation semantics, loud fail-open, acceptance criteria).

## Verification

Real end-to-end against a `THOUGHTBOX_STORAGE=supabase` server on the local Supabase stack (seeded workspace + bcrypt-hashed `tbx_` key + protocol rows, then cleaned up):
- Unauthenticated POST → 401.
- Authed POST during active Ulysses `S=2` → workspace-scoped `blocked: true` (`reflect`).
- Hook `Edit` → **exit 2** `BLOCKED [ulysses]: REFLECT REQUIRED`, with no live MCP session in the container.
- Theseus out-of-scope `Edit` → exit 2 `VISA REQUIRED`; in-scope → exit 0.
- Bad API key → exit 1 with visible "failing open" warning.

Repeat manually: seed `workspaces`/`api_keys` (bcrypt hash of a `tbx_<prefix>_<secret>` key) + an active `protocol_sessions` row, start `THOUGHTBOX_STORAGE=supabase node dist/index.js`, run the hook with `THOUGHTBOX_URL` + `THOUGHTBOX_API_KEY`.

## Tests

- `pnpm check:types` / `pnpm check:lint` / `pnpm build:local` — clean.
- `npx vitest run` — 878 passed, 3 failed: the 3 known pre-existing environmental failures (`branch-workers` ×2, `intelligence-pipeline` ×1 — local Supabase edge runtime 503). Untouched.
- `protocol-hook-integration.test.ts` extended: hosted authed surface (401 / workspace-scoped block / body-spoof ignored), real-curl hook round-trip against a live server, loud fail-open cases, config-file resolution, local blocked-wins aggregation. 18 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)