### PR TITLE
feat(peer-notebook): close the graduation loop — graduated notebooks execute their own cells

### DIFF
--- a/.specs/mcp-peer-notebooks/SPEC-CONTROL-PLANE.md
+++ b/.specs/mcp-peer-notebooks/SPEC-CONTROL-PLANE.md
@@ -34,7 +34,12 @@ claims:
     statement: The deployed product inspection surface is the Next.js web app reading Supabase peer rows, not the legacy src/observatory server
     type: governance
     behavioral: false
-    required_evidence: DIAGRAMS.md and spec define the web app read model without depending on src/observatory
+    required_evidence: DIAGRAMS.md and spec define the web app read model without depending on src/observatory. First delivered surface is the read-only peers page at apps/web/src/app/w/[workspaceSlug]/peers/page.tsx, reading peer_notebooks, peer_manifests, and peer_invocations through the authed workspace-member RLS policies
+  - id: c7
+    statement: A graduated notebook's own code cells are executable through the runtime provider - graduation captures an immutable code snapshot on the manifest record and the local-process provider runs the snapshot's entry cell through the notebook execution engine, so graduation is invocability, not ceremony
+    type: implementation
+    behavioral: true
+    required_evidence: Manifests whose runtime.entry is "notebook:<cellFilename>" graduate with compiledFrom.notebook (PeerNotebookCodeSnapshot in src/peer-notebook/types.ts) - the notebook's code cells (manifest cell excluded), package.json cell, tsconfig, and language, captured as data by buildNotebookCodeSnapshot in src/peer-notebook/handler.ts. The broker threads the snapshot into RuntimeInvocationInput.notebook; LocalProcessRuntimeProvider.runNotebookEntry materializes it into a scratch directory and executes the entry cell via executeCodeCell/writeCodeCellToDisk from src/notebook/execution.ts under the manifest budget, with the peer cell protocol TB_PEER_INPUT_PATH -> TB_PEER_OUTPUT_PATH. Graduation rejects notebook entries whose cell is missing and package.json cells declaring dependencies (v1 dependency-free boundary). Evidence is src/peer-notebook/__tests__/graduation-execution.test.ts - author -> graduate -> approve -> invoke from a FRESH handler session sharing only the repository, real cell output, trace events, plus the negative paths - exercised by the first graduated peer, contradiction-scan (src/peer-notebook/peers/contradiction-scan-notebook.ts)
 links:
   - docs/decisions/archive/adr/staging/ADR-022.json
   - .specs/mcp-peer-notebooks/DIAGRAMS.md
@@ -152,6 +157,39 @@ registered claim-extractor entry, supersession, malformed JSON, missing
 manifest cell, schema violation, unregistered entry, missing entry, wrong
 provider, notebookId mismatch, unknown notebook) and the durable graduation
 test in `src/peer-notebook/__tests__/supabase-repository.test.ts`.
+
+Implementation note: the graduation-execution slice (c7) closes the loop the
+5.4 note left open - graduated notebooks are now runnable, not just compiled.
+A manifest may declare `runtime.entry: "notebook:<cellFilename>"`. At
+graduation, `buildNotebookCodeSnapshot` (`src/peer-notebook/handler.ts`)
+captures the notebook's executable surface as pure data onto the manifest
+record (`compiledFrom.notebook`, type `PeerNotebookCodeSnapshot`): every code
+cell except `peer.manifest.json`, the package.json cell, the tsconfig, and the
+language. The snapshot is immutable execution source - invocations never read
+live notebook state, so the peer works from any later session once approved.
+The broker threads the snapshot into `RuntimeInvocationInput.notebook`, and
+`LocalProcessRuntimeProvider.runNotebookEntry` materializes it into a scratch
+directory and executes the entry cell THROUGH the notebook execution engine
+(`writeCodeCellToDisk`/`writePackageJsonToDisk`/`writeTsconfigToDisk`/
+`executeCodeCell` from `src/notebook/execution.ts`) under the manifest budget.
+Peer cell protocol: the cell reads `{ invocationId, tool, args,
+artifactContent }` JSON from `TB_PEER_INPUT_PATH` and writes
+`{ result, artifacts }` JSON to `TB_PEER_OUTPUT_PATH` (the sidecar-file analog
+of the builtin stdin/stdout protocol, matching the engine's TB_OUTPUT_PATH
+pattern). Boundaries: notebook peers are dependency-free in v1 (a package.json
+cell declaring dependencies is rejected at graduation - no install step runs
+at invoke time); the brokered input artifact is named by an arg ending in
+`ArtifactId` (`textArtifactId` keeps pilot priority); `cancel()` during a
+notebook-cell run rejects the invocation immediately but the child is only
+reaped by the engine's budget timeout (development-only provider, documented
+gap); the RuntimeProvider contract seam is unchanged, so the deferred smolvm
+unit can implement the same snapshot execution behind real isolation. The
+first graduated peer is contradiction-scan
+(`src/peer-notebook/peers/contradiction-scan-notebook.ts`): authored as
+notebook cells, it takes a claims artifact and returns deterministic
+contradiction candidates (negation, antonym, numeric mismatch) as
+`contradictions.json` - the merge-evidence flow's candidate feed. Evidence:
+`src/peer-notebook/__tests__/graduation-execution.test.ts`.
 
 ## Non-Goals
 

--- a/.specs/mcp-peer-notebooks/SPEC-CONTROL-PLANE.md
+++ b/.specs/mcp-peer-notebooks/SPEC-CONTROL-PLANE.md
@@ -195,7 +195,9 @@ contradiction candidates (negation, antonym, numeric mismatch) as
 
 - Do not implement peer runtime code in this control-plane persistence slice.
 - Do not add Supabase migrations outside the ADR-022 peer control-plane schema.
-- Do not build web app screens.
+- Do not build web app screens beyond the read-only inspection surface (the
+  c6 peers page is delivered; interactive approval/authoring screens remain
+  out of scope for this spec).
 - Do not make Cloud Run host KVM, smolvm, or other privileged execution.
 - Do not require the v0 runtime to expose public direct MCP.
 - Do not use legacy `src/observatory` as the deployed product surface.

--- a/apps/web/src/app/w/[workspaceSlug]/peers/db.ts
+++ b/apps/web/src/app/w/[workspaceSlug]/peers/db.ts
@@ -1,0 +1,91 @@
+import { createServerClient } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+
+// Read-only Supabase access for the peers page. The peer control-plane
+// tables are not yet in the generated lib/supabase/database.types.ts, so this
+// route ships its own minimal typed view of the rows it reads (workspace
+// member read access is granted by the peer_* RLS policies in the
+// 20260430010000_create_peer_notebook_control_plane migration).
+
+export type PeerNotebookRow = {
+  id: string
+  workspace_id: string
+  slug: string
+  display_name: string
+  description: string | null
+  status: string
+  active_manifest_id: string | null
+  created_at: string
+  updated_at: string
+}
+
+export type PeerManifestRow = {
+  id: string
+  workspace_id: string
+  peer_id: string
+  version: number
+  schema_version: string
+  manifest: {
+    runtime?: { provider?: string; entry?: string }
+    exposes?: { tools?: Array<{ name?: string }> }
+  } | null
+  manifest_hash: string
+  status: string
+  approved_at: string | null
+  created_at: string
+}
+
+export type PeerInvocationRow = {
+  id: string
+  workspace_id: string
+  peer_id: string
+  manifest_hash: string
+  tool_name: string
+  status: string
+  runtime_provider: string
+  duration_ms: number | null
+  error: { message?: string } | null
+  created_at: string
+}
+
+type TableOf<Row> = {
+  Row: Row
+  Insert: Partial<Row>
+  Update: Partial<Row>
+  Relationships: []
+}
+
+type PeersDatabase = {
+  public: {
+    Tables: {
+      workspaces: TableOf<{ id: string; slug: string }>
+      peer_notebooks: TableOf<PeerNotebookRow>
+      peer_manifests: TableOf<PeerManifestRow>
+      peer_invocations: TableOf<PeerInvocationRow>
+    }
+    Views: { [_ in never]: never }
+    Functions: { [_ in never]: never }
+    Enums: { [_ in never]: never }
+    CompositeTypes: { [_ in never]: never }
+  }
+}
+
+export async function createPeersReadClient() {
+  const cookieStore = await cookies()
+
+  return createServerClient<PeersDatabase>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll()
+        },
+        setAll() {
+          // Read-only page rendered in a Server Component — session refresh
+          // is handled by middleware, so cookie writes are a no-op here.
+        },
+      },
+    },
+  )
+}

