### PR TITLE
fix(plugin): correctness bundle — session hook matcher, channel sessionId, version alignment

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "thoughtbox-claude-code",
       "source": "./plugins/thoughtbox-claude-code",
       "description": "Observability hooks, protocol enforcement, and the thoughtbox CLI",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "category": "observability",
       "keywords": ["thoughtbox", "observability", "otlp", "protocols"]
     }

--- a/.specs/reasoning-channel-hosted.md
+++ b/.specs/reasoning-channel-hosted.md
@@ -24,7 +24,7 @@ claims:
     statement: The channel client selects its transport by configuration — in-process SSE against a local server, HTTP polling of the pull endpoint against a hosted server with session-scoped query parameters when configured — and delivers identical channel notifications either way
     type: implementation
     behavioral: false
-    required_evidence: the channel client chooses SSE vs polling from config (URL host inference with an env override, warning on invalid overrides), forwarding session_id when configured and priming before emitting; unit tests cover both transports producing the same pushEvent calls; local SSE path is unchanged from current behavior
+    required_evidence: the channel client chooses SSE vs polling from config (URL host inference with an env override, warning on invalid overrides), forwarding session_id when configured and priming before emitting; both transports normalize the workspace-scoped wire shape (top-level workspaceId, session id in data.session_id) into the ThoughtboxEvent sessionId the EventFilter keys on, so a THOUGHTBOX_SESSION filter matches protocol events instead of silently dropping everything, and the filter warns (once) when it drops an event with no session attribution; unit tests cover both transports producing the same pushEvent calls
   - id: c5
     statement: The local-mode reasoning channel keeps working unchanged — the hosted path is additive and does not alter local /events SSE delivery or protocol enforcement
     type: governance

