### PR TITLE
feat(agx): B10 evidence-gated graduation + B11 standing-facts shim

### DIFF
--- a/.specs/agx/SPEC-AGX-SUBSTRATE.md
+++ b/.specs/agx/SPEC-AGX-SUBSTRATE.md
@@ -198,6 +198,20 @@ claims with ids and evidence), and handoff `standing_facts` are existing obligat
 that become claim-graph readers/writers. The thought journal remains for operator-class agents
 and is otherwise demoted to legacy; it is not extended.
 
+**B11 delivery notes (2026-07-09 — as built):** the standing-facts shim
+(`src/claims/standing-facts.ts`) is the migration surface for the first two consumers. A
+standing fact is a keyed, workspace-scoped claim: `write` → `tb.claims.assert` with the key
+encoded as a queryable statement prefix (`[fact:<key>] <statement>`); `read`/`list` →
+`tb.claims.query` returning only LIVE facts (asserted/supported); revision is an explicit
+`supersede` → `tb.claims.supersede` (old claim flips to `superseded` pointing at its
+replacement, atomically — never a silent overwrite). Consumer mapping: assumption-registry
+entries write as type `assumption` (the default); session-handoff `standing_facts` write as
+`observation`/`decision`. The shim routes through the ClaimsHandler, so facts inherit
+tb.claims validation, the supersede CAS, and Realtime status emission verbatim. Round-trip
+and supersede semantics are vitest-evidenced (`src/claims/__tests__/standing-facts.test.ts`).
+Skill/handoff integrations are deliberately NOT built here — the shim is the reader/writer
+those artifacts adopt.
+
 ## 5. Layer 2: Reactive Runbooks (EVOLVES the notebook subsystem)
 
 The prior Notebook Evidence Engine spec (`.specs/agentic-runbooks.md`, draft, largely
@@ -391,7 +405,7 @@ Phases 4+5 (≈9 M-units) shipped in about a week of agent-team time.
 | B8 | Advancer v0 (advance-on-open + cron tick) | B4–B6 | **S** | Low | Explicitly not a workflow engine |
 | B9 | Fitness ledger + aggregates | B4 | **S/M** | Low | Schema + queries |
 | B10 | Evidence-gated graduation | #389 graduation, B9 | **M** | Med | Delivered 2026-07-09 — ELG tier ladder, shadow default (§7 delivery notes) |
-| B11 | Migration shims: assumption registry & handoff standing-facts → claims | B1–B2 | **S** | Low | Principle 3 delivery |
+| B11 | Migration shims: assumption registry & handoff standing-facts → claims | B1–B2 | **S** | Low | Delivered 2026-07-09 — standing-facts shim (§4 delivery notes); consumer rewiring tracked in §12 |
 | — | Semantic relevance routing / watch predicates | B3 | **XL** | — | Deferred; v0 is explicit subscription |
 | — | MAP-Elites descriptor archive | B9 | **XL** | — | Deferred; needs fitness history first |
 | — | Durable suspended execution | — | **XL** | — | Explicitly rejected (Principle 5) |
@@ -501,8 +515,9 @@ design decisions for v0; the residual open questions are marked.
 
 ## 12. Capability Status (point-in-time)
 
-What an agent can and cannot yet do through `thoughtbox_execute`, as of **2026-07-06**
-(units B1–B5 merged via PRs #398–#402; B6+B8 built on feat/agx-await-advancer). This is
+What an agent can and cannot yet do through `thoughtbox_execute`, as of **2026-07-09**
+(units B1–B5 merged via PRs #398–#402; B6+B8 via #418; B10+B11 built on
+feat/agx-b10-graduation-b11-shims). This is
 derived status, not authority — the claims block and §9 are the pre-registration. Update the
 table as units land.
 
@@ -522,6 +537,8 @@ table as units land.
 | A runbook cell that **blocks on a claim** — a run parks at an unsatisfied `await` cell (skipped tail, durable claim subscription, instance stays `in_progress`), and the next pull past a satisfying claim status records the satisfaction and executes the cells behind it | `await` cell (`tb.runbook.addAwaitCell`) + `tb.runbook.advance` (B6) | c4 / §5 delivery notes |
 | Pull advancement of an instance by any agent, with concurrent advancers executing side effects **exactly once** — CAS reservation on `(instance_id, seq)` before any exec-cell side effect; losers observe `in_flight` (GH #403 resolved) | `tb.runbook.advance`, `tb.runbook.status`, `runbook_advance_reservations` | c4 (B8) |
 | Keep shell, filesystem, and code editing native and unmediated — the substrate wraps only trust-boundary verbs | (invariant; §10) | c10 |
+| Evidence-gated notebook→manifest **graduation** — `graduateNotebook` reads the fitness ledger and evaluates the ELG tier ladder (advisory → shadow → enforce; shadow default records would-have-blocked without blocking, `THOUGHTBOX_GRADUATION_GATE=enforce` rejects below threshold naming the missing evidence) | `peer_graduate_notebook` gate (B10, §7 delivery notes) | c8 (2026-07-09) |
+| Round-trip standing facts through the claim graph — keyed, workspace-scoped write/read/list/supersede over tb.claims semantics, for the assumption registry and handoff `standing_facts` | standing-facts shim (B11, §4 delivery notes) | Principle 3 (2026-07-09) |
 
 **Not yet — the unbuilt joins:**
 
@@ -529,9 +546,10 @@ table as units land.
 |---|---|---|
 | Cron tick advancing unattended instances (advance is agent-pull only today) | **B8 follow-up** | c4 |
 | Cells executing under the agent's **brokered allowlist and budget** (no ambient authority) | **B7** | c6 |
-| Evidence-gated notebook→manifest **graduation** (reject below fitness threshold) | **B10** | c8 |
+| Graduation gate ENFORCED by default (today: shadow default; enforce is a config switch — ELG shadow-window promotion is deliberate, not ambient) | operator decision after a shadow window | c8 |
+| Assumptions skill / session-handoff actually writing through the B11 shim (the shim is built; the consumers still write their legacy artifacts) | skill + handoff rewiring (H5) | Principle 3 |
 | Local durable claims (FileSystem `ClaimStorage`) | deferred §11.5 (gated on H1/H2) | c1 |
 
-**Verified vs claimed:** c3, c7, c10 are met and evidenced; c4 is met for the manual-pull path — vitest evidence covers (a) parking at an unsatisfied await on both the advance and real batch-run paths, (b) claim satisfaction un-parking the next advance end-to-end through the real execution path, (c) concurrent advance executing side effects exactly once, (d) the reservation CAS on both backends (`src/notebook/__tests__/await-advance.test.ts`), and code review confirms no suspended-execution machinery exists (the advancer is a loop inside one explicit call; the cron tick remains unbuilt); c1 is met for Supabase + InMemory (FS deferred by design); c2's mechanism is proven but its full two-live-client agentic test is deploy-gated; c5 (fresh-session instance resumption) has its substrate in #401 + `tb.runbook.status` but is unverified pending **Experiment H2**; c6/c8 are unbuilt. The two thesis experiments (**H1** coordination-beats-orchestrator, **H2** runbook resumption) are unrun.
+**Verified vs claimed:** c3, c7, c10 are met and evidenced; c8 is met — the gate reads the ledger and vitest covers the accept, reject-naming-the-deficit, and shadow would-have-blocked paths (`src/peer-notebook/__tests__/graduation-gate.test.ts`), with enforcement itself an opt-in switch per the ELG shadow-first policy; c4 is met for the manual-pull path — vitest evidence covers (a) parking at an unsatisfied await on both the advance and real batch-run paths, (b) claim satisfaction un-parking the next advance end-to-end through the real execution path, (c) concurrent advance executing side effects exactly once, (d) the reservation CAS on both backends (`src/notebook/__tests__/await-advance.test.ts`), and code review confirms no suspended-execution machinery exists (the advancer is a loop inside one explicit call; the cron tick remains unbuilt); c1 is met for Supabase + InMemory (FS deferred by design); c2's mechanism is proven but its full two-live-client agentic test is deploy-gated; c5 (fresh-session instance resumption) has its substrate in #401 + `tb.runbook.status` but is unverified pending **Experiment H2**; c6 is unbuilt. The two thesis experiments (**H1** coordination-beats-orchestrator, **H2** runbook resumption) are unrun.
 
-**Bottom line:** the claim graph and durable runbooks are now **wired into each other**: the reactive payoff ("block on a claim, wake the runbook") is built and test-evidenced via B6+B8, with the GH #403 double-execute hazard resolved by the advance reservation CAS. The first unbuilt things are now the B8 cron tick, brokered cell authority (**B7** / c6), and evidence-gated graduation (**B10** / c8); **H2** is unblocked and should run next (§9).
+**Bottom line:** the selection pipeline now closes end-to-end: behaviors accrue ledger fitness (B9) and graduation reads it (B10), with the ELG shadow tier keeping the evidence stream alive until an operator promotes the gate to enforce. B11 gives the first two obligatory artifacts (assumption registry, handoff standing facts) their claims-native reader/writer. The remaining unbuilt joins are the B8 cron tick and brokered cell authority (**B7** / c6); **H2** is unblocked and should run next (§9), and **H4** (graduation cheaper than specification) now has its mechanism.

--- a/.specs/agx/SPEC-AGX-SUBSTRATE.md
+++ b/.specs/agx/SPEC-AGX-SUBSTRATE.md
@@ -327,6 +327,7 @@ merged 2026-06-11).
    message-human), not toward mediating the agent body (claim c10). New verbs arrive
    primarily via graduation (§7), not specification.
 3. **Evidence-gated graduation** (claim c8): graduation reads the fitness ledger.
+   (Delivered 2026-07-09 — B10, §7 delivery notes; shadow-mode default, enforce opt-in.)
 
 ## 7. Selection Pipeline: Fitness Ledger and Graduation
 
@@ -346,6 +347,31 @@ This is the answer to "where do remote-control verbs come from": behaviors are p
 runbooks under full observability, evaluated against pre-registered outcomes, and the proven
 ones are promoted into governed, manifest-described capabilities.
 
+**B10 delivery notes (2026-07-09 — as built):**
+
+1. **The gate reads the real ledger.** `graduateNotebook` evaluates the graduating notebook's
+   fitness via the notebook source's runbook storage (`templateId` = notebook id, latest
+   template version's `getFitnessAggregate`). No storage wired, or no template version ever
+   persisted, counts as ABSENT evidence, never as a pass. Policy lives in
+   `src/notebook/runbook/graduation-gate.ts`; the graduation wiring in
+   `src/peer-notebook/handler.ts`.
+2. **Threshold policy is the ELG tier ladder** (SPEC-ENVIRONMENTAL-LEARNING-GATES, folded in
+   here): `advisory` (evaluate + log only) → `shadow` (warn + record `wouldHaveBlocked`,
+   never block — the validator tier and the gate's probation state) → `enforce` (reject with
+   an error naming each missing piece of evidence, code `graduation_below_threshold`).
+   **Default is `shadow`**, per the ELG keystone: gates are information-destroying, so
+   promotion to a live block is a deliberate act backed by shadow-window data — switch via
+   the `graduationGate` handler option or `THOUGHTBOX_GRADUATION_GATE=enforce`. Every
+   graduation result carries the full `gateDecision` record (mode, aggregate, thresholds,
+   deficits), so shadow mode leaves an auditable would-have-blocked trail with zero behavior
+   change.
+3. **Thresholds (v0 defaults):** ≥3 evidenced instances, machine-checked pass rate ≥0.9,
+   ≥1 distinct agent (`DEFAULT_GRADUATION_THRESHOLDS`; per-deployment override via handler
+   option). A never-run notebook under `enforce` is rejected with the explanation naming the
+   empty ledger. Accept/reject/shadow paths are vitest-evidenced
+   (`src/peer-notebook/__tests__/graduation-gate.test.ts`,
+   `src/notebook/__tests__/graduation-gate.test.ts`).
+
 ## 8. Build Inventory and Relative Complexity
 
 Scale: **S** ≤ 1 agent-day · **M** = one PR-sized unit (2–5 agent-days, a Phase-4/5-slice
@@ -364,7 +390,7 @@ Phases 4+5 (≈9 M-units) shipped in about a week of agent-team time.
 | B7 | Brokered `exec`-cell execution (generalize broker beyond peers) | SPEC-CONTROL-PLANE broker | **M/L** | Med | Authority model resolved to manifest reuse (§11.2): approved templates carry declared authority; drafts run under declared ∩ executor |
 | B8 | Advancer v0 (advance-on-open + cron tick) | B4–B6 | **S** | Low | Explicitly not a workflow engine |
 | B9 | Fitness ledger + aggregates | B4 | **S/M** | Low | Schema + queries |
-| B10 | Evidence-gated graduation | #389 graduation, B9 | **M** | Med | Threshold policy design |
+| B10 | Evidence-gated graduation | #389 graduation, B9 | **M** | Med | Delivered 2026-07-09 — ELG tier ladder, shadow default (§7 delivery notes) |
 | B11 | Migration shims: assumption registry & handoff standing-facts → claims | B1–B2 | **S** | Low | Principle 3 delivery |
 | — | Semantic relevance routing / watch predicates | B3 | **XL** | — | Deferred; v0 is explicit subscription |
 | — | MAP-Elites descriptor archive | B9 | **XL** | — | Deferred; needs fitness history first |

--- a/prs/feat-agx-b10-graduation-b11-shims.json
+++ b/prs/feat-agx-b10-graduation-b11-shims.json
@@ -1,0 +1,27 @@
+{
+  "branch": "feat/agx-b10-graduation-b11-shims",
+  "summary": "SPEC-AGX-SUBSTRATE B10 (evidence-gated graduation) + B11 (standing-facts migration shim). graduateNotebook now evaluates the fitness ledger through the ELG tier ladder (advisory -> shadow -> enforce) with a shadow-mode default that records would-have-blocked decisions without blocking; THOUGHTBOX_GRADUATION_GATE=enforce (or the graduationGate handler option) rejects below-threshold graduations with an error naming the missing evidence. B11 adds src/claims/standing-facts.ts: keyed, workspace-scoped standing facts (assumption registry / session-handoff standing_facts) round-trip through tb.claims semantics — write as typed claim, read back live, supersede atomically.",
+  "claims": [
+    {
+      "id": "SPEC-AGX-SUBSTRATE:c8",
+      "statement": "graduateNotebook reads the fitness ledger and rejects graduation below threshold with an error naming the deficit; tests cover accept and reject paths.",
+      "evidence_type": "test",
+      "evidence_path": "src/peer-notebook/__tests__/graduation-gate.test.ts",
+      "evidence_description": "7 tests: enforce rejects a never-run notebook with code graduation_below_threshold naming the empty ledger; enforce passes when seeded evidence meets thresholds; enforce rejects on failing pass rate naming it; shadow default graduates unchanged while recording wouldHaveBlocked; env-var switch flips enforcement; missing runbook storage counts as absent evidence. Policy unit tests (10) in src/notebook/__tests__/graduation-gate.test.ts."
+    },
+    {
+      "id": "SPEC-AGX-SUBSTRATE:b10-shadow-default",
+      "statement": "Shadow mode is the default and records would-have-blocked with zero behavior change to graduation.",
+      "evidence_type": "test",
+      "evidence_path": "src/peer-notebook/__tests__/graduation-gate.test.ts",
+      "evidence_description": "Default-mode test asserts the draft manifest lands exactly as before (status draft, version 1, no supersessions) while gateDecision records mode=shadow, pass=false, wouldHaveBlocked=true with deficits naming the missing evidence. Pre-existing graduation suite (notebook-graduation.test.ts, 9 tests) passes unmodified under the shadow default."
+    },
+    {
+      "id": "SPEC-AGX-SUBSTRATE:b11-standing-facts",
+      "statement": "Standing facts round-trip through tb.claims: write as a typed workspace-scoped claim, read back, supersede atomically (old claim -> superseded pointing at replacement).",
+      "evidence_type": "test",
+      "evidence_path": "src/claims/__tests__/standing-facts.test.ts",
+      "evidence_description": "9 tests over the real ClaimsHandler + InMemoryClaimStorage: write/read round-trip with workspace and exact-key scoping, duplicate write refused in favor of explicit supersede, supersede flips status/supersededBy and read converges on the replacement, list excludes superseded history, mutations require agent identity."
+    }
+  ]
+}

--- a/src/claims/__tests__/standing-facts.test.ts
+++ b/src/claims/__tests__/standing-facts.test.ts
@@ -1,0 +1,142 @@
+/**
+ * B11 standing-facts shim tests (SPEC-AGX-SUBSTRATE — Principle 3 migration
+ * shim): the assumption-registry / session-handoff round-trip through
+ * tb.claims. Proves write → read-back → supersede semantics over the real
+ * claims handler and InMemoryClaimStorage.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { createClaimsHandler } from '../claims-handler.js';
+import { InMemoryClaimStorage } from '../in-memory-claim-storage.js';
+import {
+  createStandingFacts,
+  decodeFactStatement,
+  encodeFactStatement,
+  normalizeFactKey,
+} from '../standing-facts.js';
+
+const WORKSPACE = 'ws-standing-facts';
+const AGENT = 'agent-shim-test';
+
+function setup() {
+  const storage = new InMemoryClaimStorage();
+  const handler = createClaimsHandler(storage);
+  return { facts: createStandingFacts(handler), storage };
+}
+
+describe('standing-fact key encoding', () => {
+  it('normalizes keys and rejects malformed ones', () => {
+    expect(normalizeFactKey('  Local-Edge.Runtime_503 ')).toBe('local-edge.runtime_503');
+    expect(() => normalizeFactKey('has spaces')).toThrow(/Invalid standing-fact key/);
+    expect(() => normalizeFactKey('-leading-dash')).toThrow(/Invalid standing-fact key/);
+    expect(() => normalizeFactKey('')).toThrow(/Invalid standing-fact key/);
+  });
+
+  it('round-trips statements through the encoding', () => {
+    const encoded = encodeFactStatement('db.pool', 'pool size is 10');
+    expect(encoded).toBe('[fact:db.pool] pool size is 10');
+    expect(decodeFactStatement(encoded)).toEqual({ key: 'db.pool', statement: 'pool size is 10' });
+    expect(decodeFactStatement('an ordinary claim statement')).toBeNull();
+  });
+});
+
+describe('standing-facts round-trip (B11)', () => {
+  it('writes a fact as a typed, workspace-scoped claim and reads it back', async () => {
+    const { facts } = setup();
+
+    const written = await facts.write(AGENT, {
+      workspaceId: WORKSPACE,
+      key: 'edge-runtime-503',
+      statement: 'local Supabase edge runtime 503s under docker-compose',
+      evidenceRefs: ['src/__tests__/branch-workers.test.ts'],
+    });
+    expect(written.claim.type).toBe('assumption'); // registry default
+    expect(written.claim.workspaceId).toBe(WORKSPACE);
+    expect(written.claim.status).toBe('asserted');
+    expect(written.claim.createdBy).toBe(AGENT);
+
+    const read = await facts.read(WORKSPACE, 'edge-runtime-503');
+    expect(read).not.toBeNull();
+    expect(read!.key).toBe('edge-runtime-503');
+    expect(read!.statement).toBe('local Supabase edge runtime 503s under docker-compose');
+    expect(read!.claim.id).toBe(written.claim.id);
+  });
+
+  it('scopes reads to the workspace and to the exact key', async () => {
+    const { facts } = setup();
+    await facts.write(AGENT, { workspaceId: WORKSPACE, key: 'db', statement: 'primary fact' });
+    await facts.write(AGENT, { workspaceId: WORKSPACE, key: 'db-pool', statement: 'pool fact' });
+    await facts.write(AGENT, { workspaceId: 'other-ws', key: 'db', statement: 'other workspace' });
+
+    const read = await facts.read(WORKSPACE, 'db');
+    expect(read!.statement).toBe('primary fact'); // "db" never matches "[fact:db-pool]"
+    expect((await facts.read('other-ws', 'db'))!.statement).toBe('other workspace');
+    expect(await facts.read(WORKSPACE, 'missing')).toBeNull();
+  });
+
+  it('refuses a duplicate write — revision is an explicit supersede', async () => {
+    const { facts } = setup();
+    await facts.write(AGENT, { workspaceId: WORKSPACE, key: 'dup', statement: 'v1' });
+
+    await expect(
+      facts.write(AGENT, { workspaceId: WORKSPACE, key: 'dup', statement: 'v2' }),
+    ).rejects.toThrow(/already exists.*use supersede/);
+  });
+
+  it('supersede flips the old claim and the read converges on the replacement', async () => {
+    const { facts } = setup();
+    const first = await facts.write(AGENT, {
+      workspaceId: WORKSPACE,
+      key: 'deploy-target',
+      statement: 'deploys to Cloud Run via docker push',
+      type: 'decision',
+    });
+
+    const { previous, current } = await facts.supersede(AGENT, {
+      workspaceId: WORKSPACE,
+      key: 'deploy-target',
+      statement: 'deploys to Cloud Run via Cloud Build triggers',
+      type: 'decision',
+    });
+
+    // tb.claims supersede semantics, verbatim: old → 'superseded' pointing
+    // at the replacement; replacement freshly 'asserted'.
+    expect(previous.claim.id).toBe(first.claim.id);
+    expect(previous.claim.status).toBe('superseded');
+    expect(previous.claim.supersededBy).toBe(current.claim.id);
+    expect(previous.statement).toBe('deploys to Cloud Run via docker push');
+    expect(current.claim.status).toBe('asserted');
+    expect(current.claim.type).toBe('decision');
+
+    const read = await facts.read(WORKSPACE, 'deploy-target');
+    expect(read!.claim.id).toBe(current.claim.id);
+    expect(read!.statement).toBe('deploys to Cloud Run via Cloud Build triggers');
+  });
+
+  it('supersede of a missing fact fails with a pointer to write', async () => {
+    const { facts } = setup();
+    await expect(
+      facts.supersede(AGENT, { workspaceId: WORKSPACE, key: 'ghost', statement: 'x' }),
+    ).rejects.toThrow(/No live standing fact "ghost"/);
+  });
+
+  it('lists only live facts, superseded history excluded', async () => {
+    const { facts } = setup();
+    await facts.write(AGENT, { workspaceId: WORKSPACE, key: 'b-fact', statement: 'bee' });
+    await facts.write(AGENT, { workspaceId: WORKSPACE, key: 'a-fact', statement: 'ay' });
+    await facts.supersede(AGENT, { workspaceId: WORKSPACE, key: 'a-fact', statement: 'ay v2' });
+
+    const listed = await facts.list(WORKSPACE);
+    expect(listed.map(fact => [fact.key, fact.statement])).toEqual([
+      ['a-fact', 'ay v2'],
+      ['b-fact', 'bee'],
+    ]);
+  });
+
+  it('requires an agent identity for mutations (tb.claims contract)', async () => {
+    const { facts } = setup();
+    await expect(
+      facts.write('', { workspaceId: WORKSPACE, key: 'anon', statement: 'x' }),
+    ).rejects.toThrow(/requires an agent identity/);
+  });
+});

--- a/src/claims/standing-facts.ts
+++ b/src/claims/standing-facts.ts
@@ -1,0 +1,188 @@
+/**
+ * Standing-facts migration shim (SPEC-AGX-SUBSTRATE B11 — Principle 3).
+ *
+ * A "standing fact" is a keyed, workspace-scoped assertion that outlives the
+ * session that wrote it: an assumption-registry entry ("supabase local edge
+ * runtime 503s under docker-compose") or a session-handoff standing fact
+ * ("prod tables are the owner's archive — never drop"). This shim gives
+ * those two consumers a claims-native round-trip so the obligatory artifact
+ * (registry file / handoff JSON) can be replaced by the claim graph rather
+ * than paralleled by it:
+ *
+ * - `write`      → `tb.claims.assert` of a typed claim whose statement
+ *                  carries the fact key as a queryable prefix
+ * - `read`/`list`→ `tb.claims.query` by that prefix, returning only the
+ *                  LIVE fact (asserted/supported — invalidated and
+ *                  superseded facts are history, not truth)
+ * - `supersede`  → `tb.claims.supersede`: the old fact flips to
+ *                  'superseded' pointing at its replacement, atomically
+ *
+ * The shim deliberately routes through ClaimsHandler (not ClaimStorage) so
+ * standing facts get exactly the tb.claims semantics: input validation, the
+ * atomic supersede CAS, and Realtime status-change emission.
+ *
+ * Statement encoding: `[fact:<key>] <statement>`. Keys are normalized to
+ * lowercase [a-z0-9._-] so the case-insensitive substring match of
+ * tb.claims.query finds exactly one key family; the closing `]` prevents
+ * prefix collisions ("db" never matches "[fact:db-pool]").
+ */
+
+import type { Claim, ClaimType } from './types.js';
+import type { ClaimsHandler } from './claims-handler.js';
+
+const FACT_KEY_PATTERN = /^[a-z0-9][a-z0-9._-]*$/;
+
+/** Statuses under which a fact is current truth rather than history. */
+const LIVE_STATUSES = new Set(['asserted', 'supported']);
+
+export interface StandingFact {
+  key: string;
+  /** The bare statement, without the [fact:key] encoding prefix. */
+  statement: string;
+  /** The underlying claim record (id, status, provenance, evidence). */
+  claim: Claim;
+}
+
+export interface StandingFactWriteInput {
+  workspaceId: string;
+  key: string;
+  statement: string;
+  /**
+   * Claim type mapping for the two intended consumers:
+   * - assumption-registry entries → 'assumption' (the default)
+   * - session-handoff standing facts → 'observation' or 'decision'
+   */
+  type?: ClaimType;
+  evidenceRefs?: string[];
+}
+
+export interface StandingFactsShim {
+  /**
+   * Assert a new standing fact. Throws if a live fact already holds the key
+   * in this workspace — revision is an explicit `supersede`, never a
+   * silent overwrite (assumption-registry semantics).
+   */
+  write(agentId: string, input: StandingFactWriteInput): Promise<StandingFact>;
+  /** The live fact for a key, or null when none (or only history) exists. */
+  read(workspaceId: string, key: string): Promise<StandingFact | null>;
+  /** All live facts in a workspace, ordered by key. */
+  list(workspaceId: string): Promise<StandingFact[]>;
+  /**
+   * Replace the live fact for a key: the prior claim flips to 'superseded'
+   * (pointing at the replacement) and the replacement is asserted, in one
+   * atomic step. Throws when no live fact holds the key.
+   */
+  supersede(
+    agentId: string,
+    input: StandingFactWriteInput,
+  ): Promise<{ previous: StandingFact; current: StandingFact }>;
+}
+
+export function normalizeFactKey(key: string): string {
+  const normalized = key.trim().toLowerCase();
+  if (!FACT_KEY_PATTERN.test(normalized)) {
+    throw new Error(
+      `Invalid standing-fact key "${key}": keys must match ${FACT_KEY_PATTERN} after lowercasing`,
+    );
+  }
+  return normalized;
+}
+
+export function encodeFactStatement(key: string, statement: string): string {
+  return `[fact:${key}] ${statement}`;
+}
+
+/** Decode a claim statement; returns null when it is not a standing fact. */
+export function decodeFactStatement(
+  statement: string,
+): { key: string; statement: string } | null {
+  const match = /^\[fact:([a-z0-9][a-z0-9._-]*)\] ([\s\S]*)$/.exec(statement);
+  if (!match) return null;
+  return { key: match[1]!, statement: match[2]! };
+}
+
+export function createStandingFacts(claims: ClaimsHandler): StandingFactsShim {
+  function toFact(claim: Claim): StandingFact | null {
+    const decoded = decodeFactStatement(claim.statement);
+    if (!decoded) return null;
+    return { key: decoded.key, statement: decoded.statement, claim };
+  }
+
+  /**
+   * All live fact claims for a key. Query narrows by the encoded prefix
+   * (case-insensitive substring), then the exact prefix + liveness are
+   * re-checked here. Multiple live claims for one key can only arise from
+   * writes that bypassed this shim; newest-first lets the reader converge
+   * on the latest assertion instead of failing.
+   */
+  async function liveFactClaims(workspaceId: string, key: string): Promise<Claim[]> {
+    const prefix = `[fact:${key}] `;
+    const result = (await claims.handle(null, 'query', {
+      workspaceId,
+      text: `[fact:${key}]`,
+    })) as { claims: Claim[] };
+    return result.claims
+      .filter(claim => claim.statement.startsWith(prefix) && LIVE_STATUSES.has(claim.status))
+      .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  }
+
+  return {
+    async write(agentId, input) {
+      const key = normalizeFactKey(input.key);
+      const [existing] = await liveFactClaims(input.workspaceId, key);
+      if (existing) {
+        throw new Error(
+          `Standing fact "${key}" already exists in workspace ${input.workspaceId} ` +
+            `(claim ${existing.id}); use supersede to revise it`,
+        );
+      }
+      const claim = (await claims.handle(agentId, 'assert', {
+        workspaceId: input.workspaceId,
+        type: input.type ?? 'assumption',
+        statement: encodeFactStatement(key, input.statement),
+        ...(input.evidenceRefs !== undefined ? { evidenceRefs: input.evidenceRefs } : {}),
+      })) as Claim;
+      return { key, statement: input.statement, claim };
+    },
+
+    async read(workspaceId, key) {
+      const [claim] = await liveFactClaims(workspaceId, normalizeFactKey(key));
+      return claim ? toFact(claim) : null;
+    },
+
+    async list(workspaceId) {
+      const result = (await claims.handle(null, 'query', {
+        workspaceId,
+        text: '[fact:',
+      })) as { claims: Claim[] };
+      const facts: StandingFact[] = [];
+      for (const claim of result.claims) {
+        if (!LIVE_STATUSES.has(claim.status)) continue;
+        const fact = toFact(claim);
+        if (fact) facts.push(fact);
+      }
+      return facts.sort((a, b) => a.key.localeCompare(b.key));
+    },
+
+    async supersede(agentId, input) {
+      const key = normalizeFactKey(input.key);
+      const [existing] = await liveFactClaims(input.workspaceId, key);
+      if (!existing) {
+        throw new Error(
+          `No live standing fact "${key}" in workspace ${input.workspaceId} to supersede; ` +
+            `use write to assert it first`,
+        );
+      }
+      const result = (await claims.handle(agentId, 'supersede', {
+        claimId: existing.id,
+        statement: encodeFactStatement(key, input.statement),
+        ...(input.type !== undefined ? { type: input.type } : {}),
+        ...(input.evidenceRefs !== undefined ? { evidenceRefs: input.evidenceRefs } : {}),
+      })) as { superseded: Claim; replacement: Claim };
+      return {
+        previous: { key, statement: decodeFactStatement(result.superseded.statement)?.statement ?? result.superseded.statement, claim: result.superseded },
+        current: { key, statement: input.statement, claim: result.replacement },
+      };
+    },
+  };
+}

--- a/src/notebook/__tests__/graduation-gate.test.ts
+++ b/src/notebook/__tests__/graduation-gate.test.ts
@@ -1,0 +1,194 @@
+/**
+ * B10 graduation-gate threshold policy tests (SPEC-AGX-SUBSTRATE claim c8,
+ * ELG tier ladder). Pure evaluation over fitness aggregates plus the full
+ * ledger-backed evaluateGraduationGate path over InMemoryRunbookStorage.
+ * The peer-notebook handler integration (accept/reject at graduation) lives
+ * in src/peer-notebook/__tests__/graduation-gate.test.ts.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_GRADUATION_THRESHOLDS,
+  GRADUATION_GATE_ENV_VAR,
+  evaluateGraduationFitness,
+  evaluateGraduationGate,
+  resolveGraduationGateMode,
+} from "../runbook/graduation-gate.js";
+import { InMemoryRunbookStorage } from "../runbook/in-memory-runbook-storage.js";
+import {
+  hashTemplateCells,
+  type FitnessAggregate,
+  type RunbookTemplateCell,
+} from "../runbook/types.js";
+
+const TEMPLATE_ID = "nb_gate_candidate";
+
+function aggregate(overrides: Partial<FitnessAggregate> = {}): FitnessAggregate {
+  return {
+    templateId: TEMPLATE_ID,
+    templateVersion: 1,
+    instances: 3,
+    evaluated: 10,
+    passed: 10,
+    passRate: 1,
+    errorRows: 0,
+    errorRate: 0,
+    distinctAgents: 1,
+    ...overrides,
+  };
+}
+
+describe("resolveGraduationGateMode", () => {
+  it("defaults to shadow (ELG: enforcement is opt-in, never ambient)", () => {
+    expect(resolveGraduationGateMode(undefined, {})).toBe("shadow");
+    expect(resolveGraduationGateMode(undefined, { [GRADUATION_GATE_ENV_VAR]: "" })).toBe("shadow");
+  });
+
+  it("reads the env var and lets explicit config beat it", () => {
+    expect(
+      resolveGraduationGateMode(undefined, { [GRADUATION_GATE_ENV_VAR]: "enforce" }),
+    ).toBe("enforce");
+    expect(
+      resolveGraduationGateMode("advisory", { [GRADUATION_GATE_ENV_VAR]: "enforce" }),
+    ).toBe("advisory");
+  });
+
+  it("throws loudly on an unrecognized env value instead of silently defaulting", () => {
+    expect(() =>
+      resolveGraduationGateMode(undefined, { [GRADUATION_GATE_ENV_VAR]: "on" }),
+    ).toThrow(/not a graduation gate mode/);
+  });
+});
+
+describe("evaluateGraduationFitness", () => {
+  it("passes when every threshold is met", () => {
+    const result = evaluateGraduationFitness(
+      TEMPLATE_ID,
+      aggregate(),
+      DEFAULT_GRADUATION_THRESHOLDS,
+    );
+    expect(result).toEqual({ pass: true, deficits: [] });
+  });
+
+  it("names the empty ledger when no template version was ever persisted", () => {
+    const result = evaluateGraduationFitness(TEMPLATE_ID, null, DEFAULT_GRADUATION_THRESHOLDS);
+    expect(result.pass).toBe(false);
+    expect(result.deficits).toHaveLength(1);
+    expect(result.deficits[0]).toContain("no fitness evidence");
+    expect(result.deficits[0]).toContain("never run as a runbook");
+  });
+
+  it("names each unmet threshold as a separate deficit", () => {
+    const result = evaluateGraduationFitness(
+      TEMPLATE_ID,
+      aggregate({ instances: 1, passed: 4, passRate: 0.4, distinctAgents: 1 }),
+      { minInstances: 3, minPassRate: 0.9, minDistinctAgents: 2 },
+    );
+    expect(result.pass).toBe(false);
+    expect(result.deficits).toHaveLength(3);
+    expect(result.deficits[0]).toContain("instances 1 below threshold 3");
+    expect(result.deficits[1]).toContain("pass rate 0.4 below threshold 0.9");
+    expect(result.deficits[2]).toContain("distinct agents 1 below threshold 2");
+  });
+
+  it("treats a null pass rate (zero evaluated rows) as missing evidence, not a pass", () => {
+    const result = evaluateGraduationFitness(
+      TEMPLATE_ID,
+      aggregate({ evaluated: 0, passed: 0, passRate: null }),
+      DEFAULT_GRADUATION_THRESHOLDS,
+    );
+    expect(result.pass).toBe(false);
+    expect(result.deficits.join(" ")).toContain("no machine-checked pass rate");
+  });
+});
+
+describe("evaluateGraduationGate (ledger-backed)", () => {
+  it("fails with a named deficit when no runbook storage is wired", async () => {
+    const decision = await evaluateGraduationGate({
+      templateId: TEMPLATE_ID,
+      storage: undefined,
+      mode: "shadow",
+    });
+    expect(decision.pass).toBe(false);
+    expect(decision.enforced).toBe(false);
+    expect(decision.wouldHaveBlocked).toBe(true);
+    expect(decision.aggregate).toBeNull();
+    expect(decision.deficits[0]).toContain("fitness ledger unavailable");
+  });
+
+  it("evaluates the latest template version's aggregate against thresholds", async () => {
+    const storage = new InMemoryRunbookStorage();
+    await seedEvidence(storage, { instances: 3, passRowsPerInstance: 2 });
+
+    const decision = await evaluateGraduationGate({
+      templateId: TEMPLATE_ID,
+      storage,
+      mode: "enforce",
+      thresholds: { minInstances: 3, minPassRate: 0.9, minDistinctAgents: 1 },
+    });
+    expect(decision.pass).toBe(true);
+    expect(decision.enforced).toBe(true);
+    expect(decision.wouldHaveBlocked).toBe(false);
+    expect(decision.templateVersion).toBe(1);
+    expect(decision.aggregate).toMatchObject({ instances: 3, passRate: 1, distinctAgents: 1 });
+    expect(decision.deficits).toEqual([]);
+  });
+
+  it("reports would-have-blocked (not enforced) below threshold in shadow mode", async () => {
+    const storage = new InMemoryRunbookStorage();
+    await seedEvidence(storage, { instances: 1, passRowsPerInstance: 1 });
+
+    const decision = await evaluateGraduationGate({
+      templateId: TEMPLATE_ID,
+      storage,
+      mode: "shadow",
+    });
+    expect(decision.pass).toBe(false);
+    expect(decision.wouldHaveBlocked).toBe(true);
+    expect(decision.deficits[0]).toContain("instances 1 below threshold 3");
+  });
+});
+
+async function seedEvidence(
+  storage: InMemoryRunbookStorage,
+  input: { instances: number; passRowsPerInstance: number },
+): Promise<void> {
+  const cells: RunbookTemplateCell[] = [
+    { cellId: "cell-1", cellType: "code", filename: "main.mjs", source: "console.log(1);" },
+  ];
+  await storage.saveTemplate({
+    templateId: TEMPLATE_ID,
+    version: 1,
+    cells,
+    cellsHash: hashTemplateCells(cells),
+    createdBy: "local",
+    createdAt: new Date().toISOString(),
+  });
+  for (let i = 0; i < input.instances; i += 1) {
+    const instanceId = `inst-${i + 1}`;
+    await storage.createInstance({
+      instanceId,
+      templateId: TEMPLATE_ID,
+      templateVersion: 1,
+      createdBy: "local",
+      createdAt: new Date().toISOString(),
+    });
+    for (let row = 0; row < input.passRowsPerInstance; row += 1) {
+      await storage.appendFitnessRows([
+        {
+          templateId: TEMPLATE_ID,
+          templateVersion: 1,
+          instanceId,
+          cellId: "cell-1",
+          tier: 1,
+          result: "pass",
+          pass: true,
+          expected: 0,
+          actual: 0,
+          agentId: "local",
+          ts: new Date().toISOString(),
+        },
+      ]);
+    }
+  }
+}

--- a/src/notebook/runbook/graduation-gate.ts
+++ b/src/notebook/runbook/graduation-gate.ts
@@ -1,0 +1,220 @@
+/**
+ * Evidence-gated graduation threshold policy (SPEC-AGX-SUBSTRATE B10, claim c8).
+ *
+ * Graduation reads the fitness ledger (B9/c7): a notebook graduates to a
+ * draft peer manifest only when its latest runbook template version carries
+ * enough machine-checked evidence. The tier policy is the environmental-
+ * learning-gates ladder (SPEC-ENVIRONMENTAL-LEARNING-GATES, folded into B10):
+ *
+ * - `advisory`  — evaluate and record the decision; log only. Shared
+ *                 interpretation: the agent sees the deficit, nothing blocks.
+ * - `shadow`    — the validator tier AND the gate's probation state: evaluate,
+ *                 warn, and record `wouldHaveBlocked` WITHOUT blocking. This
+ *                 keeps the evidence stream alive (gates are information-
+ *                 destroying — a hard block stops observing what would have
+ *                 happened), so threshold calibration stays measurable.
+ * - `enforce`   — the live gate: graduation below threshold is rejected with
+ *                 an error naming each missing piece of evidence.
+ *
+ * DEFAULT IS `shadow`: per the ELG spec, promotion to a live gate must be a
+ * deliberate act backed by shadow-window data, never the ambient default.
+ * Switch via the handler option or the THOUGHTBOX_GRADUATION_GATE env var.
+ */
+
+import type { FitnessAggregate, RunbookStorage } from "./types.js";
+
+export const GRADUATION_GATE_MODES = ["advisory", "shadow", "enforce"] as const;
+export type GraduationGateMode = (typeof GRADUATION_GATE_MODES)[number];
+
+/** Config switch: set to "advisory" | "shadow" | "enforce". Default "shadow". */
+export const GRADUATION_GATE_ENV_VAR = "THOUGHTBOX_GRADUATION_GATE";
+
+/**
+ * Declared fitness thresholds (spec §7: "N instances, pass-rate ≥ p, across
+ * ≥ k distinct agents"). Rates compare on the latest template version.
+ */
+export interface GraduationThresholds {
+  /** Distinct instances that produced machine-checked ledger rows. */
+  minInstances: number;
+  /** Pass rate over rows that reached a verdict (pass/fail). */
+  minPassRate: number;
+  /** Distinct executing agents contributing ledger rows. */
+  minDistinctAgents: number;
+}
+
+/**
+ * v0 defaults for the single-operator deployment: three evidenced instances
+ * at ≥90% machine-checked pass rate. minDistinctAgents stays 1 because
+ * cross-agent diversity is not yet obtainable in most workspaces; raise it
+ * per-deployment once multi-agent instances are routine.
+ */
+export const DEFAULT_GRADUATION_THRESHOLDS: GraduationThresholds = {
+  minInstances: 3,
+  minPassRate: 0.9,
+  minDistinctAgents: 1,
+};
+
+/**
+ * The recorded outcome of one gate evaluation. Always returned to the caller
+ * (and logged) so shadow mode leaves an auditable would-have-blocked trail
+ * with zero behavior change to graduation itself.
+ */
+export interface GraduationGateDecision {
+  mode: GraduationGateMode;
+  /** The graduating notebook id — templateId in the runbook identity scheme. */
+  templateId: string;
+  /** Latest template version evaluated; null when no version was ever persisted. */
+  templateVersion: number | null;
+  pass: boolean;
+  /** True iff mode is "enforce": a failing decision blocks graduation. */
+  enforced: boolean;
+  /** True iff the gate failed but graduation proceeded (advisory/shadow tiers). */
+  wouldHaveBlocked: boolean;
+  thresholds: GraduationThresholds;
+  /** Ledger aggregate the decision was made on; null when no evidence exists. */
+  aggregate: FitnessAggregate | null;
+  /** Human-readable deficits, one per unmet threshold. Empty iff pass. */
+  deficits: string[];
+  evaluatedAt: string;
+}
+
+/**
+ * Resolve the active gate mode: explicit config beats the env var beats the
+ * shadow default. An unrecognized value throws loudly — a silently ignored
+ * enforcement switch is the worst failure mode a gate can have.
+ */
+export function resolveGraduationGateMode(
+  explicit?: GraduationGateMode,
+  env: Record<string, string | undefined> = process.env,
+): GraduationGateMode {
+  if (explicit !== undefined) return explicit;
+  const fromEnv = env[GRADUATION_GATE_ENV_VAR];
+  if (fromEnv === undefined || fromEnv === "") return "shadow";
+  if ((GRADUATION_GATE_MODES as readonly string[]).includes(fromEnv)) {
+    return fromEnv as GraduationGateMode;
+  }
+  throw new Error(
+    `${GRADUATION_GATE_ENV_VAR}="${fromEnv}" is not a graduation gate mode; ` +
+      `expected one of: ${GRADUATION_GATE_MODES.join(", ")}`,
+  );
+}
+
+/**
+ * Pure threshold evaluation over a fitness aggregate. `aggregate` null means
+ * the notebook has no runbook template versions at all (never persisted, so
+ * never run); every deficit message names the missing evidence explicitly —
+ * the enforce-mode rejection surfaces these verbatim.
+ */
+export function evaluateGraduationFitness(
+  templateId: string,
+  aggregate: FitnessAggregate | null,
+  thresholds: GraduationThresholds,
+): { pass: boolean; deficits: string[] } {
+  const deficits: string[] = [];
+
+  if (aggregate === null) {
+    if (
+      thresholds.minInstances > 0
+      || thresholds.minPassRate > 0
+      || thresholds.minDistinctAgents > 0
+    ) {
+      deficits.push(
+        `no fitness evidence: notebook "${templateId}" has no runbook template versions ` +
+          `(it was never run as a runbook, so the fitness ledger is empty; ` +
+          `need ≥${thresholds.minInstances} evidenced instances at pass rate ≥${thresholds.minPassRate})`,
+      );
+    }
+    return { pass: deficits.length === 0, deficits };
+  }
+
+  if (aggregate.instances < thresholds.minInstances) {
+    deficits.push(
+      `evidenced instances ${aggregate.instances} below threshold ${thresholds.minInstances}`,
+    );
+  }
+  if (thresholds.minPassRate > 0) {
+    if (aggregate.passRate === null) {
+      deficits.push(
+        `no machine-checked pass rate (0 evaluated expectations in the ledger; ` +
+          `need pass rate ≥${thresholds.minPassRate})`,
+      );
+    } else if (aggregate.passRate < thresholds.minPassRate) {
+      deficits.push(
+        `pass rate ${formatRate(aggregate.passRate)} below threshold ${thresholds.minPassRate} ` +
+          `(${aggregate.passed}/${aggregate.evaluated} machine-checked expectations passed)`,
+      );
+    }
+  }
+  if (aggregate.distinctAgents < thresholds.minDistinctAgents) {
+    deficits.push(
+      `distinct agents ${aggregate.distinctAgents} below threshold ${thresholds.minDistinctAgents}`,
+    );
+  }
+
+  return { pass: deficits.length === 0, deficits };
+}
+
+export interface GraduationGateInput {
+  /** The graduating notebook id (= runbook templateId). */
+  templateId: string;
+  /**
+   * Fitness ledger access. Undefined means the graduation surface has no
+   * runbook storage wired — treated as absent evidence, not as a pass.
+   */
+  storage: Pick<RunbookStorage, "getLatestTemplate" | "getFitnessAggregate"> | undefined;
+  mode: GraduationGateMode;
+  thresholds?: Partial<GraduationThresholds> | undefined;
+}
+
+/**
+ * Full gate evaluation over the ledger: latest template version → aggregate
+ * → threshold policy → recorded decision. Never throws on missing evidence;
+ * the CALLER enforces (or shadows) based on `decision.pass` and `mode` so
+ * the decision object exists in every tier.
+ */
+export async function evaluateGraduationGate(
+  input: GraduationGateInput,
+): Promise<GraduationGateDecision> {
+  const thresholds: GraduationThresholds = {
+    ...DEFAULT_GRADUATION_THRESHOLDS,
+    ...input.thresholds,
+  };
+
+  let templateVersion: number | null = null;
+  let aggregate: FitnessAggregate | null = null;
+  const deficits: string[] = [];
+
+  if (input.storage === undefined) {
+    deficits.push(
+      "fitness ledger unavailable: no runbook storage is wired to the graduation surface, " +
+        "so no evidence can be read",
+    );
+  } else {
+    const latest = await input.storage.getLatestTemplate(input.templateId);
+    if (latest !== null) {
+      templateVersion = latest.version;
+      aggregate = await input.storage.getFitnessAggregate(input.templateId, latest.version);
+    }
+    const evaluation = evaluateGraduationFitness(input.templateId, aggregate, thresholds);
+    deficits.push(...evaluation.deficits);
+  }
+
+  const pass = deficits.length === 0;
+  const enforced = input.mode === "enforce";
+  return {
+    mode: input.mode,
+    templateId: input.templateId,
+    templateVersion,
+    pass,
+    enforced,
+    wouldHaveBlocked: !pass && !enforced,
+    thresholds,
+    aggregate,
+    deficits,
+    evaluatedAt: new Date().toISOString(),
+  };
+}
+
+function formatRate(rate: number): string {
+  return (Math.round(rate * 1000) / 1000).toString();
+}

--- a/src/peer-notebook/__tests__/graduation-gate.test.ts
+++ b/src/peer-notebook/__tests__/graduation-gate.test.ts
@@ -1,0 +1,234 @@
+/**
+ * B10 evidence-gated graduation — handler integration
+ * (SPEC-AGX-SUBSTRATE claim c8, ELG tier ladder folded into B10).
+ *
+ * Covers the done-criteria directly:
+ * - shadow default records would-have-blocked with ZERO behavior change
+ * - enforce rejects a never-run notebook naming the missing evidence
+ * - thresholds satisfied ⇒ graduation proceeds under enforce
+ * - the THOUGHTBOX_GRADUATION_GATE env switch flips enforcement
+ */
+
+import * as fs from "fs/promises";
+import * as os from "os";
+import * as path from "path";
+import { afterAll, describe, expect, it } from "vitest";
+import { NotebookHandler } from "../../notebook/index.js";
+import {
+  GRADUATION_GATE_ENV_VAR,
+} from "../../notebook/runbook/graduation-gate.js";
+import { hashTemplateCells, type RunbookTemplateCell } from "../../notebook/runbook/types.js";
+import {
+  InMemoryPeerNotebookRepository,
+  PeerNotebookHandler,
+  type PeerGraduationGateOptions,
+} from "../index.js";
+import { graduationPeerManifest } from "./fixtures.js";
+
+const WORKSPACE_ID = "workspace_graduation_gate";
+
+const tempDirs: string[] = [];
+
+afterAll(async () => {
+  for (const dir of tempDirs) {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+describe("evidence-gated graduation (B10)", () => {
+  it("shadow default: a never-run notebook still graduates, with the would-have-blocked recorded", async () => {
+    const { handler, notebookHandler } = await setup();
+    const notebookId = await notebookWithManifestCell(notebookHandler, "shadow-peer");
+
+    const result = await handler.graduateNotebook({ notebookId });
+
+    // Zero behavior change: the draft lands exactly as before the gate.
+    expect(result.manifest.status).toBe("draft");
+    expect(result.manifest.version).toBe(1);
+    expect(result.supersededManifestIds).toEqual([]);
+
+    // The decision is recorded: shadow tier, failing, non-blocking.
+    expect(result.gateDecision).toMatchObject({
+      mode: "shadow",
+      pass: false,
+      enforced: false,
+      wouldHaveBlocked: true,
+      templateId: notebookId,
+      templateVersion: null,
+    });
+    expect(result.gateDecision.deficits.join(" ")).toContain("no fitness evidence");
+  });
+
+  it("enforce: a never-run notebook is rejected with an explanation naming the missing evidence", async () => {
+    const { handler, notebookHandler } = await setup({ mode: "enforce" });
+    const notebookId = await notebookWithManifestCell(notebookHandler, "enforced-peer");
+
+    await expect(handler.graduateNotebook({ notebookId })).rejects.toMatchObject({
+      code: "graduation_below_threshold",
+      message: expect.stringContaining("no fitness evidence"),
+    });
+    await expect(handler.graduateNotebook({ notebookId })).rejects.toMatchObject({
+      message: expect.stringContaining("never run as a runbook"),
+    });
+  });
+
+  it("enforce: graduation proceeds when the fitness ledger satisfies the thresholds", async () => {
+    const { handler, notebookHandler } = await setup({
+      mode: "enforce",
+      thresholds: { minInstances: 2, minPassRate: 0.9, minDistinctAgents: 1 },
+    });
+    const notebookId = await notebookWithManifestCell(notebookHandler, "evidenced-peer");
+    await seedFitness(notebookHandler, notebookId, { instances: 2, result: "pass" });
+
+    const result = await handler.graduateNotebook({ notebookId });
+
+    expect(result.manifest.status).toBe("draft");
+    expect(result.gateDecision).toMatchObject({
+      mode: "enforce",
+      pass: true,
+      enforced: true,
+      wouldHaveBlocked: false,
+      templateVersion: 1,
+    });
+    expect(result.gateDecision.aggregate).toMatchObject({ instances: 2, passRate: 1 });
+  });
+
+  it("enforce: rejection names the failing pass rate when evidence exists but is bad", async () => {
+    const { handler, notebookHandler } = await setup({
+      mode: "enforce",
+      thresholds: { minInstances: 2, minPassRate: 0.9, minDistinctAgents: 1 },
+    });
+    const notebookId = await notebookWithManifestCell(notebookHandler, "failing-peer");
+    await seedFitness(notebookHandler, notebookId, { instances: 2, result: "fail" });
+
+    await expect(handler.graduateNotebook({ notebookId })).rejects.toMatchObject({
+      code: "graduation_below_threshold",
+      message: expect.stringContaining("pass rate 0 below threshold 0.9"),
+    });
+  });
+
+  it("advisory: below-threshold graduation proceeds and only the decision records it", async () => {
+    const { handler, notebookHandler } = await setup({ mode: "advisory" });
+    const notebookId = await notebookWithManifestCell(notebookHandler, "advisory-peer");
+
+    const result = await handler.graduateNotebook({ notebookId });
+    expect(result.manifest.status).toBe("draft");
+    expect(result.gateDecision.mode).toBe("advisory");
+    expect(result.gateDecision.pass).toBe(false);
+  });
+
+  it("THOUGHTBOX_GRADUATION_GATE=enforce flips enforcement without handler options", async () => {
+    const previous = process.env[GRADUATION_GATE_ENV_VAR];
+    process.env[GRADUATION_GATE_ENV_VAR] = "enforce";
+    try {
+      const { handler, notebookHandler } = await setup();
+      const notebookId = await notebookWithManifestCell(notebookHandler, "env-enforced-peer");
+
+      await expect(handler.graduateNotebook({ notebookId })).rejects.toMatchObject({
+        code: "graduation_below_threshold",
+      });
+    } finally {
+      if (previous === undefined) delete process.env[GRADUATION_GATE_ENV_VAR];
+      else process.env[GRADUATION_GATE_ENV_VAR] = previous;
+    }
+  });
+
+  it("enforce: a notebook source without runbook storage is missing evidence, not exempt", async () => {
+    const { notebookHandler } = await setup();
+    const notebookId = await notebookWithManifestCell(notebookHandler, "storageless-peer");
+    const handler = new PeerNotebookHandler({
+      repository: new InMemoryPeerNotebookRepository(),
+      workspaceId: WORKSPACE_ID,
+      // Narrow source: getNotebook only — no getRunbookStorage.
+      notebookSource: {
+        getNotebook: id => notebookHandler.getNotebook(id),
+      },
+      graduationGate: { mode: "enforce" },
+    });
+
+    await expect(handler.graduateNotebook({ notebookId })).rejects.toMatchObject({
+      code: "graduation_below_threshold",
+      message: expect.stringContaining("fitness ledger unavailable"),
+    });
+  });
+});
+
+async function setup(graduationGate?: PeerGraduationGateOptions) {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "tb-graduation-gate-"));
+  tempDirs.push(tempDir);
+  const notebookHandler = new NotebookHandler(tempDir);
+  const repository = new InMemoryPeerNotebookRepository();
+  const handler = new PeerNotebookHandler({
+    repository,
+    workspaceId: WORKSPACE_ID,
+    notebookSource: notebookHandler,
+    ...(graduationGate !== undefined ? { graduationGate } : {}),
+  });
+  return { handler, notebookHandler, repository };
+}
+
+async function notebookWithManifestCell(
+  notebookHandler: NotebookHandler,
+  peerId: string,
+): Promise<string> {
+  const created = await notebookHandler.handleCreateNotebook({
+    title: "Gate candidate",
+    language: "javascript",
+  });
+  const notebookId = created.notebook.id as string;
+  await notebookHandler.handleAddCell({
+    notebookId,
+    cellType: "code",
+    content: JSON.stringify(graduationPeerManifest(peerId, notebookId)),
+    filename: "peer.manifest.json",
+  });
+  return notebookId;
+}
+
+/**
+ * Seed ledger evidence for the notebook through its own runbook storage —
+ * the same substrate graduation reads (templateId = notebook id).
+ */
+async function seedFitness(
+  notebookHandler: NotebookHandler,
+  notebookId: string,
+  input: { instances: number; result: "pass" | "fail" },
+): Promise<void> {
+  const storage = notebookHandler.getRunbookStorage();
+  const cells: RunbookTemplateCell[] = [
+    { cellId: "cell-1", cellType: "code", filename: "main.mjs", source: "console.log(1);" },
+  ];
+  await storage.saveTemplate({
+    templateId: notebookId,
+    version: 1,
+    cells,
+    cellsHash: hashTemplateCells(cells),
+    createdBy: "local",
+    createdAt: new Date().toISOString(),
+  });
+  for (let i = 0; i < input.instances; i += 1) {
+    const instanceId = `${notebookId}-inst-${i + 1}`;
+    await storage.createInstance({
+      instanceId,
+      templateId: notebookId,
+      templateVersion: 1,
+      createdBy: "local",
+      createdAt: new Date().toISOString(),
+    });
+    await storage.appendFitnessRows([
+      {
+        templateId: notebookId,
+        templateVersion: 1,
+        instanceId,
+        cellId: "cell-1",
+        tier: 1,
+        result: input.result,
+        pass: input.result === "pass",
+        expected: 0,
+        actual: input.result === "pass" ? 0 : 1,
+        agentId: "local",
+        ts: new Date().toISOString(),
+      },
+    ]);
+  }
+}

--- a/src/peer-notebook/handler.ts
+++ b/src/peer-notebook/handler.ts
@@ -1,4 +1,12 @@
 import { randomUUID } from "node:crypto";
+import {
+  evaluateGraduationGate,
+  resolveGraduationGateMode,
+  type GraduationGateDecision,
+  type GraduationGateMode,
+  type GraduationThresholds,
+} from "../notebook/runbook/graduation-gate.js";
+import type { RunbookStorage } from "../notebook/runbook/types.js";
 import { createPeerBroker } from "./broker.js";
 import { LocalProcessRuntimeProvider } from "./local-process-runtime-provider.js";
 import { compilePeerManifestDraft } from "./manifest.js";
@@ -63,6 +71,24 @@ export interface PeerGraduationNotebook {
 /** Read-only notebook lookup used by peer_graduate_notebook. */
 export interface PeerGraduationNotebookSource {
   getNotebook(notebookId: string): PeerGraduationNotebook | undefined;
+  /**
+   * B10: fitness-ledger access for the evidence gate. NotebookHandler
+   * satisfies this structurally, so production wiring (notebookSource = the
+   * notebook handler) reads real ledger evidence with no extra plumbing.
+   * Absent, the gate treats evidence as unavailable — enforce mode rejects,
+   * shadow mode records the would-have-blocked.
+   */
+  getRunbookStorage?(): RunbookStorage;
+}
+
+/**
+ * B10 evidence gate configuration. Mode resolution: this option beats the
+ * THOUGHTBOX_GRADUATION_GATE env var beats the shadow default (see
+ * graduation-gate.ts for the ELG tier semantics).
+ */
+export interface PeerGraduationGateOptions {
+  mode?: GraduationGateMode;
+  thresholds?: Partial<GraduationThresholds>;
 }
 
 export interface PeerNotebookHandlerOptions {
@@ -85,6 +111,12 @@ export interface PeerNotebookHandlerOptions {
    * handlers yield target_unavailable errors at call time, never crashes.
    */
   proxyTargetDeps?: BrokerProxyTargetDeps;
+  /**
+   * B10 evidence-gated graduation policy. Absent, the gate still runs in
+   * shadow mode (or the mode named by THOUGHTBOX_GRADUATION_GATE) with
+   * default thresholds.
+   */
+  graduationGate?: PeerGraduationGateOptions;
 }
 
 export interface PeerArtifactSeedInput {
@@ -233,7 +265,12 @@ export class PeerNotebookHandler {
    */
   async graduateNotebook(
     input: PeerGraduateNotebookInput,
-  ): Promise<{ manifest: PeerManifestRecord; supersededManifestIds: string[] }> {
+  ): Promise<{
+    manifest: PeerManifestRecord;
+    supersededManifestIds: string[];
+    /** B10: the evidence-gate decision this graduation was made under. */
+    gateDecision: GraduationGateDecision;
+  }> {
     const workspaceId = this.resolveWorkspaceId();
     await this.bootstrapWorkspace(workspaceId);
 
@@ -277,7 +314,36 @@ export class PeerNotebookHandler {
       compiled.compiledFrom.notebook = buildNotebookCodeSnapshot(notebook, entryCellFilename);
     }
 
-    return this.persistDraft(workspaceId, compiled, input, { supersedeGraduatedDrafts: true });
+    // B10 evidence gate (claim c8): graduation reads the fitness ledger via
+    // the notebook source's runbook storage. Only enforce mode blocks; the
+    // shadow default records a would-have-blocked decision on the result
+    // (and stderr) with zero change to graduation behavior.
+    const gateDecision = await evaluateGraduationGate({
+      templateId: notebook.id,
+      storage: notebookSource.getRunbookStorage?.(),
+      mode: resolveGraduationGateMode(this.options.graduationGate?.mode),
+      thresholds: this.options.graduationGate?.thresholds,
+    });
+    if (!gateDecision.pass) {
+      if (gateDecision.enforced) {
+        throw new PeerNotebookError(
+          "graduation_below_threshold",
+          `Graduation of notebook ${notebook.id} rejected: fitness evidence below threshold — ` +
+            gateDecision.deficits.join("; "),
+          JSON.parse(JSON.stringify(gateDecision)) as JsonObject,
+        );
+      }
+      console.error(
+        `[graduation-gate] ${gateDecision.mode}: graduation of notebook ${notebook.id} ` +
+          `${gateDecision.mode === "shadow" ? "WOULD HAVE BEEN BLOCKED" : "is below threshold"} — ` +
+          gateDecision.deficits.join("; "),
+      );
+    }
+
+    const persisted = await this.persistDraft(workspaceId, compiled, input, {
+      supersedeGraduatedDrafts: true,
+    });
+    return { ...persisted, gateDecision };
   }
 
   /**

--- a/src/peer-notebook/index.ts
+++ b/src/peer-notebook/index.ts
@@ -29,6 +29,7 @@ export type {
   PeerInvokeToolInput,
   PeerManifestCreateInput,
   PeerGraduateNotebookInput,
+  PeerGraduationGateOptions,
   PeerGraduationNotebook,
   PeerGraduationNotebookCell,
   PeerGraduationNotebookSource,

--- a/src/peer-notebook/types.ts
+++ b/src/peer-notebook/types.ts
@@ -222,6 +222,7 @@ export class PeerNotebookError extends Error {
       | "manifest_not_found"
       | "manifest_not_active"
       | "notebook_not_found"
+      | "graduation_below_threshold"
       | "manifest_duplicate"
       | "invalid_manifest_transition"
       | "tool_not_found"


### PR DESCRIPTION
## Summary

SPEC-AGX-SUBSTRATE B10 (evidence-gated graduation) + B11 (standing-facts migration shim). graduateNotebook now evaluates the fitness ledger through the ELG tier ladder (advisory -> shadow -> enforce) with a shadow-mode default that records would-have-blocked decisions without blocking; THOUGHTBOX_GRADUATION_GATE=enforce (or the graduationGate handler option) rejects below-threshold graduations with an error naming the missing evidence. B11 adds src/claims/standing-facts.ts: keyed, workspace-scoped standing facts (assumption registry / session-handoff standing_facts) round-trip through tb.claims semantics — write as typed claim, read back live, supersede atomically.

## Claims

| ID | Statement | Evidence |
|---|---|---|
| `SPEC-AGX-SUBSTRATE:c8` (__none__) | graduateNotebook reads the fitness ledger and rejects graduation below threshold with an error naming the deficit; tests cover accept and reject paths. | test: `src/peer-notebook/__tests__/graduation-gate.test.ts` |
| `SPEC-AGX-SUBSTRATE:b10-shadow-default` (__none__) | Shadow mode is the default and records would-have-blocked with zero behavior change to graduation. | test: `src/peer-notebook/__tests__/graduation-gate.test.ts` |
| `SPEC-AGX-SUBSTRATE:b11-standing-facts` (__none__) | Standing facts round-trip through tb.claims: write as a typed workspace-scoped claim, read back, supersede atomically (old claim -> superseded pointing at replacement). | test: `src/claims/__tests__/standing-facts.test.ts` |

---
_Generated from [`prs/feat-agx-b10-graduation-b11-shims.json`](../../blob/30582292a6fdc2abf321d738af7e57b99364569e/prs/feat-agx-b10-graduation-b11-shims.json)_