--- a/apps/web/src/app/w/[workspaceSlug]/peers/page.tsx
+++ b/apps/web/src/app/w/[workspaceSlug]/peers/page.tsx
@@ -1,0 +1,251 @@
+import type { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+import {
+  createPeersReadClient,
+  type PeerInvocationRow,
+  type PeerManifestRow,
+  type PeerNotebookRow,
+} from './db'
+
+export const metadata: Metadata = { title: 'Peers' }
+
+type Props = { params: Promise<{ workspaceSlug: string }> }
+
+export default async function PeersPage({ params }: Props) {
+  const { workspaceSlug } = await params
+
+  const supabase = await createPeersReadClient()
+
+  const { data: workspace } = await supabase
+    .from('workspaces')
+    .select('id, slug')
+    .eq('slug', workspaceSlug)
+    .single()
+
+  if (!workspace) notFound()
+
+  const [peersResult, manifestsResult, invocationsResult] = await Promise.all([
+    supabase
+      .from('peer_notebooks')
+      .select('*')
+      .eq('workspace_id', workspace.id)
+      .order('updated_at', { ascending: false })
+      .limit(50),
+    supabase
+      .from('peer_manifests')
+      .select('*')
+      .eq('workspace_id', workspace.id)
+      .order('created_at', { ascending: false })
+      .limit(100),
+    supabase
+      .from('peer_invocations')
+      .select('*')
+      .eq('workspace_id', workspace.id)
+      .order('created_at', { ascending: false })
+      .limit(50),
+  ])
+
+  const peers: PeerNotebookRow[] = peersResult.data ?? []
+  const manifests: PeerManifestRow[] = manifestsResult.data ?? []
+  const invocations: PeerInvocationRow[] = invocationsResult.data ?? []
+
+  const peerSlugById = new Map(peers.map(peer => [peer.id, peer.slug]))
+  const manifestsByPeer = new Map<string, PeerManifestRow[]>()
+  for (const manifest of manifests) {
+    const list = manifestsByPeer.get(manifest.peer_id) ?? []
+    list.push(manifest)
+    manifestsByPeer.set(manifest.peer_id, list)
+  }
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-8">
+      <div>
+        <h1 className="text-2xl font-bold text-foreground">Peers</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Brokered peer notebooks — manifests through the draft-to-active lifecycle, and their invocations.
+        </p>
+      </div>
+
+      {peers.length === 0 ? (
+        <Panel title="Peers">
+          <p className="py-6 text-center text-sm text-muted-foreground">
+            No peers registered in this workspace yet.
+          </p>
+        </Panel>
+      ) : (
+        <div className="space-y-6">
+          {peers.map(peer => {
+            const peerManifests = manifestsByPeer.get(peer.id) ?? []
+            return (
+              <Panel
+                key={peer.id}
+                title={peer.display_name}
+                subtitle={`${peer.slug} · ${peerManifests.length} manifest${peerManifests.length === 1 ? '' : 's'}`}
+              >
+                {peer.description && (
+                  <p className="mb-3 text-xs text-muted-foreground">{peer.description}</p>
+                )}
+                <div className="overflow-x-auto">
+                  <table className="w-full text-left text-xs">
+                    <thead>
+                      <tr className="border-b border-foreground/10 text-muted-foreground">
+                        <th className="py-2 pr-4 font-medium">Version</th>
+                        <th className="py-2 pr-4 font-medium">Status</th>
+                        <th className="py-2 pr-4 font-medium">Runtime entry</th>
+                        <th className="py-2 pr-4 font-medium">Tools</th>
+                        <th className="py-2 pr-4 font-medium">Hash</th>
+                        <th className="py-2 font-medium">Approved</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {peerManifests.map(manifest => (
+                        <tr key={manifest.id} className="border-b border-foreground/5">
+                          <td className="py-2 pr-4 tabular-nums text-foreground">v{manifest.version}</td>
+                          <td className="py-2 pr-4">
+                            <StatusBadge status={manifest.status} active={manifest.id === peer.active_manifest_id} />
+                          </td>
+                          <td className="py-2 pr-4 font-mono text-foreground">
+                            {manifest.manifest?.runtime?.entry ?? '—'}
+                          </td>
+                          <td className="py-2 pr-4 text-muted-foreground">
+                            {(manifest.manifest?.exposes?.tools ?? [])
+                              .map(tool => tool.name)
+                              .filter(Boolean)
+                              .join(', ') || '—'}
+                          </td>
+                          <td className="py-2 pr-4 font-mono text-muted-foreground" title={manifest.manifest_hash}>
+                            {shortHash(manifest.manifest_hash)}
+                          </td>
+                          <td className="py-2 text-muted-foreground">
+                            {manifest.approved_at ? formatTimestamp(manifest.approved_at) : '—'}
+                          </td>
+                        </tr>
+                      ))}
+                      {peerManifests.length === 0 && (
+                        <tr>
+                          <td colSpan={6} className="py-4 text-center text-muted-foreground">
+                            No manifests recorded.
+                          </td>
+                        </tr>
+                      )}
+                    </tbody>
+                  </table>
+                </div>
+              </Panel>
+            )
+          })}
+        </div>
+      )}
+
+      <Panel title="Recent invocations" subtitle="Last 50">
+        {invocations.length === 0 ? (
+          <p className="py-6 text-center text-sm text-muted-foreground">
+            No peer invocations recorded yet.
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-left text-xs">
+              <thead>
+                <tr className="border-b border-foreground/10 text-muted-foreground">
+                  <th className="py-2 pr-4 font-medium">Peer</th>
+                  <th className="py-2 pr-4 font-medium">Tool</th>
+                  <th className="py-2 pr-4 font-medium">Status</th>
+                  <th className="py-2 pr-4 font-medium">Provider</th>
+                  <th className="py-2 pr-4 font-medium">Duration</th>
+                  <th className="py-2 font-medium">Started</th>
+                </tr>
+              </thead>
+              <tbody>
+                {invocations.map(invocation => (
+                  <tr key={invocation.id} className="border-b border-foreground/5">
+                    <td className="py-2 pr-4 text-foreground">
+                      {peerSlugById.get(invocation.peer_id) ?? shortHash(invocation.peer_id)}
+                    </td>
+                    <td className="py-2 pr-4 font-mono text-foreground">{invocation.tool_name}</td>
+                    <td className="py-2 pr-4">
+                      <StatusBadge status={invocation.status} />
+                      {invocation.error?.message && (
+                        <span className="ml-2 text-muted-foreground" title={invocation.error.message}>
+                          {truncate(invocation.error.message, 60)}
+                        </span>
+                      )}
+                    </td>
+                    <td className="py-2 pr-4 text-muted-foreground">{invocation.runtime_provider}</td>
+                    <td className="py-2 pr-4 tabular-nums text-muted-foreground">
+                      {invocation.duration_ms === null ? '—' : `${invocation.duration_ms} ms`}
+                    </td>
+                    <td className="py-2 text-muted-foreground">{formatTimestamp(invocation.created_at)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Panel>
+    </div>
+  )
+}
+
+function Panel({
+  title,
+  subtitle,
+  children,
+}: {
+  title: string
+  subtitle?: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="rounded-2xl border border-foreground/10 bg-foreground/[0.03] p-5">
+      <div className="mb-4 flex items-baseline justify-between">
+        <h2 className="text-sm font-semibold text-foreground">{title}</h2>
+        {subtitle && <span className="text-xs text-muted-foreground">{subtitle}</span>}
+      </div>
+      {children}
+    </div>
+  )
+}
+
+const STATUS_STYLES: Record<string, string> = {
+  active: 'border-emerald-600 text-emerald-600',
+  completed: 'border-emerald-600 text-emerald-600',
+  draft: 'border-blue-500 text-blue-500',
+  running: 'border-blue-500 text-blue-500',
+  queued: 'border-blue-500 text-blue-500',
+  failed: 'border-rose-500 text-rose-500',
+  denied: 'border-rose-500 text-rose-500',
+  timeout: 'border-rose-500 text-rose-500',
+  rejected: 'border-rose-500 text-rose-500',
+  cancelled: 'border-foreground/20 text-muted-foreground',
+  retired: 'border-foreground/20 text-muted-foreground',
+}
+
+function StatusBadge({ status, active }: { status: string; active?: boolean }) {
+  const styles = STATUS_STYLES[status] ?? 'border-foreground/20 text-muted-foreground'
+  return (
+    <span
+      className={`inline-block rounded-lg border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider ${styles}`}
+    >
+      {status}
+      {active ? ' · live' : ''}
+    </span>
+  )
+}
+
+function shortHash(value: string): string {
+  const hex = value.startsWith('sha256:') ? value.slice(7) : value
+  return hex.slice(0, 12)
+}
+
+function truncate(value: string, max: number): string {
+  return value.length > max ? `${value.slice(0, max - 1)}…` : value
+}
+
+function formatTimestamp(value: string): string {
+  return new Date(value).toLocaleString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}

--- a/src/peer-notebook/__tests__/graduation-execution.test.ts
+++ b/src/peer-notebook/__tests__/graduation-execution.test.ts
@@ -1,0 +1,293 @@
+import * as fs from "fs/promises";
+import * as os from "os";
+import * as path from "path";
+import { afterAll, describe, expect, it } from "vitest";
+import { NotebookHandler } from "../../notebook/index.js";
+import {
+  CONTRADICTION_SCAN_CELL_SOURCE,
+  CONTRADICTION_SCAN_ENTRY_FILENAME,
+  CONTRADICTION_SCAN_PEER_ID,
+  CONTRADICTION_SCAN_TOOL_NAME,
+  contradictionScanManifest,
+  InMemoryPeerNotebookRepository,
+  PeerNotebookHandler,
+  PeerNotebookTool,
+} from "../index.js";
+import { graduationPeerManifest } from "./fixtures.js";
+
+const WORKSPACE_ID = "workspace_graduation_execution";
+const E2E_TIMEOUT_MS = 30_000;
+
+const tempDirs: string[] = [];
+
+afterAll(async () => {
+  for (const dir of tempDirs) {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+// Closes the graduation loop (SPEC-CONTROL-PLANE c7): a graduated notebook's
+// OWN code cells execute at invoke time. Graduation captures the executable
+// cells into an immutable code snapshot on the manifest record
+// (compiledFrom.notebook); the local-process provider materializes that
+// snapshot and runs the entry cell through the notebook execution engine.
+// The invoking handler is a FRESH instance sharing only the repository — the
+// authoring notebook session is gone, proving cross-session invocability.
+describe("graduated notebook execution", () => {
+  it(
+    "authors, graduates, approves, then a different session invokes the notebook's own cell end-to-end",
+    { timeout: E2E_TIMEOUT_MS },
+    async () => {
+      // --- Authoring session: real notebook, real cells, real lifecycle ---
+      const { repository, notebookHandler, tool: authoringTool } = await setupAuthoringSession();
+      const notebookId = await authorContradictionScanNotebook(notebookHandler);
+
+      const graduated = await authoringTool.handle({
+        operation: "peer_graduate_notebook",
+        notebookId,
+        displayName: "Contradiction scan",
+        description: "Flags contradiction candidates in a claims artifact",
+      });
+
+      expect(graduated.manifest.status).toBe("draft");
+      const snapshot = graduated.manifest.compiledFrom.notebook;
+      expect(snapshot).toBeDefined();
+      expect(snapshot?.entryFilename).toBe(CONTRADICTION_SCAN_ENTRY_FILENAME);
+      expect(snapshot?.language).toBe("javascript");
+      expect(snapshot?.cells.map(cell => cell.filename)).toEqual([CONTRADICTION_SCAN_ENTRY_FILENAME]);
+      expect(snapshot?.cells[0]?.source).toBe(CONTRADICTION_SCAN_CELL_SOURCE);
+
+      await authoringTool.handle({
+        operation: "peer_manifest_approve",
+        manifestId: graduated.manifest.id,
+      });
+
+      // --- Invoking session: fresh handler, NO notebook source, shared repo ---
+      const invokingHandler = new PeerNotebookHandler({
+        repository,
+        workspaceId: WORKSPACE_ID,
+      });
+      const invokingTool = new PeerNotebookTool(invokingHandler);
+
+      const seeded = await invokingTool.handle({
+        operation: "peer_artifact_seed",
+        name: "claims.json",
+        text: JSON.stringify({
+          claims: [
+            { id: "c1", text: "The cache is enabled" },
+            { id: "c2", text: "The cache is not enabled" },
+            { id: "c3", text: "Latency increased after the change" },
+            { id: "c4", text: "Latency decreased after the change" },
+            { id: "c5", text: "The deploy shipped on Tuesday" },
+          ],
+        }),
+      });
+
+      const invoked = await invokingTool.handle({
+        operation: "peer_invoke",
+        peerId: CONTRADICTION_SCAN_PEER_ID,
+        tool: CONTRADICTION_SCAN_TOOL_NAME,
+        args: { claimsArtifactId: seeded.artifact.id },
+      });
+
+      expect(invoked.result).toMatchObject({
+        candidateCount: 2,
+        claimCount: 5,
+        contradictionsArtifactId: expect.any(String),
+      });
+
+      const contradictionsArtifactId =
+        (invoked.result as { contradictionsArtifactId: string }).contradictionsArtifactId;
+      const artifact = await invokingTool.handle({
+        operation: "peer_get_artifact",
+        artifactId: contradictionsArtifactId,
+      });
+      expect(artifact.artifact.name).toBe("contradictions.json");
+      expect(artifact.artifact.content).toEqual({
+        candidates: [
+          {
+            leftId: "c1",
+            leftText: "The cache is enabled",
+            rightId: "c2",
+            rightText: "The cache is not enabled",
+            kind: "negation",
+          },
+          {
+            leftId: "c3",
+            leftText: "Latency increased after the change",
+            rightId: "c4",
+            rightText: "Latency decreased after the change",
+            kind: "antonym",
+          },
+        ],
+      });
+
+      // Invocation record + trace events carry the real execution story.
+      const read = await invokingTool.handle({
+        operation: "peer_get_invocation",
+        invocationId: invoked.invocationId,
+      });
+      expect(read.invocation.status).toBe("completed");
+      expect(read.invocation.runtimeProvider).toBe("local-process");
+
+      const traced = await invokingTool.handle({
+        operation: "peer_list_trace_events",
+        invocationId: invoked.invocationId,
+      });
+      expect(traced.events).toEqual(expect.arrayContaining([
+        expect.objectContaining({ eventType: "peer_invocation_created" }),
+        expect.objectContaining({
+          eventType: "outbound_call_allowed",
+          attrs: { target: "artifact.get" },
+        }),
+        expect.objectContaining({ eventType: "peer_artifact_written" }),
+        expect.objectContaining({ eventType: "peer_invocation_completed" }),
+      ]));
+    },
+  );
+
+  it("blocks invoke while the graduated notebook manifest is still a draft", async () => {
+    const { repository, notebookHandler, tool } = await setupAuthoringSession();
+    const notebookId = await authorContradictionScanNotebook(notebookHandler);
+
+    await tool.handle({ operation: "peer_graduate_notebook", notebookId });
+
+    const invokingTool = new PeerNotebookTool(new PeerNotebookHandler({
+      repository,
+      workspaceId: WORKSPACE_ID,
+    }));
+    const seeded = await invokingTool.handle({
+      operation: "peer_artifact_seed",
+      text: JSON.stringify({ claims: [{ id: "c1", text: "A" }] }),
+    });
+
+    await expect(invokingTool.handle({
+      operation: "peer_invoke",
+      peerId: CONTRADICTION_SCAN_PEER_ID,
+      tool: CONTRADICTION_SCAN_TOOL_NAME,
+      args: { claimsArtifactId: seeded.artifact.id },
+    })).rejects.toMatchObject({
+      code: "manifest_not_active",
+      message: expect.stringContaining("is draft"),
+    });
+  });
+
+  it("rejects graduation when the notebook entry cell does not exist", async () => {
+    const { notebookHandler, tool } = await setupAuthoringSession();
+    const created = await notebookHandler.handleCreateNotebook({
+      title: "Missing entry cell",
+      language: "javascript",
+    });
+    const notebookId = created.notebook.id as string;
+    const manifest = graduationPeerManifest("missing-entry-peer", notebookId, {
+      entry: "notebook:missing-cell.js",
+    });
+    await notebookHandler.handleAddCell({
+      notebookId,
+      cellType: "code",
+      content: JSON.stringify(manifest),
+      filename: "peer.manifest.json",
+    });
+
+    await expect(tool.handle({
+      operation: "peer_graduate_notebook",
+      notebookId,
+    })).rejects.toMatchObject({
+      code: "manifest_compile_error",
+      message: expect.stringContaining('no code cell named "missing-cell.js"'),
+    });
+  });
+
+  it("rejects graduation when the notebook package.json declares dependencies", async () => {
+    const { notebookHandler, tool } = await setupAuthoringSession();
+    const notebookId = await authorContradictionScanNotebook(notebookHandler);
+    const notebook = notebookHandler.getNotebook(notebookId);
+    const pkgCell = notebook?.cells.find(cell => cell.type === "package.json");
+    expect(pkgCell).toBeDefined();
+    await notebookHandler.handleUpdateCell({
+      notebookId,
+      cellId: pkgCell?.id,
+      content: JSON.stringify({ type: "module", dependencies: { lodash: "4.17.21" } }),
+    });
+
+    await expect(tool.handle({
+      operation: "peer_graduate_notebook",
+      notebookId,
+    })).rejects.toMatchObject({
+      code: "manifest_compile_error",
+      message: expect.stringContaining("dependency-free"),
+    });
+  });
+
+  it("fails invoke with invalid_args when a notebook-entry manifest lacks the graduation snapshot", async () => {
+    // Manifest created through the file-draft path (peer_manifest_create)
+    // never captures a code snapshot; a notebook entry there is a dead letter
+    // and the provider says so instead of guessing at live notebook state.
+    const { repository, tool } = await setupAuthoringSession();
+    const created = await tool.handle({
+      operation: "peer_manifest_create",
+      manifestJson: JSON.stringify(contradictionScanManifest("nb_orphan_manifest")),
+    });
+    await tool.handle({
+      operation: "peer_manifest_approve",
+      manifestId: created.manifest.id,
+    });
+
+    const invokingTool = new PeerNotebookTool(new PeerNotebookHandler({
+      repository,
+      workspaceId: WORKSPACE_ID,
+    }));
+    const seeded = await invokingTool.handle({
+      operation: "peer_artifact_seed",
+      text: JSON.stringify({ claims: [{ id: "c1", text: "A" }] }),
+    });
+
+    await expect(invokingTool.handle({
+      operation: "peer_invoke",
+      peerId: CONTRADICTION_SCAN_PEER_ID,
+      tool: CONTRADICTION_SCAN_TOOL_NAME,
+      args: { claimsArtifactId: seeded.artifact.id },
+    })).rejects.toMatchObject({
+      code: "invalid_args",
+      message: expect.stringContaining("compiledFrom.notebook is absent"),
+    });
+  });
+});
+
+async function setupAuthoringSession() {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "tb-graduation-exec-"));
+  tempDirs.push(tempDir);
+  const notebookHandler = new NotebookHandler(tempDir);
+  const repository = new InMemoryPeerNotebookRepository();
+  const handler = new PeerNotebookHandler({
+    repository,
+    workspaceId: WORKSPACE_ID,
+    notebookSource: notebookHandler,
+  });
+
+  return { repository, notebookHandler, tool: new PeerNotebookTool(handler) };
+}
+
+/** Author the contradiction-scan notebook exactly as an agent session would. */
+async function authorContradictionScanNotebook(notebookHandler: NotebookHandler): Promise<string> {
+  const created = await notebookHandler.handleCreateNotebook({
+    title: "Contradiction scan peer",
+    language: "javascript",
+  });
+  const notebookId = created.notebook.id as string;
+
+  await notebookHandler.handleAddCell({
+    notebookId,
+    cellType: "code",
+    content: CONTRADICTION_SCAN_CELL_SOURCE,
+    filename: CONTRADICTION_SCAN_ENTRY_FILENAME,
+  });
+  await notebookHandler.handleAddCell({
+    notebookId,
+    cellType: "code",
+    content: JSON.stringify(contradictionScanManifest(notebookId)),
+    filename: "peer.manifest.json",
+  });
+
+  return notebookId;
+}

--- a/src/peer-notebook/broker.ts
+++ b/src/peer-notebook/broker.ts
@@ -131,6 +131,7 @@ export class PeerBroker {
           tool: input.tool,
           args: input.args,
           entry: manifest.manifest.runtime.entry,
+          notebook: manifest.compiledFrom.notebook,
           brokerProxyUrl: "memory://broker-proxy",
           scopedToken,
           budgets: manifest.manifest.budgets,

--- a/src/peer-notebook/handler.ts
+++ b/src/peer-notebook/handler.ts
@@ -5,7 +5,7 @@ import { compilePeerManifestDraft } from "./manifest.js";
 import { createBrokerProxyTargets, type BrokerProxyTargetDeps } from "./proxy-targets.js";
 import { InMemoryPeerNotebookRepository, type PeerNotebookRepository } from "./repositories.js";
 import type { RuntimeProvider } from "./runtime-provider.js";
-import { PeerNotebookError } from "./types.js";
+import { notebookEntryFilename, PeerNotebookError } from "./types.js";
 import type {
   CompiledPeerManifest,
   JsonObject,
@@ -15,6 +15,7 @@ import type {
   PeerManifest,
   PeerManifestRecord,
   PeerManifestStatus,
+  PeerNotebookCodeSnapshot,
   PeerNotebookRecord,
   PeerTraceEventRecord,
   RuntimeProviderName,
@@ -53,6 +54,10 @@ export interface PeerGraduationNotebookCell {
 export interface PeerGraduationNotebook {
   id: string;
   cells: PeerGraduationNotebookCell[];
+  /** Notebook language; drives how a `notebook:` entry cell executes. */
+  language?: string;
+  /** Optional tsconfig captured into the graduation code snapshot. */
+  "tsconfig.json"?: string;
 }
 
 /** Read-only notebook lookup used by peer_graduate_notebook. */
@@ -262,6 +267,15 @@ export class PeerNotebookHandler {
       );
     }
     this.validateGraduatedRuntimeBinding(compiled.manifest);
+
+    // A `notebook:` runtime entry graduates with an immutable code snapshot on
+    // the manifest record: the notebook's executable cells, captured now, are
+    // what the runtime provider will execute — never live notebook state, so
+    // the peer keeps working after the authoring session is gone.
+    const entryCellFilename = notebookEntryFilename(compiled.manifest.runtime.entry);
+    if (entryCellFilename !== null) {
+      compiled.compiledFrom.notebook = buildNotebookCodeSnapshot(notebook, entryCellFilename);
+    }
 
     return this.persistDraft(workspaceId, compiled, input, { supersedeGraduatedDrafts: true });
   }
@@ -623,6 +637,74 @@ function manifestDraftSourcesFromNotebook(notebook: PeerGraduationNotebook): Man
     sources.push({ name: cell.filename, content: cell.source, sourceType: "cell" });
   }
   return sources;
+}
+
+/**
+ * Capture the executable code snapshot for a `notebook:` runtime entry.
+ * Included: every code cell except the manifest cell, the package.json cell,
+ * and the notebook tsconfig. Cell text is captured as data — nothing executes
+ * at graduation. v1 boundary: notebook peers must be dependency-free (node
+ * builtins only); the local-process provider materializes the snapshot into a
+ * scratch directory without running an install step.
+ */
+function buildNotebookCodeSnapshot(
+  notebook: PeerGraduationNotebook,
+  entryCellFilename: string,
+): PeerNotebookCodeSnapshot {
+  const cells: PeerNotebookCodeSnapshot["cells"] = [];
+  let packageJson: string | undefined;
+  for (const cell of notebook.cells) {
+    if (cell.type === "package.json" && typeof cell.source === "string") {
+      packageJson = cell.source;
+      continue;
+    }
+    if (cell.type !== "code") continue;
+    if (typeof cell.filename !== "string" || typeof cell.source !== "string") continue;
+    if (cell.filename === MANIFEST_CELL_FILENAME) continue;
+    cells.push({ filename: cell.filename, source: cell.source });
+  }
+
+  if (!cells.some(cell => cell.filename === entryCellFilename)) {
+    throw new PeerNotebookError(
+      "manifest_compile_error",
+      `Graduated manifest names runtime.entry "notebook:${entryCellFilename}" ` +
+        `but notebook ${notebook.id} has no code cell named "${entryCellFilename}"`,
+    );
+  }
+
+  if (packageJson !== undefined) {
+    let dependencies: Record<string, unknown> = {};
+    try {
+      const parsed = JSON.parse(packageJson) as { dependencies?: Record<string, unknown> };
+      dependencies = parsed.dependencies ?? {};
+    } catch {
+      throw new PeerNotebookError(
+        "manifest_compile_error",
+        `Notebook ${notebook.id} package.json cell is not valid JSON`,
+      );
+    }
+    if (Object.keys(dependencies).length > 0) {
+      throw new PeerNotebookError(
+        "manifest_compile_error",
+        `Notebook ${notebook.id} package.json declares dependencies ` +
+          `(${Object.keys(dependencies).join(", ")}); notebook peers must be dependency-free in v1`,
+      );
+    }
+  }
+
+  const language: PeerNotebookCodeSnapshot["language"] =
+    notebook.language === "typescript" || (notebook.language === undefined && entryCellFilename.endsWith(".ts"))
+      ? "typescript"
+      : "javascript";
+
+  return {
+    notebookId: notebook.id,
+    entryFilename: entryCellFilename,
+    language,
+    cells,
+    ...(packageJson !== undefined ? { packageJson } : {}),
+    ...(notebook["tsconfig.json"] !== undefined ? { tsconfigJson: notebook["tsconfig.json"] } : {}),
+  };
 }
 
 function previewText(text: string): string {

--- a/src/peer-notebook/index.ts
+++ b/src/peer-notebook/index.ts
@@ -33,6 +33,14 @@ export type {
   PeerGraduationNotebookCell,
   PeerGraduationNotebookSource,
 } from "./handler.js";
+export {
+  CONTRADICTION_SCAN_CELL_SOURCE,
+  CONTRADICTION_SCAN_DOC_MARKDOWN,
+  CONTRADICTION_SCAN_ENTRY_FILENAME,
+  CONTRADICTION_SCAN_PEER_ID,
+  CONTRADICTION_SCAN_TOOL_NAME,
+  contradictionScanManifest,
+} from "./peers/contradiction-scan-notebook.js";
 export { PEER_NOTEBOOK_TOOL, PeerNotebookTool, peerNotebookToolInputSchema } from "./tool.js";
 export type { PeerNotebookToolInput } from "./tool.js";
 export type {
@@ -47,13 +55,15 @@ export type {
   PeerManifest,
   PeerManifestRecord,
   PeerManifestStatus,
+  PeerNotebookCodeSnapshot,
   PeerNotebookRecord,
+  PeerNotebookSnapshotCell,
   PeerNotebookStatus,
   PeerToolManifest,
   PeerTraceEventRecord,
   RuntimeProviderName,
 } from "./types.js";
-export { PeerNotebookError } from "./types.js";
+export { NOTEBOOK_ENTRY_PREFIX, notebookEntryFilename, PeerNotebookError } from "./types.js";
 export type {
   RuntimeArtifactOutput,
   RuntimeInvocationInput,

--- a/src/peer-notebook/local-process-runtime-provider.ts
+++ b/src/peer-notebook/local-process-runtime-provider.ts
@@ -1,6 +1,15 @@
 import { spawn, type ChildProcess } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import * as fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  executeCodeCell,
+  writeCodeCellToDisk,
+  writePackageJsonToDisk,
+  writeTsconfigToDisk,
+} from "../notebook/execution.js";
 import type {
   RuntimeArtifactOutput,
   RuntimeInvocationInput,
@@ -8,8 +17,8 @@ import type {
   RuntimeProvider,
   RuntimeProviderDescription,
 } from "./runtime-provider.js";
-import type { JsonValue } from "./types.js";
-import { PeerNotebookError } from "./types.js";
+import type { JsonValue, PeerNotebookCodeSnapshot } from "./types.js";
+import { notebookEntryFilename, PeerNotebookError } from "./types.js";
 
 const PROVIDER_DIR = path.dirname(fileURLToPath(import.meta.url));
 const SCRIPT_EXTENSION = import.meta.url.endsWith(".ts") ? ".ts" : ".js";
@@ -37,9 +46,20 @@ export interface LocalProcessRuntimeProviderOptions {
  *   events match the mock contract fixture path. In-child broker calls are
  *   out of scope for v1.
  * - Entry scripts resolve from a fixed registry keyed by manifest
- *   runtime.entry; manifests cannot point at arbitrary filesystem paths.
+ *   runtime.entry, OR — for graduated notebooks — from the immutable code
+ *   snapshot captured on the manifest record at graduation
+ *   (`runtime.entry: "notebook:<cellFilename>"`). Manifests can never point
+ *   at arbitrary filesystem paths.
+ * - Notebook entries execute through the notebook execution engine
+ *   (src/notebook/execution.ts): the snapshot is materialized into a scratch
+ *   directory, the entry cell reads its invocation payload JSON from
+ *   TB_PEER_INPUT_PATH and writes `{ result, artifacts }` JSON to
+ *   TB_PEER_OUTPUT_PATH.
  * - The manifest budget (budgets.maxDurationMs) is enforced on the child via
  *   SIGTERM, escalating to SIGKILL; cancel() kills the child the same way.
+ *   For notebook entries the engine enforces the same budget via its timeout;
+ *   cancel() rejects the invocation immediately but the cell process is only
+ *   reaped by the engine timeout (v1 gap, acceptable for development-only).
  * - cancel() also covers the pre-spawn window: invocations are tracked from
  *   the moment invoke() is entered, and a cancel arriving while the broker
  *   round trips are still in flight preempts the spawn entirely.
@@ -49,6 +69,7 @@ export class LocalProcessRuntimeProvider implements RuntimeProvider {
   private readonly children = new Map<string, ChildProcess>();
   private readonly activeInvocations = new Set<string>();
   private readonly cancelledInvocations = new Set<string>();
+  private readonly notebookCancels = new Map<string, () => void>();
 
   constructor(options: LocalProcessRuntimeProviderOptions = {}) {
     this.entries = { ...BUILTIN_ENTRIES, ...options.entries };
@@ -67,11 +88,12 @@ export class LocalProcessRuntimeProvider implements RuntimeProvider {
   async invoke(input: RuntimeInvocationInput): Promise<RuntimeInvocationResult> {
     this.activeInvocations.add(input.invocationId);
     try {
-      const scriptPath = this.resolveEntryScript(input);
+      const entryCellFilename = notebookEntryFilename(input.entry);
+      const scriptPath = entryCellFilename === null ? this.resolveEntryScript(input) : null;
       const artifactContent = await fetchInputArtifact(input);
       this.throwIfCancelledBeforeSpawn(input.invocationId);
 
-      if (input.tool === "extract_claims") {
+      if (input.tool === "extract_claims" && entryCellFilename === null) {
         // Pilot-parity denied probe: traced as denied_outbound_call exactly as
         // the mock contract fixture path records it.
         await input.brokerProxy.callTool("thoughtbox.knowledge.queryGraph", { query: "denied pilot probe" });
@@ -84,10 +106,14 @@ export class LocalProcessRuntimeProvider implements RuntimeProvider {
         args: input.args,
         artifactContent,
       });
-      return await this.runEntryProcess(input, scriptPath, payload);
+      if (entryCellFilename !== null) {
+        return await this.runNotebookEntry(input, entryCellFilename, payload);
+      }
+      return await this.runEntryProcess(input, scriptPath as string, payload);
     } finally {
       this.activeInvocations.delete(input.invocationId);
       this.cancelledInvocations.delete(input.invocationId);
+      this.notebookCancels.delete(input.invocationId);
     }
   }
 
@@ -96,6 +122,12 @@ export class LocalProcessRuntimeProvider implements RuntimeProvider {
     if (child) {
       this.cancelledInvocations.add(input.invocationId);
       terminate(child);
+      return;
+    }
+    const rejectNotebookRun = this.notebookCancels.get(input.invocationId);
+    if (rejectNotebookRun) {
+      this.cancelledInvocations.add(input.invocationId);
+      rejectNotebookRun();
       return;
     }
     if (this.activeInvocations.has(input.invocationId)) {
@@ -110,7 +142,10 @@ export class LocalProcessRuntimeProvider implements RuntimeProvider {
   }
 
   resolvesEntry(entry: string): boolean {
-    return Object.hasOwn(this.entries, entry);
+    // Notebook entries resolve from the manifest's own graduation snapshot,
+    // not the fixed registry; the graduation flow validates that the named
+    // cell exists in the graduating notebook.
+    return notebookEntryFilename(entry) !== null || Object.hasOwn(this.entries, entry);
   }
 
   async heartbeat(): Promise<void> {}
@@ -209,23 +244,151 @@ export class LocalProcessRuntimeProvider implements RuntimeProvider {
       child.stdin?.end();
     });
   }
+
+  /**
+   * Execute a graduated notebook's entry cell from the manifest's code
+   * snapshot: materialize the snapshot into a scratch directory using the
+   * notebook execution engine's disk layout (src/<filename>, package.json,
+   * tsconfig.json), hand the invocation payload to the cell via
+   * TB_PEER_INPUT_PATH, run the cell through executeCodeCell under the
+   * manifest budget, and read `{ result, artifacts }` from TB_PEER_OUTPUT_PATH.
+   */
+  private async runNotebookEntry(
+    input: RuntimeInvocationInput,
+    entryCellFilename: string,
+    payload: string,
+  ): Promise<RuntimeInvocationResult> {
+    const snapshot = this.requireNotebookSnapshot(input, entryCellFilename);
+    const workDir = await fs.mkdtemp(path.join(os.tmpdir(), "tb-peer-run-"));
+
+    try {
+      if (snapshot.tsconfigJson) {
+        await writeTsconfigToDisk(workDir, snapshot.tsconfigJson);
+      }
+      if (snapshot.packageJson) {
+        await writePackageJsonToDisk(workDir, snapshot.packageJson);
+      }
+      for (const cell of snapshot.cells) {
+        await writeCodeCellToDisk(workDir, cell.filename, cell.source);
+      }
+
+      const inputPath = path.join(workDir, `peer-input-${randomUUID()}.json`);
+      const outputPath = path.join(workDir, `peer-output-${randomUUID()}.json`);
+      await fs.writeFile(inputPath, payload, "utf8");
+
+      const timeoutMs = input.budgets.maxDurationMs;
+      const cancelSignal = new Promise<never>((_, reject) => {
+        this.notebookCancels.set(input.invocationId, () => {
+          reject(new Error(`Peer process cancelled for invocation ${input.invocationId}`));
+        });
+      });
+
+      const execution = await Promise.race([
+        executeCodeCell(entryCellFilename, snapshot.language, {
+          cwd: workDir,
+          env: { TB_PEER_INPUT_PATH: inputPath, TB_PEER_OUTPUT_PATH: outputPath },
+          timeout: timeoutMs,
+        }),
+        cancelSignal,
+      ]);
+
+      if (this.cancelledInvocations.has(input.invocationId)) {
+        throw new Error(`Peer process cancelled for invocation ${input.invocationId}`);
+      }
+      if (!execution.success) {
+        // The engine reports its budget SIGTERM as exitCode -1 plus this
+        // stderr marker (src/notebook/execution.ts executeCommand).
+        if (/Execution timed out after \d+ms/.test(execution.stderr)) {
+          throw new PeerNotebookError(
+            "timeout",
+            `Peer notebook cell exceeded budget maxDurationMs=${timeoutMs} for invocation ${input.invocationId}`,
+          );
+        }
+        throw new Error(
+          `Peer notebook cell ${entryCellFilename} exited with ${execution.exitCode ?? "unknown"} ` +
+            `for invocation ${input.invocationId}: ${(execution.stderr || execution.stdout).slice(0, STDERR_LIMIT)}`,
+        );
+      }
+
+      let resultJson: string;
+      try {
+        resultJson = await fs.readFile(outputPath, "utf8");
+      } catch {
+        throw new PeerNotebookError(
+          "invalid_result",
+          `Peer notebook cell ${entryCellFilename} wrote no result to TB_PEER_OUTPUT_PATH for invocation ${input.invocationId}`,
+        );
+      }
+      return parseRuntimeResult(resultJson);
+    } finally {
+      this.notebookCancels.delete(input.invocationId);
+      await fs.rm(workDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }
+
+  private requireNotebookSnapshot(
+    input: RuntimeInvocationInput,
+    entryCellFilename: string,
+  ): PeerNotebookCodeSnapshot {
+    const snapshot = input.notebook;
+    if (!snapshot) {
+      throw new PeerNotebookError(
+        "invalid_args",
+        `Peer ${input.peerId} runtime.entry "${input.entry}" requires the graduation code snapshot, ` +
+          "but the manifest record carries none (compiledFrom.notebook is absent)",
+      );
+    }
+    if (snapshot.entryFilename !== entryCellFilename) {
+      throw new PeerNotebookError(
+        "invalid_args",
+        `Peer ${input.peerId} runtime.entry "${input.entry}" does not match the graduation snapshot ` +
+          `entry cell "${snapshot.entryFilename}"`,
+      );
+    }
+    if (!snapshot.cells.some(cell => cell.filename === entryCellFilename)) {
+      throw new PeerNotebookError(
+        "invalid_args",
+        `Peer ${input.peerId} graduation snapshot has no code cell named "${entryCellFilename}"`,
+      );
+    }
+    return snapshot;
+  }
 }
 
 async function fetchInputArtifact(input: RuntimeInvocationInput): Promise<JsonValue | null> {
-  const textArtifactId = input.args.textArtifactId;
-  if (input.tool === "extract_claims" && typeof textArtifactId !== "string") {
+  const inputArtifactId = resolveInputArtifactId(input);
+  if (input.tool === "extract_claims" && inputArtifactId === null) {
     throw new PeerNotebookError("invalid_args", "extract_claims requires textArtifactId");
   }
-  if (typeof textArtifactId !== "string") {
+  if (inputArtifactId === null) {
     return null;
   }
 
-  const read = await input.brokerProxy.callTool("artifact.get", { artifactId: textArtifactId });
+  const read = await input.brokerProxy.callTool("artifact.get", { artifactId: inputArtifactId });
   if (!read.ok) {
     throw new PeerNotebookError("outbound_denied", read.error.message);
   }
   const body = read.result as { artifact?: { content?: JsonValue } };
   return body.artifact?.content ?? null;
+}
+
+/**
+ * Input-artifact convention: the invocation's single brokered input is named
+ * by an arg ending in "ArtifactId" (textArtifactId for the claim-extractor
+ * pilot, claimsArtifactId for contradiction-scan, ...). textArtifactId keeps
+ * priority for pilot parity; otherwise the lexicographically first match wins
+ * so the fetch is deterministic.
+ */
+function resolveInputArtifactId(input: RuntimeInvocationInput): string | null {
+  const direct = input.args.textArtifactId;
+  if (typeof direct === "string") {
+    return direct;
+  }
+  const candidateKeys = Object.keys(input.args)
+    .filter(key => key.endsWith("ArtifactId") && typeof input.args[key] === "string")
+    .sort();
+  const key = candidateKeys[0];
+  return key === undefined ? null : (input.args[key] as string);
 }
 
 function scriptCommand(scriptPath: string): { command: string; commandArgs: string[] } {

--- a/src/peer-notebook/peers/contradiction-scan-notebook.ts
+++ b/src/peer-notebook/peers/contradiction-scan-notebook.ts
@@ -1,0 +1,272 @@
+import type { PeerManifest } from "../types.js";
+import { NOTEBOOK_ENTRY_PREFIX } from "../types.js";
+
+/**
+ * Contradiction-scan peer, authored as NOTEBOOK CONTENT — not a builtin entry.
+ *
+ * Unlike claim-extractor (a platform-owned script registered in the
+ * local-process BUILTIN_ENTRIES registry), this peer's executable code lives
+ * in a notebook code cell. The exports here are the authoring material: cell
+ * sources plus a manifest builder. A session authors the notebook through the
+ * notebook engine (notebook_create / notebook_add_cell), graduates it with
+ * peer_graduate_notebook — which captures the cells into the manifest's
+ * immutable code snapshot — and approves it with peer_manifest_approve. From
+ * then on any session can invoke `scan_contradictions` and the local-process
+ * provider executes the snapshot's entry cell through the notebook execution
+ * engine.
+ *
+ * The peer takes a claims artifact (the claim-extractor output shape,
+ * `{ claims: [{ id, text }] }`, or an array, or plain text with one claim per
+ * line) and returns contradiction CANDIDATES: deterministic lexical detection
+ * of negation pairs, antonym predicates, and numeric mismatches. Candidates
+ * feed the merge-evidence flow — they are leads for a human or agent to
+ * adjudicate, not verdicts.
+ */
+
+export const CONTRADICTION_SCAN_PEER_ID = "contradiction-scan";
+export const CONTRADICTION_SCAN_ENTRY_FILENAME = "contradiction-scan.js";
+export const CONTRADICTION_SCAN_TOOL_NAME = "scan_contradictions";
+
+export const CONTRADICTION_SCAN_DOC_MARKDOWN = [
+  "Scans a set of claims for contradiction candidates: negation pairs,",
+  "antonym predicates, and numeric mismatches. Input is a claims artifact",
+  "(claim-extractor output shape); output is a contradictions.json artifact",
+  "with candidate pairs and the reason each pair was flagged.",
+].join("\n");
+
+/**
+ * Entry cell source (plain JavaScript, node builtins only — notebook peers
+ * are dependency-free in v1). Peer cell protocol: read
+ * `{ invocationId, tool, args, artifactContent }` JSON from TB_PEER_INPUT_PATH,
+ * write `{ result, artifacts }` JSON to TB_PEER_OUTPUT_PATH, exit non-zero on
+ * failure with the message on stderr.
+ */
+export const CONTRADICTION_SCAN_CELL_SOURCE = `// Contradiction-scan peer entry cell (graduated notebook peer).
+// Reads { invocationId, tool, args, artifactContent } from TB_PEER_INPUT_PATH,
+// writes { result, artifacts } to TB_PEER_OUTPUT_PATH.
+import { readFileSync, writeFileSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+
+const NEGATORS = new Set([
+  "not", "no", "never", "cannot", "dont", "doesnt", "didnt",
+  "wont", "isnt", "arent", "wasnt", "werent",
+]);
+
+const ANTONYM_PAIRS = [
+  ["increased", "decreased"], ["increases", "decreases"],
+  ["enabled", "disabled"], ["enables", "disables"],
+  ["passes", "fails"], ["passed", "failed"],
+  ["allows", "denies"], ["allowed", "denied"],
+  ["active", "inactive"], ["always", "never"],
+  ["faster", "slower"], ["higher", "lower"],
+  ["before", "after"], ["up", "down"],
+];
+const ANTONYMS = new Map();
+for (const [a, b] of ANTONYM_PAIRS) {
+  ANTONYMS.set(a, b);
+  ANTONYMS.set(b, a);
+}
+
+const NUMBER = /^\\d+(\\.\\d+)?$/;
+
+function claimTokens(text) {
+  return text
+    .toLowerCase()
+    .replace(/n't\\b/g, " not")
+    .replace(/[^a-z0-9.\\s]/g, " ")
+    .split(/\\s+/)
+    .map(token => token.replace(/\\.+$/, ""))
+    .filter(Boolean);
+}
+
+function negationCandidate(left, right) {
+  const hasNegator = tokens => tokens.some(token => NEGATORS.has(token));
+  if (hasNegator(left) === hasNegator(right)) return false;
+  const strip = tokens => tokens.filter(token => !NEGATORS.has(token)).join(" ");
+  return strip(left) === strip(right) && strip(left).length > 0;
+}
+
+function alignedDiffs(left, right) {
+  if (left.length !== right.length) return null;
+  const diffs = [];
+  for (let i = 0; i < left.length; i++) {
+    if (left[i] !== right[i]) diffs.push([left[i], right[i]]);
+  }
+  return diffs;
+}
+
+function antonymCandidate(left, right) {
+  const diffs = alignedDiffs(left, right);
+  if (!diffs || diffs.length !== 1) return false;
+  const [a, b] = diffs[0];
+  return ANTONYMS.get(a) === b;
+}
+
+function numericCandidate(left, right) {
+  const diffs = alignedDiffs(left, right);
+  if (!diffs || diffs.length === 0) return false;
+  return diffs.every(([a, b]) => NUMBER.test(a) && NUMBER.test(b) && a !== b);
+}
+
+function parseClaims(content) {
+  let value = content;
+  if (typeof value === "string") {
+    try {
+      value = JSON.parse(value);
+    } catch {
+      // Plain text fallback: one claim per line.
+      return value
+        .split(/\\n+/)
+        .map(line => line.trim())
+        .filter(Boolean)
+        .map((text, index) => ({ id: "claim_" + (index + 1), text }));
+    }
+  }
+  const list = Array.isArray(value)
+    ? value
+    : value && typeof value === "object" && Array.isArray(value.claims)
+      ? value.claims
+      : null;
+  if (!list) {
+    throw new Error("claims artifact must be {claims:[{id,text}]}, an array, or plain text");
+  }
+  return list.map((claim, index) =>
+    typeof claim === "string"
+      ? { id: "claim_" + (index + 1), text: claim }
+      : { id: String(claim.id ?? "claim_" + (index + 1)), text: String(claim.text ?? "") },
+  );
+}
+
+function scan(claims) {
+  const tokenized = claims.map(claim => ({ ...claim, tokens: claimTokens(claim.text) }));
+  const candidates = [];
+  for (let i = 0; i < tokenized.length; i++) {
+    for (let j = i + 1; j < tokenized.length; j++) {
+      const left = tokenized[i];
+      const right = tokenized[j];
+      let kind = null;
+      if (negationCandidate(left.tokens, right.tokens)) kind = "negation";
+      else if (antonymCandidate(left.tokens, right.tokens)) kind = "antonym";
+      else if (numericCandidate(left.tokens, right.tokens)) kind = "numeric_mismatch";
+      if (kind) {
+        candidates.push({
+          leftId: left.id,
+          leftText: left.text,
+          rightId: right.id,
+          rightText: right.text,
+          kind,
+        });
+      }
+    }
+  }
+  return candidates;
+}
+
+function main() {
+  const input = JSON.parse(readFileSync(process.env.TB_PEER_INPUT_PATH, "utf8"));
+  if (input.tool !== "scan_contradictions") {
+    throw new Error("contradiction-scan only supports scan_contradictions, got " + input.tool);
+  }
+  if (input.artifactContent === null || input.artifactContent === undefined) {
+    throw new Error("scan_contradictions requires a claims artifact (claimsArtifactId)");
+  }
+  const claims = parseClaims(input.artifactContent);
+  const candidates = scan(claims);
+  const contradictionsArtifactId = randomUUID();
+  const body = { candidates };
+  writeFileSync(process.env.TB_PEER_OUTPUT_PATH, JSON.stringify({
+    result: {
+      contradictionsArtifactId,
+      candidateCount: candidates.length,
+      claimCount: claims.length,
+    },
+    artifacts: [
+      {
+        artifactId: contradictionsArtifactId,
+        kind: "json",
+        name: "contradictions.json",
+        mimeType: "application/json",
+        content: body,
+        preview: body,
+      },
+    ],
+  }));
+}
+
+try {
+  main();
+} catch (error) {
+  process.stderr.write(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}
+`;
+
+/**
+ * peer.manifest.json cell content for the contradiction-scan notebook. The
+ * notebookId must be the ACTUAL id of the graduating notebook (graduation
+ * rejects mismatches), so the author fills it in at authoring time.
+ */
+export function contradictionScanManifest(notebookId: string): PeerManifest {
+  return {
+    schemaVersion: "peer-notebook.v0",
+    peerId: CONTRADICTION_SCAN_PEER_ID,
+    notebookId,
+    runtime: {
+      provider: "local-process",
+      entry: `${NOTEBOOK_ENTRY_PREFIX}${CONTRADICTION_SCAN_ENTRY_FILENAME}`,
+      timeoutMs: 60_000,
+    },
+    exposes: {
+      tools: [
+        {
+          name: CONTRADICTION_SCAN_TOOL_NAME,
+          description:
+            "Scan a claims artifact for contradiction candidates (negation, antonym, numeric mismatch)",
+          inputSchema: {
+            type: "object",
+            properties: {
+              claimsArtifactId: { type: "string" },
+            },
+            required: ["claimsArtifactId"],
+            additionalProperties: false,
+          },
+          outputSchema: {
+            type: "object",
+            properties: {
+              contradictionsArtifactId: { type: "string" },
+              candidateCount: { type: "number" },
+              claimCount: { type: "number" },
+            },
+            required: ["contradictionsArtifactId", "candidateCount", "claimCount"],
+            additionalProperties: false,
+          },
+        },
+      ],
+      resources: [],
+      prompts: [],
+    },
+    mayCall: {
+      mcpTools: ["artifact.get"],
+    },
+    network: {
+      enabled: false,
+      allowHosts: [],
+    },
+    filesystem: {
+      mounts: [],
+    },
+    secrets: {
+      bindings: [],
+    },
+    persistence: {
+      snapshot: "manual",
+      exportNotebookOnInvoke: false,
+      retainArtifactsDays: 30,
+    },
+    budgets: {
+      maxDurationMs: 60_000,
+      maxToolCalls: 4,
+      maxArtifactBytes: 10_000_000,
+    },
+  };
+}

--- a/src/peer-notebook/runtime-provider.ts
+++ b/src/peer-notebook/runtime-provider.ts
@@ -3,6 +3,7 @@ import type {
   ArtifactKind,
   JsonObject,
   JsonValue,
+  PeerNotebookCodeSnapshot,
   RuntimeProviderName,
 } from "./types.js";
 
@@ -24,6 +25,11 @@ export interface RuntimeInvocationInput {
   args: JsonObject;
   /** Executable entry name from manifest runtime.entry (required by local-process). */
   entry?: string;
+  /**
+   * Graduated-notebook code snapshot from the manifest record
+   * (compiledFrom.notebook); present when entry is `notebook:<filename>`.
+   */
+  notebook?: PeerNotebookCodeSnapshot;
   brokerProxyUrl: string;
   scopedToken: string;
   budgets: {

--- a/src/peer-notebook/supabase-repository.ts
+++ b/src/peer-notebook/supabase-repository.ts
@@ -429,7 +429,7 @@ export class SupabasePeerNotebookRepository implements PeerNotebookRepository {
       manifest,
       manifestHash: row.manifest_hash,
       status: row.status as PeerManifestStatus,
-      compiledFrom: row.compiled_from as PeerManifestRecord["compiledFrom"],
+      compiledFrom: row.compiled_from as unknown as PeerManifestRecord["compiledFrom"],
       approvedAt: row.approved_at,
       createdAt: row.created_at,
     };

--- a/src/peer-notebook/tool.ts
+++ b/src/peer-notebook/tool.ts
@@ -35,7 +35,7 @@ export type PeerNotebookToolInput = z.infer<typeof peerNotebookToolInputSchema>;
 
 export const PEER_NOTEBOOK_TOOL = {
   name: "thoughtbox_peer_notebook",
-  description: "Brokered MCP peer notebook pilot surface. Seeds text artifacts, invokes the claim-extractor peer on the development-only local-process runtime, manages the draft-to-active manifest lifecycle, graduates notebooks into draft peer manifests, and reads invocations, traces, and artifacts.",
+  description: "Brokered MCP peer notebook surface. Seeds text artifacts, invokes peers on the development-only local-process runtime (the builtin claim-extractor plus graduated notebook peers such as contradiction-scan, whose own code cells execute from the graduation snapshot), manages the draft-to-active manifest lifecycle, graduates notebooks into draft peer manifests, and reads invocations, traces, and artifacts.",
   inputSchema: peerNotebookToolInputSchema,
   annotations: {
     readOnlyHint: false,

--- a/src/peer-notebook/types.ts
+++ b/src/peer-notebook/types.ts
@@ -84,6 +84,44 @@ export interface ManifestDraftSource {
   sourceType?: "file" | "cell";
 }
 
+/**
+ * Manifest runtime.entry prefix marking a graduated-notebook entry: the code
+ * after the prefix is the filename of a code cell in the graduating notebook,
+ * executed by the runtime provider from the manifest's captured code snapshot
+ * (never from live notebook state).
+ */
+export const NOTEBOOK_ENTRY_PREFIX = "notebook:";
+
+/** Cell filename named by a `notebook:` runtime entry, or null for registry entries. */
+export function notebookEntryFilename(entry: string | undefined): string | null {
+  if (!entry || !entry.startsWith(NOTEBOOK_ENTRY_PREFIX)) {
+    return null;
+  }
+  const filename = entry.slice(NOTEBOOK_ENTRY_PREFIX.length);
+  return filename.length > 0 ? filename : null;
+}
+
+export interface PeerNotebookSnapshotCell {
+  filename: string;
+  source: string;
+}
+
+/**
+ * Executable code snapshot captured at graduation for manifests whose
+ * runtime.entry names a notebook cell (`notebook:<filename>`). The snapshot is
+ * the immutable execution source: invocations materialize it into a scratch
+ * directory and run the entry cell through the notebook execution engine, so
+ * a graduated peer keeps working after the authoring notebook session is gone.
+ */
+export interface PeerNotebookCodeSnapshot {
+  notebookId: string;
+  entryFilename: string;
+  language: "javascript" | "typescript";
+  cells: PeerNotebookSnapshotCell[];
+  packageJson?: string;
+  tsconfigJson?: string;
+}
+
 export interface CompiledPeerManifest {
   manifest: PeerManifest;
   canonicalJson: string;
@@ -92,6 +130,8 @@ export interface CompiledPeerManifest {
   compiledFrom: {
     sourceName: string;
     sourceType: "file" | "cell";
+    /** Present only for graduated manifests with a `notebook:` runtime entry. */
+    notebook?: PeerNotebookCodeSnapshot;
   };
 }
 


### PR DESCRIPTION
## Summary

Graduation was ceremony: the draft→approve→active lifecycle governed exactly one hardcoded peer (`BUILTIN_ENTRIES = {claim-extractor}`), and a graduated notebook could not actually run. This PR closes the loop.

### 1. Runtime path for graduated notebooks (SPEC-CONTROL-PLANE c7)
- Manifests may declare `runtime.entry: "notebook:<cellFilename>"`.
- Graduation captures the notebook's executable cells as an **immutable code snapshot** on the manifest record (`compiledFrom.notebook`, persisted through the existing `compiled_from` jsonb column — no migration needed). Invocations never read live notebook state, so the peer works from any later session once approved.
- The broker threads the snapshot into `RuntimeInvocationInput.notebook`; `LocalProcessRuntimeProvider.runNotebookEntry` materializes it into a scratch dir and executes the entry cell **through the notebook execution engine** (`executeCodeCell`/`writeCodeCellToDisk` from `src/notebook/execution.ts`) under the manifest budget. Cell protocol: `TB_PEER_INPUT_PATH` → `TB_PEER_OUTPUT_PATH` (sidecar analog of the builtin stdin/stdout protocol).
- The `RuntimeProvider` contract seam is unchanged — the deferred smolvm unit can implement the same snapshot execution behind real isolation.
- v1 boundaries: notebook peers are dependency-free (package.json with dependencies rejected at graduation); `cancel()` mid-cell rejects immediately but the child is reaped by the engine budget timeout (development-only provider, documented).

### 2. First real graduated peer: contradiction-scan
`src/peer-notebook/peers/contradiction-scan-notebook.ts` — authored as notebook cell content (NOT a builtin). Takes a claims artifact (claim-extractor output shape) and returns deterministic contradiction candidates (negation, antonym, numeric mismatch) as `contradictions.json` — the candidate feed for the merge-evidence flow.

Proven end-to-end in `src/peer-notebook/__tests__/graduation-execution.test.ts`: author via real `NotebookHandler` ops → `peer_graduate_notebook` → `peer_manifest_approve` → invoke from a **fresh handler session sharing only the repository** → real cell output + trace events (`outbound_call_allowed artifact.get`, `peer_invocation_completed`), plus negative paths (draft blocks invoke, missing entry cell, dependencies, missing snapshot).

### 3. Read-only peers page
`apps/web/src/app/w/[workspaceSlug]/peers/` — lists peer notebooks, manifest lifecycle (version/status/entry/tools/hash/approval), and recent invocations from Supabase via workspace-member RLS. Peer tables typed locally in the route dir (not yet in generated database types).

## Spec
`.specs/mcp-peer-notebooks/SPEC-CONTROL-PLANE.md`: new claim **c7** (graduated-notebook execution, behavioral) + implementation note; c6 evidence names the peers page; web-screen non-goal scoped to interactive surfaces.

## Tests
- `npx vitest run`: 889 passed, 3 failed — the 3 known pre-existing environmental failures (branch-workers ×2, intelligence-pipeline ×1, local Supabase edge runtime 503).
- Peer suite: 69 passed (64 baseline + 5 new graduation-execution tests).
- `pnpm check:types`, `pnpm check:lint`, `pnpm build:local`: clean.
- apps/web: `tsc --noEmit` clean, vitest 36/36, `next lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)