--- a/plugins/thoughtbox-claude-code/.claude-plugin/plugin.json
+++ b/plugins/thoughtbox-claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "thoughtbox-claude-code",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Thoughtbox observability, protocol enforcement, and CLI for Claude Code",
   "author": {
     "name": "Kastalien Research"

--- a/plugins/thoughtbox-claude-code/dist/event-client.d.ts
+++ b/plugins/thoughtbox-claude-code/dist/event-client.d.ts
@@ -4,7 +4,7 @@
  * Connects to the Thoughtbox /events SSE endpoint and emits
  * parsed ThoughtboxEvent objects. Reconnects with exponential backoff.
  */
-import type { ThoughtboxEvent } from "./event-types.js";
+import { type ThoughtboxEvent } from "./event-types.js";
 export interface EventClientConfig {
     baseUrl: string;
     apiKey: string;

--- a/plugins/thoughtbox-claude-code/dist/event-client.js
+++ b/plugins/thoughtbox-claude-code/dist/event-client.js
@@ -4,6 +4,7 @@
  * Connects to the Thoughtbox /events SSE endpoint and emits
  * parsed ThoughtboxEvent objects. Reconnects with exponential backoff.
  */
+import { extractSessionId, } from "./event-types.js";
 const MIN_BACKOFF_MS = 1000;
 const MAX_BACKOFF_MS = 30_000;
 const BACKOFF_MULTIPLIER = 2;
@@ -67,8 +68,17 @@ export class EventClient {
                 for (const line of lines) {
                     if (line.startsWith("data: ")) {
                         try {
-                            const event = JSON.parse(line.slice(6));
-                            this.config.onEvent(event);
+                            // Server events are workspace-scoped (top-level workspaceId,
+                            // session id inside data.session_id) — normalize to the
+                            // sessionId the EventFilter and formatters key on.
+                            const raw = JSON.parse(line.slice(6));
+                            this.config.onEvent({
+                                source: raw.source,
+                                type: raw.type,
+                                sessionId: extractSessionId(raw),
+                                timestamp: raw.timestamp,
+                                data: raw.data ?? {},
+                            });
                         }
                         catch {
                             // Ignore unparseable events

--- a/plugins/thoughtbox-claude-code/dist/event-filter.d.ts
+++ b/plugins/thoughtbox-claude-code/dist/event-filter.d.ts
@@ -1,6 +1,11 @@
 /**
  * Filters events for the current Thoughtbox session.
  * Events not tied to this session are dropped.
+ *
+ * Session attribution comes from `data.session_id` on server events (see
+ * extractSessionId in event-types.ts); protocol events always carry it.
+ * An event with NO session attribution cannot match a session filter, so it
+ * is dropped — but loudly (one warning), never silently.
  */
 import type { ThoughtboxEvent } from "./event-types.js";
 export interface EventFilterConfig {
@@ -8,6 +13,7 @@ export interface EventFilterConfig {
 }
 export declare class EventFilter {
     private config;
+    private warnedUnattributed;
     constructor(config: EventFilterConfig);
     shouldForward(event: ThoughtboxEvent): boolean;
     setSessionId(sessionId: string): void;

--- a/plugins/thoughtbox-claude-code/dist/event-filter.js
+++ b/plugins/thoughtbox-claude-code/dist/event-filter.js
@@ -1,15 +1,28 @@
 /**
  * Filters events for the current Thoughtbox session.
  * Events not tied to this session are dropped.
+ *
+ * Session attribution comes from `data.session_id` on server events (see
+ * extractSessionId in event-types.ts); protocol events always carry it.
+ * An event with NO session attribution cannot match a session filter, so it
+ * is dropped — but loudly (one warning), never silently.
  */
 export class EventFilter {
     config;
+    warnedUnattributed = false;
     constructor(config) {
         this.config = config;
     }
     shouldForward(event) {
         if (!this.config.sessionId)
             return true;
+        if (!event.sessionId) {
+            if (!this.warnedUnattributed) {
+                this.warnedUnattributed = true;
+                console.error(`[Channel] Dropping "${event.type}" event: it carries no session attribution (data.session_id) but a session filter is set (THOUGHTBOX_SESSION). Unset the filter to receive workspace-wide events. Further drops will be silent.`);
+            }
+            return false;
+        }
         return event.sessionId === this.config.sessionId;
     }
     setSessionId(sessionId) {

--- a/plugins/thoughtbox-claude-code/dist/event-types.d.ts
+++ b/plugins/thoughtbox-claude-code/dist/event-types.d.ts
@@ -10,3 +10,26 @@ export interface ThoughtboxEvent {
     timestamp: string;
     data: Record<string, unknown>;
 }
+/**
+ * Raw event shape on the wire — both the local /events SSE stream and the
+ * hosted GET /protocol/events pull endpoint. Server events are
+ * workspace-scoped: they carry a top-level `workspaceId` (never a top-level
+ * `sessionId`), and the Thoughtbox session id travels inside
+ * `data.session_id` (the protocol handler prepends it to every event's
+ * data). Transports normalize this into ThoughtboxEvent via
+ * {@link extractSessionId} so EventFilter and the channel formatters can
+ * key on sessionId.
+ */
+export interface WireThoughtboxEvent {
+    source: ThoughtboxEvent['source'];
+    type: ThoughtboxEvent['type'];
+    sessionId?: string;
+    workspaceId?: string;
+    timestamp: string;
+    data?: Record<string, unknown>;
+}
+/** Derive the session id from a wire event; '' when unattributed. */
+export declare function extractSessionId(raw: {
+    sessionId?: unknown;
+    data?: Record<string, unknown>;
+}): string;

--- a/plugins/thoughtbox-claude-code/dist/event-types.js
+++ b/plugins/thoughtbox-claude-code/dist/event-types.js
@@ -2,4 +2,11 @@
  * Thoughtbox event types consumed by the Claude Code channel transport.
  * Must stay in sync with the server-side event emitter.
  */
-export {};
+/** Derive the session id from a wire event; '' when unattributed. */
+export function extractSessionId(raw) {
+    if (typeof raw.sessionId === 'string' && raw.sessionId.length > 0) {
+        return raw.sessionId;
+    }
+    const fromData = raw.data?.['session_id'];
+    return typeof fromData === 'string' ? fromData : '';
+}

--- a/plugins/thoughtbox-claude-code/dist/polling-event-client.d.ts
+++ b/plugins/thoughtbox-claude-code/dist/polling-event-client.d.ts
@@ -11,7 +11,7 @@
  * emitting, so a fresh channel reacts to NEW protocol events rather than
  * replaying completed sessions.
  */
-import type { ThoughtboxEvent } from "./event-types.js";
+import { type ThoughtboxEvent } from "./event-types.js";
 export interface PollingEventClientConfig {
     baseUrl: string;
     apiKey: string;
@@ -34,6 +34,8 @@ export declare class PollingEventClient {
     private scheduleNext;
     private poll;
     private emit;
+    private prime;
+    private primeOnce;
     private fetchPage;
     private reportError;
 }

--- a/plugins/thoughtbox-claude-code/dist/polling-event-client.js
+++ b/plugins/thoughtbox-claude-code/dist/polling-event-client.js
@@ -11,6 +11,7 @@
  * emitting, so a fresh channel reacts to NEW protocol events rather than
  * replaying completed sessions.
  */
+import { extractSessionId } from "./event-types.js";
 const DEFAULT_POLL_INTERVAL_MS = 3000;
 const PAGE_LIMIT = 200;
 const MIN_BACKOFF_MS = 1000;
@@ -27,21 +28,12 @@ export class PollingEventClient {
     }
     async connect() {
         this.closed = false;
-        // Prime the cursor to the current tail without emitting.
-        try {
-            while (true) {
-                const page = await this.fetchPage(this.cursor);
-                if (page.events.length === 0)
-                    break;
-                this.cursor = page.cursor;
-                if (page.events.length < PAGE_LIMIT)
-                    break;
-            }
-            this.config.onConnect?.();
-        }
-        catch (error) {
-            this.reportError(error);
-        }
+        this.backoffMs = MIN_BACKOFF_MS;
+        await this.prime();
+        if (this.closed)
+            return;
+        this.config.onConnect?.();
+        this.backoffMs = MIN_BACKOFF_MS;
         this.scheduleNext(this.config.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS);
     }
     close() {
@@ -83,7 +75,7 @@ export class PollingEventClient {
         }
     }
     emit(event) {
-        const sessionId = typeof event.data.session_id === "string" ? event.data.session_id : "";
+        const sessionId = extractSessionId(event);
         this.config.onEvent({
             source: event.source,
             type: event.type,
@@ -92,10 +84,36 @@ export class PollingEventClient {
             data: event.data,
         });
     }
+    async prime() {
+        while (!this.closed) {
+            try {
+                await this.primeOnce();
+                return;
+            }
+            catch (error) {
+                this.reportError(error);
+                const delay = this.backoffMs;
+                this.backoffMs = Math.min(this.backoffMs * BACKOFF_MULTIPLIER, MAX_BACKOFF_MS);
+                await new Promise((resolve) => setTimeout(resolve, delay));
+            }
+        }
+    }
+    async primeOnce() {
+        while (true) {
+            const page = await this.fetchPage(this.cursor);
+            if (page.events.length === 0)
+                break;
+            this.cursor = page.cursor;
+            if (page.events.length < PAGE_LIMIT)
+                break;
+        }
+    }
     async fetchPage(cursor) {
         const params = new URLSearchParams();
         if (cursor > 0)
             params.set("changed_since", String(cursor));
+        if (this.config.sessionId)
+            params.set("session_id", this.config.sessionId);
         params.set("limit", String(PAGE_LIMIT));
         const url = `${this.config.baseUrl}/protocol/events?${params.toString()}`;
         const response = await fetch(url, {

--- a/plugins/thoughtbox-claude-code/dist/thoughtbox-channel.d.ts
+++ b/plugins/thoughtbox-claude-code/dist/thoughtbox-channel.d.ts
@@ -7,7 +7,9 @@
  * via the `claude/channel` notification surface.
  *
  * Configuration via environment variables:
- *   THOUGHTBOX_URL      - Thoughtbox HTTP server URL (required)
+ *   THOUGHTBOX_URL      - Optional override for the Thoughtbox HTTP server URL;
+ *                         when absent, derives from local Claude settings
+ *                         written by `thoughtbox init`
  *   THOUGHTBOX_SESSION  - Optional active Thoughtbox session id; when set,
  *                         only events for this session are forwarded
  */

--- a/plugins/thoughtbox-claude-code/dist/thoughtbox-channel.js
+++ b/plugins/thoughtbox-claude-code/dist/thoughtbox-channel.js
@@ -29,6 +29,9 @@ function selectTransport(baseUrl) {
     const override = process.env.THOUGHTBOX_CHANNEL_MODE;
     if (override === "sse" || override === "poll")
         return override;
+    if (override !== undefined) {
+        console.error(`[Channel] Warning: THOUGHTBOX_CHANNEL_MODE="${override}" is not supported; falling back to URL-based transport detection`);
+    }
     try {
         const host = new URL(baseUrl).hostname;
         return host === "localhost" || host === "127.0.0.1" || host === "::1"

--- a/plugins/thoughtbox-claude-code/hooks/hooks.json
+++ b/plugins/thoughtbox-claude-code/hooks/hooks.json
@@ -22,7 +22,7 @@
         ]
       },
       {
-        "matcher": "mcp__thoughtbox-cloud-run__thoughtbox_execute",
+        "matcher": "^mcp__.*__thoughtbox_execute$",
         "hooks": [
           {
             "type": "command",

--- a/plugins/thoughtbox-claude-code/package.json
+++ b/plugins/thoughtbox-claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thoughtbox-claude-code",
-  "version": "0.1.5",
+  "version": "0.1.7",
   "type": "module",
   "description": "Thoughtbox plugin for Claude Code — hooks, channel, and CLI",
   "bin": {

--- a/plugins/thoughtbox-claude-code/src/__tests__/event-client.test.ts
+++ b/plugins/thoughtbox-claude-code/src/__tests__/event-client.test.ts
@@ -1,0 +1,97 @@
+/**
+ * EventClient (SSE transport) normalization tests.
+ *
+ * The /events SSE stream sends workspace-scoped events: top-level
+ * workspaceId, session id inside data.session_id, no top-level sessionId.
+ * Before normalization, EventClient cast the raw JSON to ThoughtboxEvent,
+ * so event.sessionId was undefined and a session filter dropped everything.
+ * These tests pin the normalized emit shape.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { EventClient } from '../event-client.js';
+import type { ThoughtboxEvent } from '../event-types.js';
+
+function sseResponse(frames: string[]): Response {
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const encoder = new TextEncoder();
+      for (const frame of frames) {
+        controller.enqueue(encoder.encode(frame));
+      }
+      controller.close();
+    },
+  });
+  return new Response(body, {
+    status: 200,
+    headers: { 'Content-Type': 'text/event-stream' },
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('EventClient', () => {
+  it('normalizes server wire events (workspaceId + data.session_id) into sessionId', async () => {
+    const wireEvent = {
+      source: 'protocol',
+      type: 'ulysses_outcome',
+      workspaceId: 'ws-1',
+      timestamp: '2026-07-01T00:00:00.000Z',
+      data: { session_id: 's1', S: 2, assessment: 'FAIL' },
+    };
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(sseResponse([`data: ${JSON.stringify(wireEvent)}\n\n`]));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const received: ThoughtboxEvent[] = [];
+    const client = new EventClient({
+      baseUrl: 'http://localhost:3000',
+      apiKey: 'tbx_test',
+      onEvent: (e) => {
+        received.push(e);
+        client.close(); // stop before the reconnect loop re-fetches
+      },
+    });
+
+    await client.connect();
+    client.close();
+
+    expect(received).toHaveLength(1);
+    expect(received[0]!.sessionId).toBe('s1'); // derived from data.session_id
+    expect(received[0]!.type).toBe('ulysses_outcome');
+    expect(received[0]!.data.S).toBe(2);
+  });
+
+  it('emits empty sessionId for unattributed events instead of undefined', async () => {
+    const wireEvent = {
+      source: 'hub',
+      type: 'message_posted',
+      workspaceId: 'ws-1',
+      timestamp: '2026-07-01T00:00:00.000Z',
+      data: { channel: 'general' },
+    };
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(sseResponse([`data: ${JSON.stringify(wireEvent)}\n\n`]));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const received: ThoughtboxEvent[] = [];
+    const client = new EventClient({
+      baseUrl: 'http://localhost:3000',
+      apiKey: 'tbx_test',
+      onEvent: (e) => {
+        received.push(e);
+        client.close();
+      },
+    });
+
+    await client.connect();
+    client.close();
+
+    expect(received).toHaveLength(1);
+    expect(received[0]!.sessionId).toBe('');
+  });
+});

--- a/plugins/thoughtbox-claude-code/src/__tests__/event-filter.test.ts
+++ b/plugins/thoughtbox-claude-code/src/__tests__/event-filter.test.ts
@@ -1,0 +1,78 @@
+/**
+ * EventFilter + wire normalization tests.
+ *
+ * Server events are workspace-scoped: the wire shape carries a top-level
+ * workspaceId and puts the Thoughtbox session id inside data.session_id.
+ * These tests pin the fix for the silent-drop bug where a sessionId filter
+ * dropped every event because event.sessionId was never populated.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { EventFilter } from '../event-filter.js';
+import { extractSessionId, type ThoughtboxEvent } from '../event-types.js';
+
+function evt(sessionId: string, type: ThoughtboxEvent['type'] = 'ulysses_outcome'): ThoughtboxEvent {
+  return {
+    source: 'protocol',
+    type,
+    sessionId,
+    timestamp: '2026-07-01T00:00:00.000Z',
+    data: { session_id: sessionId },
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('extractSessionId', () => {
+  it('prefers a top-level sessionId when present', () => {
+    expect(
+      extractSessionId({ sessionId: 's-top', data: { session_id: 's-data' } }),
+    ).toBe('s-top');
+  });
+
+  it('derives the session id from data.session_id (server wire shape)', () => {
+    expect(
+      extractSessionId({ data: { session_id: 's-data', workspace: 'w1' } }),
+    ).toBe('s-data');
+  });
+
+  it('returns empty string for unattributed events', () => {
+    expect(extractSessionId({ data: { foo: 'bar' } })).toBe('');
+    expect(extractSessionId({})).toBe('');
+    expect(extractSessionId({ sessionId: 42, data: { session_id: 7 } })).toBe('');
+  });
+});
+
+describe('EventFilter', () => {
+  it('forwards everything when no session filter is set', () => {
+    const filter = new EventFilter({});
+    expect(filter.shouldForward(evt('any-session'))).toBe(true);
+    expect(filter.shouldForward(evt(''))).toBe(true);
+  });
+
+  it('forwards only matching sessions when a filter is set', () => {
+    const filter = new EventFilter({ sessionId: 's1' });
+    expect(filter.shouldForward(evt('s1'))).toBe(true);
+    expect(filter.shouldForward(evt('s2'))).toBe(false);
+  });
+
+  it('drops unattributed events under a session filter, warning once (not silently)', () => {
+    const warn = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const filter = new EventFilter({ sessionId: 's1' });
+
+    expect(filter.shouldForward(evt(''))).toBe(false);
+    expect(filter.shouldForward(evt(''))).toBe(false);
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0]![0])).toContain('no session attribution');
+  });
+
+  it('setSessionId activates filtering after construction', () => {
+    const filter = new EventFilter({});
+    filter.setSessionId('s9');
+    expect(filter.shouldForward(evt('s9'))).toBe(true);
+    expect(filter.shouldForward(evt('other'))).toBe(false);
+  });
+});

--- a/plugins/thoughtbox-claude-code/src/event-client.ts
+++ b/plugins/thoughtbox-claude-code/src/event-client.ts
@@ -5,7 +5,11 @@
  * parsed ThoughtboxEvent objects. Reconnects with exponential backoff.
  */
 
-import type { ThoughtboxEvent } from "./event-types.js";
+import {
+  extractSessionId,
+  type ThoughtboxEvent,
+  type WireThoughtboxEvent,
+} from "./event-types.js";
 
 export interface EventClientConfig {
   baseUrl: string;
@@ -91,8 +95,17 @@ export class EventClient {
         for (const line of lines) {
           if (line.startsWith("data: ")) {
             try {
-              const event = JSON.parse(line.slice(6)) as ThoughtboxEvent;
-              this.config.onEvent(event);
+              // Server events are workspace-scoped (top-level workspaceId,
+              // session id inside data.session_id) — normalize to the
+              // sessionId the EventFilter and formatters key on.
+              const raw = JSON.parse(line.slice(6)) as WireThoughtboxEvent;
+              this.config.onEvent({
+                source: raw.source,
+                type: raw.type,
+                sessionId: extractSessionId(raw),
+                timestamp: raw.timestamp,
+                data: raw.data ?? {},
+              });
             } catch {
               // Ignore unparseable events
             }

--- a/plugins/thoughtbox-claude-code/src/event-filter.ts
+++ b/plugins/thoughtbox-claude-code/src/event-filter.ts
@@ -1,6 +1,11 @@
 /**
  * Filters events for the current Thoughtbox session.
  * Events not tied to this session are dropped.
+ *
+ * Session attribution comes from `data.session_id` on server events (see
+ * extractSessionId in event-types.ts); protocol events always carry it.
+ * An event with NO session attribution cannot match a session filter, so it
+ * is dropped — but loudly (one warning), never silently.
  */
 
 import type { ThoughtboxEvent } from "./event-types.js";
@@ -11,6 +16,7 @@ export interface EventFilterConfig {
 
 export class EventFilter {
   private config: EventFilterConfig;
+  private warnedUnattributed = false;
 
   constructor(config: EventFilterConfig) {
     this.config = config;
@@ -18,6 +24,15 @@ export class EventFilter {
 
   shouldForward(event: ThoughtboxEvent): boolean {
     if (!this.config.sessionId) return true;
+    if (!event.sessionId) {
+      if (!this.warnedUnattributed) {
+        this.warnedUnattributed = true;
+        console.error(
+          `[Channel] Dropping "${event.type}" event: it carries no session attribution (data.session_id) but a session filter is set (THOUGHTBOX_SESSION). Unset the filter to receive workspace-wide events. Further drops will be silent.`,
+        );
+      }
+      return false;
+    }
     return event.sessionId === this.config.sessionId;
   }
 

--- a/plugins/thoughtbox-claude-code/src/event-types.ts
+++ b/plugins/thoughtbox-claude-code/src/event-types.ts
@@ -21,3 +21,34 @@ export interface ThoughtboxEvent {
   timestamp: string;
   data: Record<string, unknown>;
 }
+
+/**
+ * Raw event shape on the wire — both the local /events SSE stream and the
+ * hosted GET /protocol/events pull endpoint. Server events are
+ * workspace-scoped: they carry a top-level `workspaceId` (never a top-level
+ * `sessionId`), and the Thoughtbox session id travels inside
+ * `data.session_id` (the protocol handler prepends it to every event's
+ * data). Transports normalize this into ThoughtboxEvent via
+ * {@link extractSessionId} so EventFilter and the channel formatters can
+ * key on sessionId.
+ */
+export interface WireThoughtboxEvent {
+  source: ThoughtboxEvent['source'];
+  type: ThoughtboxEvent['type'];
+  sessionId?: string;
+  workspaceId?: string;
+  timestamp: string;
+  data?: Record<string, unknown>;
+}
+
+/** Derive the session id from a wire event; '' when unattributed. */
+export function extractSessionId(raw: {
+  sessionId?: unknown;
+  data?: Record<string, unknown>;
+}): string {
+  if (typeof raw.sessionId === 'string' && raw.sessionId.length > 0) {
+    return raw.sessionId;
+  }
+  const fromData = raw.data?.['session_id'];
+  return typeof fromData === 'string' ? fromData : '';
+}

--- a/plugins/thoughtbox-claude-code/src/polling-event-client.ts
+++ b/plugins/thoughtbox-claude-code/src/polling-event-client.ts
@@ -12,7 +12,7 @@
  * replaying completed sessions.
  */
 
-import type { ThoughtboxEvent } from "./event-types.js";
+import { extractSessionId, type ThoughtboxEvent } from "./event-types.js";
 
 export interface PollingEventClientConfig {
   baseUrl: string;
@@ -102,8 +102,7 @@ export class PollingEventClient {
   }
 
   private emit(event: PulledEvent): void {
-    const sessionId =
-      typeof event.data.session_id === "string" ? event.data.session_id : "";
+    const sessionId = extractSessionId(event);
     this.config.onEvent({
       source: event.source,
       type: event.type,


### PR DESCRIPTION
## What

Plugin correctness bundle making a fresh `thoughtbox init` + plugin install work end to end.

### 1. session_tracker.sh matcher fix
`hooks/hooks.json` hardcoded matcher `mcp__thoughtbox-cloud-run__thoughtbox_execute`, but `thoughtbox init` writes the MCP server as `thoughtbox` (`DEFAULT_SERVER_NAME`), so the run↔session binding hook never fired for init-configured installs. Now `^mcp__.*__thoughtbox_execute$` — per the Claude Code hooks reference, matchers containing regex metacharacters are evaluated as unanchored JS regexes, so this matches any server name exposing `thoughtbox_execute` (verified against docs and by simulating a PostToolUse payload through the script: state file written, exit 0).

### 2. Channel sessionId filter fix (silent-drop bug)
Server events are workspace-scoped on the wire (top-level `workspaceId`, session id inside `data.session_id`). The SSE `EventClient` cast raw JSON to `ThoughtboxEvent`, so `event.sessionId` was `undefined` and a `THOUGHTBOX_SESSION` filter silently dropped everything. Fix: shared `extractSessionId`/`WireThoughtboxEvent` normalization in both transports (the polling client already did this ad hoc), and `EventFilter` now warns once instead of staying silent when it drops an event with no session attribution. Spec c4 evidence updated in `SPEC-REASONING-CHANNEL-HOSTED`.

### 3. Live verification of the hosted channel loop (local stack)
Headless E2E against a local server in supabase mode (local Supabase stack, no hosted mutations):
- protocol event appended → `GET /protocol/events` returns it with cursor advance, tenant-scoped (Bearer `tbx_` key)
- built `dist/thoughtbox-channel.js` spawned exactly as Claude Code would (stdio MCP, config resolved from an init-style `settings.local.json`, `THOUGHTBOX_CHANNEL_MODE=poll`) → real `notifications/claude/channel` JSON-RPC frame observed on stdout with correct content/meta (`severity: high`, `session_id`, "REFLECT required")
- with `THOUGHTBOX_SESSION` set: only the matching session's event forwarded; foreign-session event correctly filtered

**Remaining human-attended check**: Claude Code actually *rendering* `notifications/claude/channel` as `<channel>` blocks in a live session (experimental capability). Everything up to and including the notification leaving the channel process over stdio is verified.

### 4. Version/dist consistency
- `package.json` had drifted to 0.1.5 vs 0.1.6 manifests → all three (`package.json`, `plugin.json`, `marketplace.json`) now 0.1.7.
- Committed dist was stale relative to src (e.g. the `THOUGHTBOX_CHANNEL_MODE` override warning existed in src but not dist) — rebuilt; dist now matches src including these fixes.

## Tests
- `pnpm check:types` ✓, `pnpm check:lint` ✓, `pnpm build:local` ✓
- `npx vitest run`: 922 passed / 2 failed — the 2 failures are the known pre-existing environmental branch-workers failures (local Supabase edge runtime). New plugin tests: 9 added (EventFilter + SSE EventClient normalization), all 12 plugin tests green.
- Note: the shared local Supabase stack had accumulated 53 `roundtrip-*@test.local` auth users, pushing `test@test.local` off `listUsers()`'s first page (default 50) and breaking `ensureTestWorkspace` for the whole Supabase suite (70 failures). Cleaned up the local stack; a follow-up should make the helper paginate or fetch by email.

🤖 Generated with [Claude Code](https://claude.com/claude-code)