### PR TITLE
feat: agent-user-feedback bundle — thoughtTypes, arg coercion, tb.vars, OTLP cost RPC

### DIFF
--- a/.specs/agent-user-feedback/claude-code-001.md
+++ b/.specs/agent-user-feedback/claude-code-001.md
@@ -94,6 +94,16 @@ The runtime auto-handles `thoughtNumber` (next-in-sequence), `isRevision: true`,
 
 ### A3. Inconsistent SDK calling conventions — UUID-string-coercion bug
 
+> **Status: FIXED (2026-07-09, feat/agent-user-feedback-fixes).** Suggestion 2
+> was implemented via `coerceCallArgs` in `src/code-mode/execute-tool.ts`:
+> positional SDK methods (`tb.session.get/search/resume/export/analyze`,
+> `tb.knowledge.getEntity`) now accept a single named-args object as well,
+> throw a clear two-form usage error when a required field is missing, and
+> reject ambiguous object-plus-positional calls. Regression tests use the
+> exact failing shape from this section
+> (src/code-mode/__tests__/execute-tool.test.ts). A single SDK-wide
+> convention (suggestion 1) was NOT adopted — both forms are now first-class.
+
 **Found during verification.** I called:
 
 ```js

--- a/.specs/agent-user-feedback/claude-code-001.md
+++ b/.specs/agent-user-feedback/claude-code-001.md
@@ -35,6 +35,16 @@ The verification step itself was useful and I'd recommend any future agent doing
 
 ### A1. Widen `thoughtType` enum (or add free-form `subtype`)
 
+> **Status: SHIPPED (2026-07-09, feat/agent-user-feedback-fixes).** The minimal
+> suggestion was implemented: `finding`, `synthesis`, `question`, `conclusion`
+> added to the enum in `src/thought/tool.ts`, `src/thought/operations.ts`,
+> `src/thought-handler.ts`, `src/persistence/types.ts`,
+> `src/events/thought-emitter.ts`, `src/audit/manifest-generator.ts`,
+> `src/code-mode/sdk-types.ts`, and the apps/web session-view mirrors. The
+> `thoughts.thought_type` CHECK constraint is extended by migration
+> `supabase/migrations/20260709120000_add_inquiry_thoughttypes.sql`. The
+> free-form `subtype` variant was NOT implemented.
+
 **Where**: `src/thought/tool.ts` (Zod schema, lines ~75-78 per the `2026-04-28-systemic-flaws-audit.md` reference) and the corresponding handler validators in `src/thought-handler.ts`.
 
 **Current enum**: `reasoning | decision_frame | action_report | belief_snapshot | assumption_update | context_snapshot | progress`.

--- a/apps/web/src/components/session-area/session-trace-explorer.tsx
+++ b/apps/web/src/components/session-area/session-trace-explorer.tsx
@@ -125,6 +125,10 @@ export function SessionTraceExplorer({
       assumption_update: 0,
       context_snapshot: 0,
       progress: 0,
+      finding: 0,
+      synthesis: 0,
+      question: 0,
+      conclusion: 0,
     }
     for (const row of rows) {
       counts[row.displayType]++

--- a/apps/web/src/components/session-area/session-trace-toolbar.tsx
+++ b/apps/web/src/components/session-area/session-trace-toolbar.tsx
@@ -11,6 +11,10 @@ const ALL_TYPES: ThoughtDisplayType[] = [
   'assumption_update',
   'context_snapshot',
   'progress',
+  'finding',
+  'synthesis',
+  'question',
+  'conclusion',
 ]
 
 type ViewMode = 'full' | 'decisions'

--- a/apps/web/src/lib/session/audit-manifest.ts
+++ b/apps/web/src/lib/session/audit-manifest.ts
@@ -26,6 +26,10 @@ export interface AuditManifest {
     context_snapshot: number
     progress: number
     action_receipt: number
+    finding: number
+    synthesis: number
+    question: number
+    conclusion: number
   }
   decisions: {
     total: number
@@ -115,6 +119,10 @@ export function parseAuditManifest(value: unknown): AuditManifest | null {
       context_snapshot: num(thoughtCounts.context_snapshot),
       progress: num(thoughtCounts.progress),
       action_receipt: num(thoughtCounts.action_receipt),
+      finding: num(thoughtCounts.finding),
+      synthesis: num(thoughtCounts.synthesis),
+      question: num(thoughtCounts.question),
+      conclusion: num(thoughtCounts.conclusion),
     },
     decisions: {
       total: num(decisions.total),

--- a/apps/web/src/lib/session/badge-styles.ts
+++ b/apps/web/src/lib/session/badge-styles.ts
@@ -25,6 +25,10 @@ export const THOUGHT_TYPE_BADGE: Record<ThoughtDisplayType, string> = {
   assumption_update: 'bg-amber-500/15 text-amber-300 ring-1 ring-amber-500/20',
   context_snapshot: 'bg-background text-foreground ring-1 ring-ring/20',
   reasoning: 'bg-background text-foreground ring-1 ring-ring',
+  finding: 'bg-emerald-500/15 text-emerald-300 ring-1 ring-emerald-500/20',
+  synthesis: 'bg-teal-500/15 text-teal-300 ring-1 ring-teal-500/20',
+  question: 'bg-cyan-500/15 text-cyan-300 ring-1 ring-cyan-500/20',
+  conclusion: 'bg-indigo-500/15 text-indigo-300 ring-1 ring-indigo-500/20',
 }
 
 export const THOUGHT_TYPE_LABEL: Record<ThoughtDisplayType, string> = {
@@ -35,6 +39,10 @@ export const THOUGHT_TYPE_LABEL: Record<ThoughtDisplayType, string> = {
   assumption_update: 'Assumption',
   context_snapshot: 'Context',
   reasoning: 'Reasoning',
+  finding: 'Finding',
+  synthesis: 'Synthesis',
+  question: 'Question',
+  conclusion: 'Conclusion',
 }
 
 export const REVISION_BADGE =

--- a/apps/web/src/lib/session/compute-session-summary.ts
+++ b/apps/web/src/lib/session/compute-session-summary.ts
@@ -26,6 +26,10 @@ export function computeSessionSummary(
     assumption_update: 0,
     context_snapshot: 0,
     progress: 0,
+    finding: 0,
+    synthesis: 0,
+    question: 0,
+    conclusion: 0,
   }
 
   const branchIds = new Set<string>()

--- a/apps/web/src/lib/session/phase-detection.ts
+++ b/apps/web/src/lib/session/phase-detection.ts
@@ -133,6 +133,10 @@ function generateLabel(
       assumption_update: 'Assumption Phase',
       context_snapshot: 'Context Phase',
       progress: 'Progress Phase',
+      finding: 'Finding Phase',
+      synthesis: 'Synthesis Phase',
+      question: 'Question Phase',
+      conclusion: 'Conclusion Phase',
     }
     return labels[dominant[0]] || 'Phase'
   }

--- a/apps/web/src/lib/session/view-models.ts
+++ b/apps/web/src/lib/session/view-models.ts
@@ -32,7 +32,8 @@ export type RawThoughtRecord = {
   branchFromThought?: number
 
   thoughtType?: 'reasoning' | 'decision_frame' | 'action_report' |
-    'belief_snapshot' | 'assumption_update' | 'context_snapshot' | 'progress'
+    'belief_snapshot' | 'assumption_update' | 'context_snapshot' | 'progress' |
+    'finding' | 'synthesis' | 'question' | 'conclusion'
 
   confidence?: 'high' | 'medium' | 'low'
   options?: { label: string; selected: boolean; reason?: string }[]
@@ -169,6 +170,10 @@ export type ThoughtDisplayType =
   | 'assumption_update'
   | 'context_snapshot'
   | 'progress'
+  | 'finding'
+  | 'synthesis'
+  | 'question'
+  | 'conclusion'
 
 export type ThoughtRowVM = {
   id: string

--- a/src/audit/__tests__/manifest-generator.test.ts
+++ b/src/audit/__tests__/manifest-generator.test.ts
@@ -56,6 +56,23 @@ describe('generateAuditData', () => {
     expect(result.thoughtCounts.action_report).toBe(1);
   });
 
+  it('counts inquiry-session thought types (finding/synthesis/question/conclusion)', () => {
+    const thoughts = [
+      thought({ thoughtNumber: 1, thoughtType: 'question' }),
+      thought({ thoughtNumber: 2, thoughtType: 'finding' }),
+      thought({ thoughtNumber: 3, thoughtType: 'finding' }),
+      thought({ thoughtNumber: 4, thoughtType: 'synthesis' }),
+      thought({ thoughtNumber: 5, thoughtType: 'conclusion' }),
+    ];
+    const result = generateAuditData('sess-2', thoughts);
+    expect(result.thoughtCounts.total).toBe(5);
+    expect(result.thoughtCounts.question).toBe(1);
+    expect(result.thoughtCounts.finding).toBe(2);
+    expect(result.thoughtCounts.synthesis).toBe(1);
+    expect(result.thoughtCounts.conclusion).toBe(1);
+    expect(result.thoughtCounts.reasoning).toBe(0);
+  });
+
   it('aggregates decision confidence levels', () => {
     const thoughts = [
       thought({

--- a/src/audit/manifest-generator.ts
+++ b/src/audit/manifest-generator.ts
@@ -24,6 +24,10 @@ export interface AuditData {
     context_snapshot: number;
     progress: number;
     action_receipt: number;
+    finding: number;
+    synthesis: number;
+    question: number;
+    conclusion: number;
   };
 
   decisions: {
@@ -64,6 +68,10 @@ const THOUGHT_TYPES: ThoughtType[] = [
   'context_snapshot',
   'progress',
   'action_receipt',
+  'finding',
+  'synthesis',
+  'question',
+  'conclusion',
 ];
 
 function countByType(
@@ -86,6 +94,10 @@ function countByType(
     context_snapshot: counts['context_snapshot'],
     progress: counts['progress'],
     action_receipt: counts['action_receipt'],
+    finding: counts['finding'],
+    synthesis: counts['synthesis'],
+    question: counts['question'],
+    conclusion: counts['conclusion'],
   };
 }
 

--- a/src/code-mode/__tests__/execute-tool.test.ts
+++ b/src/code-mode/__tests__/execute-tool.test.ts
@@ -334,6 +334,131 @@ describe("thoughtbox_execute", () => {
   });
 });
 
+describe("thoughtbox_execute named-vs-positional coercion (feedback A3)", () => {
+  // Exact failing shape from .specs/agent-user-feedback/claude-code-001.md §A3:
+  // tb.session.export({ sessionId, format, includeMetadata }) was coerced to
+  // the positional sessionId slot and hit Postgres as "[object Object]".
+  it("tb.session.export accepts the named-object form", async () => {
+    const { tool } = createHarness();
+    const result = await tool.handle({
+      code: `async () => {
+        const t = await tb.thought({
+          thought: "seed session",
+          thoughtType: "reasoning",
+          nextThoughtNeeded: false,
+          sessionTitle: "Coercion Regression",
+        });
+        return await tb.session.export({
+          sessionId: t.sessionId ?? t.closedSessionId,
+          format: "markdown",
+          includeMetadata: true,
+        });
+      }`,
+    });
+    const output = JSON.parse(result.content[0].text);
+    expect(output.error).toBeUndefined();
+    expect(JSON.stringify(output)).not.toContain("[object Object]");
+  });
+
+  it("tb.session.export still accepts the positional form", async () => {
+    const { tool } = createHarness();
+    const result = await tool.handle({
+      code: `async () => {
+        const t = await tb.thought({
+          thought: "seed session",
+          thoughtType: "reasoning",
+          nextThoughtNeeded: false,
+        });
+        return await tb.session.export(t.sessionId ?? t.closedSessionId, "markdown");
+      }`,
+    });
+    const output = JSON.parse(result.content[0].text);
+    expect(output.error).toBeUndefined();
+  });
+
+  it("tb.session.get and tb.session.analyze accept both forms", async () => {
+    const { tool } = createHarness();
+    const result = await tool.handle({
+      code: `async () => {
+        const t = await tb.thought({
+          thought: "seed session",
+          thoughtType: "reasoning",
+          nextThoughtNeeded: false,
+        });
+        const id = t.sessionId ?? t.closedSessionId;
+        const positional = await tb.session.get(id);
+        const named = await tb.session.get({ sessionId: id });
+        const analyzed = await tb.session.analyze({ sessionId: id });
+        const idOf = (r) => r?.session?.id ?? r?.id;
+        return { positionalId: idOf(positional), namedId: idOf(named), analyzed };
+      }`,
+    });
+    const output = JSON.parse(result.content[0].text);
+    expect(output.error).toBeUndefined();
+    expect(output.result.namedId).toBeDefined();
+    expect(output.result.namedId).toBe(output.result.positionalId);
+    expect(output.result.analyzed).toBeDefined();
+  });
+
+  it("tb.session.search accepts named form with limit", async () => {
+    const { tool } = createHarness();
+    const result = await tool.handle({
+      code: `async () => tb.session.search({ query: "anything", limit: 5 })`,
+    });
+    const output = JSON.parse(result.content[0].text);
+    expect(output.error).toBeUndefined();
+  });
+
+  it("throws a clear error when the named object is missing the required field", async () => {
+    const { tool } = createHarness();
+    const result = await tool.handle({
+      code: `async () => tb.session.export({ format: "markdown" })`,
+    });
+    const output = JSON.parse(result.content[0].text);
+    expect(output.error).toContain("tb.session.export");
+    expect(output.error).toContain("missing required 'sessionId'");
+    expect(output.error).toContain("positional (sessionId, format)");
+    expect(output.error).toContain("named ({ sessionId, format })");
+  });
+
+  it("throws a clear error on ambiguous object-plus-positional calls", async () => {
+    const { tool } = createHarness();
+    const result = await tool.handle({
+      code: `async () => tb.session.export({ sessionId: "abc" }, "markdown")`,
+    });
+    const output = JSON.parse(result.content[0].text);
+    expect(output.error).toContain("ambiguous");
+    expect(output.error).toContain("tb.session.export");
+  });
+
+  it("tb.knowledge.getEntity accepts positional, camelCase, and snake_case named forms", async () => {
+    const knowledgeDir = await mkdtemp(join(tmpdir(), "tb-knowledge-coercion-"));
+    tempHubDirs.push(knowledgeDir);
+    const knowledgeStorage = new FileSystemKnowledgeStorage({ basePath: knowledgeDir });
+    await knowledgeStorage.setProject("coercion-test");
+    const { tool } = createHarness({
+      knowledgeTool: new KnowledgeTool(new KnowledgeHandler(knowledgeStorage)),
+    });
+    const result = await tool.handle({
+      code: `async () => {
+        const e = await tb.knowledge.createEntity({
+          name: "coercion-test-entity",
+          type: "Concept",
+          label: "Coercion Test",
+        });
+        const positional = await tb.knowledge.getEntity(e.id);
+        const camel = await tb.knowledge.getEntity({ entityId: e.id });
+        const snake = await tb.knowledge.getEntity({ entity_id: e.id });
+        return { positional, camel, snake };
+      }`,
+    });
+    const output = JSON.parse(result.content[0].text);
+    expect(output.error).toBeUndefined();
+    expect(output.result.camel.id).toBe(output.result.positional.id);
+    expect(output.result.snake.id).toBe(output.result.positional.id);
+  });
+});
+
 describe("thoughtbox_execute tb.hub", () => {
   it("register makes the agentId implicit for subsequent calls", async () => {
     const { tool } = await createHubHarness();

--- a/src/code-mode/__tests__/execute-tool.test.ts
+++ b/src/code-mode/__tests__/execute-tool.test.ts
@@ -459,6 +459,94 @@ describe("thoughtbox_execute named-vs-positional coercion (feedback A3)", () => 
   });
 });
 
+describe("thoughtbox_execute tb.vars (RLM-lite session variables)", () => {
+  it("a value set in one execute call is readable in a later call on the same session", async () => {
+    const { tool } = createHarness();
+
+    const setResult = await tool.handle({
+      code: `async () => tb.vars.set("survey", { models: ["a", "b"], scores: [0.9, 0.4] })`,
+    });
+    const setOutput = JSON.parse(setResult.content[0].text);
+    expect(setOutput.error).toBeUndefined();
+    expect(setOutput.result.name).toBe("survey");
+    expect(setOutput.result.bytes).toBeGreaterThan(0);
+
+    // Separate handle() call = separate vm context; the variable must survive.
+    const getResult = await tool.handle({
+      code: `async () => tb.vars.get("survey")`,
+    });
+    const getOutput = JSON.parse(getResult.content[0].text);
+    expect(getOutput.error).toBeUndefined();
+    expect(getOutput.result).toEqual({ models: ["a", "b"], scores: [0.9, 0.4] });
+  });
+
+  it("variables are isolated between ExecuteTool instances (sessions)", async () => {
+    const { tool: sessionA } = createHarness();
+    const { tool: sessionB } = createHarness();
+
+    await sessionA.handle({ code: `async () => tb.vars.set("secret", 42)` });
+    const result = await sessionB.handle({ code: `async () => tb.vars.get("secret")` });
+    const output = JSON.parse(result.content[0].text);
+    expect(output.result).toBeNull();
+    expect(output.error).toContain("no such variable in this MCP session");
+  });
+
+  it("get of an unset name throws a clear error pointing at tb.vars.list()", async () => {
+    const { tool } = createHarness();
+    const result = await tool.handle({ code: `async () => tb.vars.get("nope")` });
+    const output = JSON.parse(result.content[0].text);
+    expect(output.error).toContain("tb.vars.get('nope')");
+    expect(output.error).toContain("tb.vars.list()");
+  });
+
+  it("rejects non-JSON-serialisable values with a clear error", async () => {
+    const { tool } = createHarness();
+    const result = await tool.handle({
+      code: `async () => tb.vars.set("fn", () => 1)`,
+    });
+    const output = JSON.parse(result.content[0].text);
+    expect(output.error).toContain("tb.vars.set('fn')");
+    expect(output.error).toContain("JSON-serialisable");
+  });
+
+  it("supports named-args form, list, and delete", async () => {
+    const { tool } = createHarness();
+    const result = await tool.handle({
+      code: `async () => {
+        await tb.vars.set({ name: "x", value: [1, 2, 3] });
+        await tb.vars.set("y", "hello");
+        const listed = await tb.vars.list();
+        const deleted = await tb.vars.delete("x");
+        const deletedAgain = await tb.vars.delete("x");
+        const after = await tb.vars.list();
+        return { listed, deleted, deletedAgain, after };
+      }`,
+    });
+    const output = JSON.parse(result.content[0].text);
+    expect(output.error).toBeUndefined();
+    expect(output.result.listed.count).toBe(2);
+    expect(output.result.listed.vars.map((v: { name: string }) => v.name).sort()).toEqual(["x", "y"]);
+    expect(output.result.deleted).toEqual({ deleted: true });
+    expect(output.result.deletedAgain).toEqual({ deleted: false });
+    expect(output.result.after.count).toBe(1);
+  });
+
+  it("stored values are deep copies — later mutation of the source does not leak", async () => {
+    const { tool } = createHarness();
+    const result = await tool.handle({
+      code: `async () => {
+        const obj = { n: 1 };
+        await tb.vars.set("snapshot", obj);
+        obj.n = 999;
+        return await tb.vars.get("snapshot");
+      }`,
+    });
+    const output = JSON.parse(result.content[0].text);
+    expect(output.error).toBeUndefined();
+    expect(output.result).toEqual({ n: 1 });
+  });
+});
+
 describe("thoughtbox_execute tb.hub", () => {
   it("register makes the agentId implicit for subsequent calls", async () => {
     const { tool } = await createHubHarness();

--- a/src/code-mode/__tests__/search-tool.test.ts
+++ b/src/code-mode/__tests__/search-tool.test.ts
@@ -27,6 +27,8 @@ describe("thoughtbox_search", () => {
       "theseus",
       "thought",
       "ulysses",
+      // tb.vars.* — durable named session variables (RLM-lite)
+      "vars",
     ]);
   });
 

--- a/src/code-mode/execute-tool.ts
+++ b/src/code-mode/execute-tool.ts
@@ -124,7 +124,7 @@ export const EXECUTE_TOOL = {
   name: "thoughtbox_execute",
   description: `Run JavaScript using the \`tb\` SDK to chain Thoughtbox operations in a single call.
 
-**One state-mutating operation per call.** Submit only one \`tb.thought()\`, \`tb.ulysses()\`, \`tb.theseus()\`, hub-mutating call (\`tb.hub.register()\`, \`tb.hub.createWorkspace()\`, \`tb.hub.createProblem()\`, \`tb.hub.mergeProposal()\`, etc.), claims-mutating call (\`tb.claims.assert()\`, \`tb.claims.invalidate()\`, \`tb.claims.supersede()\`, etc.), or merge-mutating call (\`tb.merge.request()\`) per \`thoughtbox_execute\` invocation. Each response contains guidance (patterns, session state, protocol state) that should inform your next operation. Batching multiple state-mutating calls bypasses this feedback loop and produces lower-quality reasoning. Read-only operations (\`tb.session.*\`, \`tb.knowledge.*\`, \`tb.observability()\`, \`tb.branch.*\`, \`tb.hub.whoami()\`, \`tb.hub.listWorkspaces()\`, \`tb.hub.readChannel()\`, \`tb.claims.query()\`, \`tb.claims.affected()\`, \`tb.merge.status()\`, \`tb.merge.list()\`, \`tb.merge.claimDiff()\`, etc.) may be freely chained.
+**One state-mutating operation per call.** Submit only one \`tb.thought()\`, \`tb.ulysses()\`, \`tb.theseus()\`, hub-mutating call (\`tb.hub.register()\`, \`tb.hub.createWorkspace()\`, \`tb.hub.createProblem()\`, \`tb.hub.mergeProposal()\`, etc.), claims-mutating call (\`tb.claims.assert()\`, \`tb.claims.invalidate()\`, \`tb.claims.supersede()\`, etc.), or merge-mutating call (\`tb.merge.request()\`) per \`thoughtbox_execute\` invocation. Each response contains guidance (patterns, session state, protocol state) that should inform your next operation. Batching multiple state-mutating calls bypasses this feedback loop and produces lower-quality reasoning. Read-only operations (\`tb.session.*\`, \`tb.knowledge.*\`, \`tb.observability()\`, \`tb.branch.*\`, \`tb.hub.whoami()\`, \`tb.hub.listWorkspaces()\`, \`tb.hub.readChannel()\`, \`tb.claims.query()\`, \`tb.claims.affected()\`, \`tb.merge.status()\`, \`tb.merge.list()\`, \`tb.merge.claimDiff()\`, etc.) and session variables (\`tb.vars.*\` — store intermediate values across execute calls within this MCP session) may be freely chained.
 
 ${TB_SDK_TYPES}
 
@@ -364,7 +364,90 @@ function coerceCallArgs(
   return mapped;
 }
 
-function buildTbObject(deps: ExecuteToolDeps, ctx: TbContext): Record<string, unknown> {
+// --- tb.vars — durable named variables (RLM-lite) ------------------------
+
+const MAX_VARS = 100;
+const MAX_VAR_BYTES = 256_000;
+
+/**
+ * Session-scoped variable store backing tb.vars.* (catalog:
+ * src/code-mode/vars-operations.ts). One store per ExecuteTool instance;
+ * server-factory creates one ExecuteTool per MCP session, so variables
+ * survive across thoughtbox_execute calls within a session and die with it.
+ * No persistence — this is deliberate v1 scope.
+ *
+ * Values are stored as JSON strings and re-parsed on read. This both
+ * enforces JSON-serialisability at set time (with a clear error, not a
+ * silent undefined) and prevents objects created inside one node:vm
+ * context from leaking live references into later executions.
+ */
+export class SessionVarsStore {
+  private vars = new Map<string, string>();
+
+  set(name: string, value: unknown): { name: string; bytes: number } {
+    if (typeof name !== "string" || name.length === 0) {
+      throw new Error("tb.vars.set: 'name' must be a non-empty string.");
+    }
+    let serialized: string | undefined;
+    try {
+      serialized = JSON.stringify(value);
+    } catch (err) {
+      throw new Error(
+        `tb.vars.set('${name}'): value is not JSON-serialisable ` +
+          `(${(err as Error).message}). Only JSON-serialisable values can be stored.`,
+      );
+    }
+    if (serialized === undefined) {
+      throw new Error(
+        `tb.vars.set('${name}'): value serialised to undefined (functions, ` +
+          "symbols, and undefined cannot be stored). Only JSON-serialisable " +
+          "values can be stored.",
+      );
+    }
+    if (serialized.length > MAX_VAR_BYTES) {
+      throw new Error(
+        `tb.vars.set('${name}'): serialised value is ${serialized.length} bytes, ` +
+          `over the ${MAX_VAR_BYTES}-byte per-variable limit.`,
+      );
+    }
+    if (!this.vars.has(name) && this.vars.size >= MAX_VARS) {
+      throw new Error(
+        `tb.vars.set('${name}'): variable limit reached (${MAX_VARS}). ` +
+          "Delete unused variables with tb.vars.delete(name).",
+      );
+    }
+    this.vars.set(name, serialized);
+    return { name, bytes: serialized.length };
+  }
+
+  get(name: string): unknown {
+    const serialized = this.vars.get(name);
+    if (serialized === undefined) {
+      throw new Error(
+        `tb.vars.get('${name}'): no such variable in this MCP session. ` +
+          "Variables are session-scoped and in-memory only (a server or " +
+          "session restart clears them). Use tb.vars.list() to see what exists.",
+      );
+    }
+    return JSON.parse(serialized);
+  }
+
+  list(): { vars: Array<{ name: string; bytes: number }>; count: number } {
+    const vars = Array.from(this.vars.entries()).map(([name, serialized]) => ({
+      name,
+      bytes: serialized.length,
+    }));
+    return { vars, count: vars.length };
+  }
+
+  delete(name: string): { deleted: boolean } {
+    return { deleted: this.vars.delete(name) };
+  }
+}
+
+// --- end tb.vars ----------------------------------------------------------
+
+function buildTbObject(deps: ExecuteToolDeps, ctx: TbContext, varsStore: SessionVarsStore): Record<string, unknown> {
   const { thoughtTool, sessionTool, knowledgeTool, notebookTool,
           theseusTool, ulyssesTool, observabilityHandler, branchHandler,
           hubDispatcher, claimsDispatcher, mergeDispatcher } = deps;
@@ -657,11 +740,39 @@ function buildTbObject(deps: ExecuteToolDeps, ctx: TbContext): Record<string, un
     // --- tb.merge (SPEC-MERGE-CORE) — owned by merge-core ---------------
     merge,
     // --- end tb.merge --------------------------------------------------------
+
+    // --- tb.vars — durable named variables (RLM-lite) --------------------
+    // Session-scoped, in-memory, JSON-only. Catalog:
+    // src/code-mode/vars-operations.ts. All methods accept positional or
+    // named-args form, and none count as the call's one state-mutating
+    // reasoning operation.
+    vars: {
+      set: async (...args: unknown[]) => {
+        const a = coerceCallArgs("tb.vars.set", ["name", "value"], ["name", "value"], args);
+        return varsStore.set(a.name as string, a.value);
+      },
+      get: async (...args: unknown[]) => {
+        const a = coerceCallArgs("tb.vars.get", ["name"], ["name"], args);
+        return varsStore.get(a.name as string);
+      },
+      list: async () => varsStore.list(),
+      delete: async (...args: unknown[]) => {
+        const a = coerceCallArgs("tb.vars.delete", ["name"], ["name"], args);
+        return varsStore.delete(a.name as string);
+      },
+    },
+    // --- end tb.vars ------------------------------------------------------
   };
 }
 
 export class ExecuteTool {
   private deps: ExecuteToolDeps;
+  /**
+   * tb.vars backing store. ExecuteTool is constructed once per MCP session
+   * (server-factory), so this store is exactly session-scoped: it survives
+   * across handle() calls and dies with the session.
+   */
+  private varsStore = new SessionVarsStore();
 
   constructor(deps: ExecuteToolDeps) {
     this.deps = deps;
@@ -684,7 +795,7 @@ export class ExecuteTool {
     };
 
     const tbCtx: TbContext = {};
-    const tb = buildTbObject(this.deps, tbCtx);
+    const tb = buildTbObject(this.deps, tbCtx, this.varsStore);
 
     // Security: pass only bridged objects, NOT host builtins.
     // vm.createContext auto-provides context-local copies of Object,

--- a/src/code-mode/execute-tool.ts
+++ b/src/code-mode/execute-tool.ts
@@ -299,6 +299,71 @@ interface TbContext {
   sessionId?: string;
 }
 
+/**
+ * Named-vs-positional argument coercion for SDK methods with positional
+ * signatures (feedback spec A3). Historically `tb.session.export({ sessionId,
+ * format })` shoved the whole object into the positional `sessionId` slot,
+ * which Postgres then rejected as `invalid input syntax for type uuid:
+ * "[object Object]"` — the worst failure mode, a wrong-looking type error.
+ *
+ * Rules:
+ * - A single plain-object argument is treated as named args. It must contain
+ *   every required parameter (extra keys pass through; downstream Zod strips
+ *   unknowns).
+ * - Otherwise arguments are mapped positionally onto `params`.
+ * - Mixing both forms (object first arg plus more positional args) is
+ *   ambiguous and throws with the two accepted call shapes spelled out.
+ */
+function coerceCallArgs(
+  method: string,
+  params: string[],
+  required: string[],
+  args: unknown[],
+): Record<string, unknown> {
+  const positionalSig = `(${params.join(", ")})`;
+  const namedSig = `({ ${params.join(", ")} })`;
+  const usage = `${method} accepts positional ${positionalSig} or named ${namedSig}`;
+
+  const [first, ...rest] = args;
+  const firstIsObject =
+    typeof first === "object" && first !== null && !Array.isArray(first);
+
+  if (firstIsObject) {
+    if (rest.some((r) => r !== undefined)) {
+      throw new Error(
+        `${method}: ambiguous call — received a named-args object plus extra ` +
+          `positional arguments. ${usage}, not a mix of both.`,
+      );
+    }
+    const named = first as Record<string, unknown>;
+    for (const req of required) {
+      if (named[req] === undefined) {
+        throw new Error(
+          `${method}: named-args object is missing required '${req}'. ${usage}.`,
+        );
+      }
+    }
+    return named;
+  }
+
+  if (Array.isArray(first)) {
+    throw new Error(
+      `${method}: received an array as the first argument. ${usage}.`,
+    );
+  }
+
+  const mapped: Record<string, unknown> = {};
+  params.forEach((param, i) => {
+    if (args[i] !== undefined) mapped[param] = args[i];
+  });
+  for (const req of required) {
+    if (mapped[req] === undefined) {
+      throw new Error(`${method}: missing required '${req}'. ${usage}.`);
+    }
+  }
+  return mapped;
+}
+
 function buildTbObject(deps: ExecuteToolDeps, ctx: TbContext): Record<string, unknown> {
   const { thoughtTool, sessionTool, knowledgeTool, notebookTool,
           theseusTool, ulyssesTool, observabilityHandler, branchHandler,
@@ -393,20 +458,35 @@ function buildTbObject(deps: ExecuteToolDeps, ctx: TbContext): Record<string, un
     session: {
       list: async (args?: { limit?: number; offset?: number; tags?: string[] }) =>
         unwrapToolResult(await sessionTool.handle({ operation: "session_list", ...args })),
-      get: async (sessionId: string) =>
-        unwrapToolResult(await sessionTool.handle({ operation: "session_get", sessionId })),
-      search: async (query: string, limit?: number) =>
-        unwrapToolResult(await sessionTool.handle({ operation: "session_search", query, limit })),
-      resume: async (sessionId: string) =>
-        unwrapToolResult(await sessionTool.handle({ operation: "session_resume", sessionId })),
+      get: async (...args: unknown[]) =>
+        unwrapToolResult(await sessionTool.handle({
+          operation: "session_get",
+          ...coerceCallArgs("tb.session.get", ["sessionId"], ["sessionId"], args),
+        } as SessionToolInput)),
+      search: async (...args: unknown[]) =>
+        unwrapToolResult(await sessionTool.handle({
+          operation: "session_search",
+          ...coerceCallArgs("tb.session.search", ["query", "limit"], ["query"], args),
+        } as SessionToolInput)),
+      resume: async (...args: unknown[]) =>
+        unwrapToolResult(await sessionTool.handle({
+          operation: "session_resume",
+          ...coerceCallArgs("tb.session.resume", ["sessionId"], ["sessionId"], args),
+        } as SessionToolInput)),
       resumeLatest: async (args?: { tags?: string[] }) =>
         unwrapToolResult(await sessionTool.handle({ operation: "session_resume_latest", ...args } as SessionToolInput)),
       queryThoughts: async (args: { sessionId: string; type?: string; start?: number; end?: number; referencesThought?: number; revisionsOf?: number }) =>
         unwrapToolResult(await sessionTool.handle({ operation: "session_query_thoughts", ...args } as SessionToolInput)),
-      export: async (sessionId: string, format?: "markdown" | "cipher" | "json") =>
-        unwrapToolResult(await sessionTool.handle({ operation: "session_export", sessionId, format })),
-      analyze: async (sessionId: string) =>
-        unwrapToolResult(await sessionTool.handle({ operation: "session_analyze", sessionId })),
+      export: async (...args: unknown[]) =>
+        unwrapToolResult(await sessionTool.handle({
+          operation: "session_export",
+          ...coerceCallArgs("tb.session.export", ["sessionId", "format"], ["sessionId"], args),
+        } as SessionToolInput)),
+      analyze: async (...args: unknown[]) =>
+        unwrapToolResult(await sessionTool.handle({
+          operation: "session_analyze",
+          ...coerceCallArgs("tb.session.analyze", ["sessionId"], ["sessionId"], args),
+        } as SessionToolInput)),
     },
 
     knowledge: {
@@ -414,10 +494,21 @@ function buildTbObject(deps: ExecuteToolDeps, ctx: TbContext): Record<string, un
         normalizeEntityResult(unwrapToolResult(await requireKnowledgeTool().handle({
           operation: "knowledge_create_entity", ...args,
         } as KnowledgeToolInput))),
-      getEntity: async (entityId: string) =>
-        normalizeEntityResult(unwrapToolResult(await requireKnowledgeTool().handle({
+      getEntity: async (...args: unknown[]) => {
+        // Accept positional (entityId) plus named { entityId } or the
+        // operation's snake_case { entity_id }.
+        const coerced = coerceCallArgs("tb.knowledge.getEntity", ["entityId"], [], args);
+        const entityId = coerced.entityId ?? coerced.entity_id;
+        if (entityId === undefined) {
+          throw new Error(
+            "tb.knowledge.getEntity: missing required 'entityId'. Accepts " +
+              "positional (entityId) or named ({ entityId }) / ({ entity_id }).",
+          );
+        }
+        return normalizeEntityResult(unwrapToolResult(await requireKnowledgeTool().handle({
           operation: "knowledge_get_entity", entity_id: entityId,
-        } as KnowledgeToolInput))),
+        } as KnowledgeToolInput)));
+      },
       listEntities: async (args?: Record<string, unknown>) =>
         unwrapToolResult(await requireKnowledgeTool().handle({
           operation: "knowledge_list_entities", ...args,

--- a/src/code-mode/sdk-types.ts
+++ b/src/code-mode/sdk-types.ts
@@ -26,7 +26,7 @@ interface TB {
   /** Submit a structured thought. Source: src/thought/tool.ts */
   thought(input: {
     thought: string;
-    thoughtType: "reasoning" | "decision_frame" | "action_report" | "belief_snapshot" | "assumption_update" | "context_snapshot" | "progress";
+    thoughtType: "reasoning" | "decision_frame" | "action_report" | "belief_snapshot" | "assumption_update" | "context_snapshot" | "progress" | "finding" | "synthesis" | "question" | "conclusion";
     nextThoughtNeeded: boolean;
     thoughtNumber?: number;
     totalThoughts?: number;

--- a/src/code-mode/sdk-types.ts
+++ b/src/code-mode/sdk-types.ts
@@ -50,24 +50,34 @@ interface TB {
     agentName?: string;
   }): Promise<unknown>;
 
-  /** Session management. Source: src/sessions/tool.ts */
+  /**
+   * Session management. Source: src/sessions/tool.ts
+   * Positional methods (get, search, resume, export, analyze) equally accept
+   * a single named-args object, e.g. export({ sessionId, format }).
+   */
   session: {
     list(args?: { limit?: number; offset?: number; tags?: string[] }): Promise<unknown>;
     get(sessionId: string): Promise<unknown>;
+    get(args: { sessionId: string }): Promise<unknown>;
     search(query: string, limit?: number): Promise<unknown>;
+    search(args: { query: string; limit?: number }): Promise<unknown>;
     resume(sessionId: string): Promise<unknown>;
+    resume(args: { sessionId: string }): Promise<unknown>;
     /** Resume the most recently updated session in this workspace (no ID needed). */
     resumeLatest(args?: { tags?: string[] }): Promise<unknown>;
     /** Structured thought-graph queries: exactly one of type | start+end | referencesThought | revisionsOf. */
     queryThoughts(args: { sessionId: string; type?: string; start?: number; end?: number; referencesThought?: number; revisionsOf?: number }): Promise<unknown>;
     export(sessionId: string, format?: "markdown" | "cipher" | "json"): Promise<unknown>;
+    export(args: { sessionId: string; format?: "markdown" | "cipher" | "json" }): Promise<unknown>;
     analyze(sessionId: string): Promise<unknown>;
+    analyze(args: { sessionId: string }): Promise<unknown>;
   };
 
   /** Knowledge graph. Source: src/knowledge/tool.ts */
   knowledge: {
     createEntity(args: { name: string; type: "Insight" | "Concept" | "Workflow" | "Decision" | "Agent"; label: string; properties?: Record<string, unknown>; created_by?: string; visibility?: "public" | "agent-private" | "user-private" | "team-private" }): Promise<unknown>;
     getEntity(entityId: string): Promise<unknown>;
+    getEntity(args: { entityId: string } | { entity_id: string }): Promise<unknown>;
     listEntities(args?: { types?: string[]; name_pattern?: string; created_after?: string; created_before?: string; limit?: number; offset?: number }): Promise<unknown>;
     addObservation(args: { entity_id: string; content: string; source_session?: string; added_by?: string }): Promise<unknown>;
     createRelation(args: { from_id: string; to_id: string; relation_type: "RELATES_TO" | "BUILDS_ON" | "CONTRADICTS" | "EXTRACTED_FROM" | "APPLIED_IN" | "LEARNED_BY" | "DEPENDS_ON" | "SUPERSEDES" | "MERGED_FROM"; properties?: Record<string, unknown> }): Promise<unknown>;

--- a/src/code-mode/sdk-types.ts
+++ b/src/code-mode/sdk-types.ts
@@ -273,6 +273,23 @@ interface TB {
     addAwaitCell(args: { notebookId: string; claimId: string; until: ClaimStatus | ClaimStatus[]; position?: number }): Promise<unknown>;
   };
 
+  /**
+   * Durable named variables (RLM-lite): store a JSON-serialisable value in
+   * one thoughtbox_execute call and read it back in a later call within the
+   * SAME MCP session, without threading it through your context window.
+   * In-memory only — variables are lost when the session ends; nothing is
+   * persisted. get() throws a clear error for unset names. Freely chainable
+   * (does not count as the call's one state-mutating operation). Methods
+   * also accept named-args form, e.g. set({ name, value }).
+   * Source: src/code-mode/vars-operations.ts
+   */
+  vars: {
+    set(name: string, value: unknown): Promise<{ name: string; bytes: number }>;
+    get(name: string): Promise<unknown>;
+    list(): Promise<{ vars: Array<{ name: string; bytes: number }>; count: number }>;
+    delete(name: string): Promise<{ deleted: boolean }>;
+  };
+
   // --- tb.merge (SPEC-MERGE-CORE) — owned by merge-core -----------------
   /**
    * Merge evidence: collapse competing branches to a finalized decision

--- a/src/code-mode/search-index.ts
+++ b/src/code-mode/search-index.ts
@@ -26,6 +26,8 @@ import { MERGE_OPERATIONS } from "../merge/operations.js";
 // --- end tb.merge ---
 // tb.runbook.* (SPEC-AGX-SUBSTRATE B6+B8) — owned by flagship-b6b8
 import { RUNBOOK_OPERATIONS } from "../notebook/runbook/operations.js";
+// tb.vars.* — durable named session variables (RLM-lite)
+import { VARS_OPERATIONS } from "./vars-operations.js";
 import { PEER_NOTEBOOK_TOOL } from "../peer-notebook/tool.js";
 import {
   STATIC_RESOURCES,
@@ -263,6 +265,8 @@ export function buildSearchCatalog(): SearchCatalog {
       // --- end tb.merge ---
       // tb.runbook.* (SPEC-AGX-SUBSTRATE B6+B8) — owned by flagship-b6b8
       runbook: indexOperations(RUNBOOK_OPERATIONS),
+      // tb.vars.* — durable named session variables (RLM-lite)
+      vars: indexOperations(VARS_OPERATIONS),
     },
 
     prompts: [

--- a/src/code-mode/search-tool.ts
+++ b/src/code-mode/search-tool.ts
@@ -45,7 +45,7 @@ interface SearchCatalog {
   resourceTemplates: Array<{ name: string; uriTemplate: string; description: string; mimeType: string }>;
 }
 
-Modules in catalog.operations: session, thought, knowledge, notebook, theseus, ulysses, observability, branch, hub, claims, runbook, merge
+Modules in catalog.operations: session, thought, knowledge, notebook, theseus, ulysses, observability, branch, hub, claims, runbook, merge, vars
 Public MCP tools in catalog.publicTools: thoughtbox_search, thoughtbox_execute, thoughtbox_peer_notebook
 
 Examples:

--- a/src/code-mode/vars-operations.ts
+++ b/src/code-mode/vars-operations.ts
@@ -1,0 +1,92 @@
+/**
+ * Operations catalog for tb.vars — durable named variables (RLM-lite).
+ *
+ * Session-scoped variable store for the Code Mode execute tool: one
+ * thoughtbox_execute call can store a named JSON-serialisable value and a
+ * later call in the SAME MCP session can read it back, without threading
+ * data through the model's context window. In-memory, per MCP session,
+ * no persistence — variables vanish when the session ends.
+ *
+ * Runtime lives in src/code-mode/execute-tool.ts (state on the
+ * per-session ExecuteTool instance).
+ */
+
+import type { OperationDefinition } from "../sessions/operations.js";
+
+export const VARS_OPERATIONS: OperationDefinition[] = [
+  {
+    name: "set",
+    title: "Set Variable",
+    description:
+      "Store a named JSON-serialisable value that survives across thoughtbox_execute calls within the same MCP session (in-memory only; not persisted; lost when the session ends). Values are deep-copied via JSON round-trip, so non-serialisable values (functions, undefined, circular structures) are rejected with a clear error. Overwrites any existing value under the same name. Freely chainable — vars calls do not count against the one-state-mutating-operation-per-call rule.",
+    category: "vars",
+    inputSchema: {
+      type: "object",
+      properties: {
+        name: { type: "string", description: "Variable name" },
+        value: {
+          description: "Any JSON-serialisable value to store",
+        },
+      },
+      required: ["name", "value"],
+    },
+    example: {
+      code: "await tb.vars.set('candidateSessions', sessions.map(s => s.id))",
+    },
+  },
+  {
+    name: "get",
+    title: "Get Variable",
+    description:
+      "Read back a value stored earlier in this MCP session via tb.vars.set. Throws a clear error naming the variable if it was never set (or the session restarted) — use tb.vars.list() to see what exists.",
+    category: "vars",
+    inputSchema: {
+      type: "object",
+      properties: {
+        name: { type: "string", description: "Variable name" },
+      },
+      required: ["name"],
+    },
+    example: {
+      code: "const ids = await tb.vars.get('candidateSessions')",
+    },
+  },
+  {
+    name: "list",
+    title: "List Variables",
+    description:
+      "List the names (and serialised sizes in bytes) of all variables stored in this MCP session.",
+    category: "vars",
+    inputSchema: {
+      type: "object",
+      properties: {},
+    },
+    example: {
+      code: "await tb.vars.list()",
+    },
+  },
+  {
+    name: "delete",
+    title: "Delete Variable",
+    description:
+      "Remove a stored variable. Returns { deleted: boolean } (false if the name was not set).",
+    category: "vars",
+    inputSchema: {
+      type: "object",
+      properties: {
+        name: { type: "string", description: "Variable name" },
+      },
+      required: ["name"],
+    },
+    example: {
+      code: "await tb.vars.delete('candidateSessions')",
+    },
+  },
+];
+
+/** Get vars operation definition by name. */
+export function getVarsOperation(
+  name: string,
+): OperationDefinition | undefined {
+  return VARS_OPERATIONS.find((op) => op.name === name);
+}

--- a/src/events/thought-emitter.ts
+++ b/src/events/thought-emitter.ts
@@ -30,7 +30,7 @@ export interface Thought {
   revisesThought?: number;
   branchId?: string;
   branchFromThought?: number;
-  thoughtType?: 'reasoning' | 'decision_frame' | 'action_report' | 'belief_snapshot' | 'assumption_update' | 'context_snapshot' | 'progress' | 'action_receipt';
+  thoughtType?: 'reasoning' | 'decision_frame' | 'action_report' | 'belief_snapshot' | 'assumption_update' | 'context_snapshot' | 'progress' | 'action_receipt' | 'finding' | 'synthesis' | 'question' | 'conclusion';
   confidence?: 'high' | 'medium' | 'low';
   options?: Array<{ label: string; selected: boolean; reason?: string }>;
   actionResult?: { success: boolean; reversible: 'yes' | 'no' | 'partial'; tool: string; target: string; sideEffects?: string[] };

--- a/src/observability/__tests__/gateway-handler.test.ts
+++ b/src/observability/__tests__/gateway-handler.test.ts
@@ -32,7 +32,7 @@ describe('ObservabilityGatewayHandler', () => {
       expect(parsePayload(result).error).toBe('OTEL queries require Supabase configuration');
     });
 
-    it('session_cost returns an error result when Supabase is not configured', async () => {
+    it('session_cost returns an explicit documented local-mode error', async () => {
       const handler = new ObservabilityGatewayHandler({ storage: new InMemoryStorage() });
 
       const result = await handler.handle({
@@ -41,7 +41,10 @@ describe('ObservabilityGatewayHandler', () => {
       });
 
       expect(result.isError).toBe(true);
-      expect(parsePayload(result).error).toBe('OTEL queries require Supabase configuration');
+      const error = parsePayload(result).error as string;
+      expect(error).toContain('session_cost is unavailable in local mode');
+      expect(error).toContain('otel_session_cost');
+      expect(error).toContain('SUPABASE_URL');
     });
 
     it('session_timeline returns an error result when sessionId is missing', async () => {

--- a/src/observability/gateway-handler.ts
+++ b/src/observability/gateway-handler.ts
@@ -194,11 +194,23 @@ export class ObservabilityGatewayHandler {
     );
   }
 
+  /**
+   * session_cost is hosted-mode only by design: cost aggregation runs
+   * server-side in Postgres via the otel_session_cost RPC (SUM/COUNT GROUP
+   * BY model), and there is no local OTEL event store to aggregate over.
+   * Local/self-hosted servers get the explicit error below instead of a
+   * silent empty result.
+   */
   private async handleSessionCost(
     args: { sessionId?: string },
   ) {
     if (!this.otelStorage) {
-      throw new Error('OTEL queries require Supabase configuration');
+      throw new Error(
+        'session_cost is unavailable in local mode: cost aggregation runs ' +
+          'server-side via the Supabase otel_session_cost RPC and requires ' +
+          'SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY (hosted mode). There ' +
+          'is no local OTEL event store.',
+      );
     }
     return this.otelStorage.querySessionCost(
       this.workspaceId,

--- a/src/observability/operations.ts
+++ b/src/observability/operations.ts
@@ -106,7 +106,7 @@ export const OBSERVABILITY_OPERATIONS: OperationDefinition[] = [
     name: "session_cost",
     title: "Session Cost",
     description:
-      "Get aggregated API cost data for a Claude Code session, broken down by model. If no sessionId is provided, returns costs across all sessions.",
+      "Get aggregated API cost data for a Claude Code session, broken down by model. If no sessionId is provided, returns costs across all sessions. Aggregation runs server-side in Postgres via the otel_session_cost RPC (bounded memory as otel_events grows). Hosted mode only: in local/self-hosted mode there is no OTEL event store and this operation returns an explicit 'unavailable in local mode' error.",
     category: "otel",
     inputSchema: {
       type: "object",

--- a/src/otel/otel-storage.ts
+++ b/src/otel/otel-storage.ts
@@ -211,31 +211,30 @@ export class OtelEventStorage {
       }
     }
 
-    let query = this.supabase
-      .from('otel_events')
-      .select('event_attrs, metric_value')
-      .eq('workspace_id', workspaceId)
-      .eq('event_type', 'metric')
-      .eq('event_name', 'claude_code.cost.usage');
-
-    if (otelSessionIds) {
-      query = query.in('session_id', otelSessionIds);
-    }
-
-    const { data, error } = await query;
-    if (error) {
-      throw new Error(`Cost query failed: ${error.message}`);
-    }
-
+    // Server-side aggregation via the otel_session_cost RPC (migration
+    // 20260327142217): SUM/COUNT GROUP BY model runs in Postgres, so memory
+    // stays bounded as otel_events grows. This replaces the previous
+    // select-every-cost-event + client-side GROUP BY. The RPC takes a single
+    // otel session id, so a thoughtbox session that spans multiple otel
+    // sessions (multiple runs) issues one call per otel session id and merges
+    // the per-model aggregates — bounded by models x runs, not event count.
     const aggregates = new Map<string, CostEntry>();
-    for (const row of data ?? []) {
-      const attrs = (row.event_attrs ?? {}) as Record<string, unknown>;
-      const model = typeof attrs.model === 'string' ? attrs.model : 'unknown';
-      const metricValue = typeof row.metric_value === 'number' ? row.metric_value : 0;
-      const existing = aggregates.get(model) || { model, total_cost: 0, data_points: 0 };
-      existing.total_cost += metricValue;
-      existing.data_points += 1;
-      aggregates.set(model, existing);
+    const targets: Array<string | null> = otelSessionIds ?? [null];
+    for (const otelSessionId of targets) {
+      const { data, error } = await this.supabase.rpc('otel_session_cost', {
+        p_workspace_id: workspaceId,
+        ...(otelSessionId !== null ? { p_session_id: otelSessionId } : {}),
+      });
+      if (error) {
+        throw new Error(`Cost query failed: ${error.message}`);
+      }
+      for (const row of data ?? []) {
+        const existing = aggregates.get(row.model)
+          || { model: row.model, total_cost: 0, data_points: 0 };
+        existing.total_cost += row.total_cost;
+        existing.data_points += Number(row.data_points);
+        aggregates.set(row.model, existing);
+      }
     }
 
     const costs = Array.from(aggregates.values());

--- a/src/persistence/__tests__/audit-manifest.test.ts
+++ b/src/persistence/__tests__/audit-manifest.test.ts
@@ -43,6 +43,10 @@ function makeManifest(sessionId: string): AuditManifest {
       context_snapshot: 0,
       progress: 0,
       action_receipt: 0,
+      finding: 0,
+      synthesis: 0,
+      question: 0,
+      conclusion: 0,
     },
     decisions: { total: 1, byConfidence: { high: 1, medium: 0, low: 0 } },
     actions: {

--- a/src/persistence/__tests__/supabase-storage.test.ts
+++ b/src/persistence/__tests__/supabase-storage.test.ts
@@ -390,6 +390,10 @@ describe('SupabaseStorage (ThoughtboxStorage)', () => {
           context_snapshot: 0,
           progress: 0,
           action_receipt: 0,
+          finding: 0,
+          synthesis: 0,
+          question: 0,
+          conclusion: 0,
         },
         decisions: { total: 1, byConfidence: { high: 0, medium: 1, low: 0 } },
         actions: {

--- a/src/persistence/types.ts
+++ b/src/persistence/types.ts
@@ -126,7 +126,7 @@ export interface ThoughtData {
   timestamp: string; // ISO 8601 - always present after persistence
 
   /** Operations mode: structured thought type for programmatic filtering */
-  thoughtType: 'reasoning' | 'decision_frame' | 'action_report' | 'belief_snapshot' | 'assumption_update' | 'context_snapshot' | 'progress' | 'action_receipt';
+  thoughtType: 'reasoning' | 'decision_frame' | 'action_report' | 'belief_snapshot' | 'assumption_update' | 'context_snapshot' | 'progress' | 'action_receipt' | 'finding' | 'synthesis' | 'question' | 'conclusion';
 
   /** Confidence level for decision_frame thoughts */
   confidence?: 'high' | 'medium' | 'low';
@@ -371,6 +371,10 @@ export interface AuditManifest {
     context_snapshot: number;
     progress: number;
     action_receipt: number;
+    finding: number;
+    synthesis: number;
+    question: number;
+    conclusion: number;
   };
   decisions: {
     total: number;

--- a/src/resources/static-registry.ts
+++ b/src/resources/static-registry.ts
@@ -74,7 +74,7 @@ export const STATIC_RESOURCES: StaticResourceDef[] = [
     key: "gateway-operations",
     name: "Gateway Operations Catalog",
     uri: "thoughtbox://gateway/operations",
-    description: "Complete catalog of operations available through the Code Mode gateway, grouped by tb SDK module (thought, session, knowledge, notebook, theseus, ulysses, observability, branch, hub, claims, runbook, merge)",
+    description: "Complete catalog of operations available through the Code Mode gateway, grouped by tb SDK module (thought, session, knowledge, notebook, theseus, ulysses, observability, branch, hub, claims, runbook, merge, vars)",
     mimeType: "application/json",
   },
   {

--- a/src/sessions/thought-query.ts
+++ b/src/sessions/thought-query.ts
@@ -76,7 +76,8 @@ export class ThoughtQuery {
    * Query thoughts by type.
    * Accepts cipher chars (H/E/C/Q/R/P/O/A/X) or full thoughtType names
    * (reasoning, decision_frame, action_report, belief_snapshot,
-   *  assumption_update, context_snapshot, progress).
+   *  assumption_update, context_snapshot, progress, action_receipt,
+   *  finding, synthesis, question, conclusion).
    */
   private async queryByType(sessionId: string, type: string): Promise<ThoughtQueryResult> {
     const isCipherChar = type.length === 1 && /^[HECQRPOAX]$/.test(type);

--- a/src/thought-handler.ts
+++ b/src/thought-handler.ts
@@ -32,7 +32,7 @@ export interface ThoughtData {
   // SIL-101: Verbose response mode - when false (default), return minimal response
   verbose?: boolean;
   // Operations mode: structured thought type for auditability filtering
-  thoughtType?: 'reasoning' | 'decision_frame' | 'action_report' | 'belief_snapshot' | 'assumption_update' | 'context_snapshot' | 'progress' | 'action_receipt';
+  thoughtType?: 'reasoning' | 'decision_frame' | 'action_report' | 'belief_snapshot' | 'assumption_update' | 'context_snapshot' | 'progress' | 'action_receipt' | 'finding' | 'synthesis' | 'question' | 'conclusion';
   // AUDIT-001: Structured metadata fields (discriminated by thoughtType)
   confidence?: 'high' | 'medium' | 'low';
   options?: Array<{ label: string; selected: boolean; reason?: string }>;
@@ -382,7 +382,14 @@ export class ThoughtHandler {
     data: Record<string, unknown>
   ): void {
     switch (thoughtType) {
+      // reasoning and the inquiry-session types (finding, synthesis,
+      // question, conclusion) carry no payload beyond the base `thought`
+      // field, so they need no structured-field validation.
       case 'reasoning':
+      case 'finding':
+      case 'synthesis':
+      case 'question':
+      case 'conclusion':
         break;
       case 'decision_frame':
         this.validateDecisionFrame(data);
@@ -409,7 +416,8 @@ export class ThoughtHandler {
         throw new Error(
           `Unknown thoughtType: '${thoughtType as string}'. ` +
           "Valid types: reasoning, decision_frame, action_report, " +
-          "belief_snapshot, assumption_update, context_snapshot, progress."
+          "belief_snapshot, assumption_update, context_snapshot, progress, " +
+          "action_receipt, finding, synthesis, question, conclusion."
         );
     }
   }

--- a/src/thought/operations.ts
+++ b/src/thought/operations.ts
@@ -12,7 +12,7 @@ export const THOUGHT_OPERATIONS: OperationDefinition[] = [
     name: "thoughtbox_thought",
     title: "Record Thought",
     description:
-      "Submit a structured thought to the active reasoning session. Supports branching, revision, typed metadata (decision frames, action reports, belief snapshots, assumption updates, context snapshots, progress), and multi-agent attribution.",
+      "Submit a structured thought to the active reasoning session. Supports branching, revision, typed metadata (decision frames, action reports, belief snapshots, assumption updates, context snapshots, progress), payload-free inquiry types (finding, synthesis, question, conclusion), and multi-agent attribution.",
     category: "reasoning",
     inputSchema: {
       type: "object",
@@ -45,8 +45,13 @@ export const THOUGHT_OPERATIONS: OperationDefinition[] = [
             "assumption_update",
             "context_snapshot",
             "progress",
+            "finding",
+            "synthesis",
+            "question",
+            "conclusion",
           ],
-          description: "The structured type of this thought",
+          description:
+            "The structured type of this thought. Inquiry-session types (finding, synthesis, question, conclusion) carry no extra payload, like reasoning.",
         },
         isRevision: {
           type: "boolean",

--- a/src/thought/tool.ts
+++ b/src/thought/tool.ts
@@ -72,9 +72,10 @@ export const thoughtToolInputSchema = z.object({
   
   // Type discriminators & Metadata
   thoughtType: z.enum([
-    "reasoning", "decision_frame", "action_report", 
-    "belief_snapshot", "assumption_update", "context_snapshot", "progress"
-  ]).describe("The structured type of this thought"),
+    "reasoning", "decision_frame", "action_report",
+    "belief_snapshot", "assumption_update", "context_snapshot", "progress",
+    "finding", "synthesis", "question", "conclusion"
+  ]).describe("The structured type of this thought. Inquiry-session types (finding, synthesis, question, conclusion) carry no extra payload, like reasoning."),
   
   confidence: z.enum(["high", "medium", "low"]).optional().describe("Confidence level for decision frames"),
   options: z.array(OptionSchema).optional().describe("Options evaluated during decision frames"),

--- a/supabase/migrations/20260709120000_add_inquiry_thoughttypes.sql
+++ b/supabase/migrations/20260709120000_add_inquiry_thoughttypes.sql
@@ -1,0 +1,19 @@
+-- Add the payload-free inquiry-session thought types to the
+-- thoughts.thought_type CHECK constraint (feedback spec
+-- .specs/agent-user-feedback/claude-code-001.md A1): finding, synthesis,
+-- question, conclusion. They validate like 'reasoning' — no structured
+-- metadata columns are involved.
+--
+-- Non-destructive: widens the allowed value set only; existing rows are
+-- untouched. Mirrors the pattern of
+-- 20260323020000_add_action_receipt_thoughttype.sql.
+
+ALTER TABLE thoughts DROP CONSTRAINT IF EXISTS thoughts_thought_type_check;
+ALTER TABLE thoughts ADD CONSTRAINT thoughts_thought_type_check CHECK (
+  thought_type = ANY (ARRAY[
+    'reasoning', 'decision_frame', 'action_report',
+    'belief_snapshot', 'assumption_update', 'context_snapshot',
+    'progress', 'action_receipt',
+    'finding', 'synthesis', 'question', 'conclusion'
+  ]::text[])
+);


### PR DESCRIPTION
## Summary

Ships the verified agent-user-feedback bundle (`.specs/agent-user-feedback/`) plus two folds, as four independent changes + one final migration commit:

### 1. Broaden the `thoughtType` enum (feedback A1)
Adds four payload-free inquiry-session types — `finding`, `synthesis`, `question`, `conclusion` — to every mirror of the union: thought tool Zod schema, thought operations catalog, thought-handler validation, persistence types (`ThoughtData`, `AuditManifest`), thought-emitter, audit manifest generator, tb SDK type hints, and the apps/web session-view mirrors. They validate like `reasoning` (no structured payload). Nothing removed; the #421 critique removal is untouched.

- Audit-manifest byType aggregations extended and covered by a new unit test.
- `thoughts.thought_type` DB CHECK constraint extension is the **separate final commit** (`20260709120000_add_inquiry_thoughttypes.sql`), non-destructive, DDL dry-run verified against local Supabase in a rolled-back transaction. May be held back pending the DB-parity ruling; until applied, hosted inserts of the new types are rejected by the constraint.
- `scripts/check-event-type-parity.ts` guards `protocol_history.event_type` (untouched by this PR — no new event_type literals in `src/protocol/handler.ts`); it needs `SUPABASE_ACCESS_TOKEN` and could not be executed in this environment.

### 2. Named-vs-positional SDK arg coercion (feedback A3 — the "[object Object]" bug)
`tb.session.export({ sessionId, format })` previously passed the whole object into the positional `sessionId` slot → `invalid input syntax for type uuid: "[object Object]"`. New `coerceCallArgs` in `src/code-mode/execute-tool.ts`: positional methods (`tb.session.get/search/resume/export/analyze`, `tb.knowledge.getEntity`) accept both forms; missing required fields and ambiguous object+positional mixes throw errors that spell out both accepted call shapes. Regression tests use the exact failing shape from the feedback spec.

### 3. `tb.vars` — durable named session variables (RLM-lite)
`tb.vars.set(name, value)` / `get` / `list` / `delete`: JSON-serialisable values stored on the per-MCP-session ExecuteTool instance, surviving across `thoughtbox_execute` calls, dying with the session (in-memory v1, no persistence, deliberate). Deep-copy JSON semantics (no cross-vm-context reference leaks), clear errors for non-serialisable values and unset names, caps at 100 vars / 256KB per value. Registered per the post-#421 single-registry structure: vars operations module, search catalog, search-tool module list, gateway-operations description, SDK type hints. Drift guard green.

### 4. OTLP session cost via `otel_session_cost` RPC
`querySessionCost` no longer selects every cost event and aggregates client-side; SUM/COUNT GROUP BY runs in Postgres via the existing RPC (one call per bound otel session id, per-model merge). Local mode now returns an explicit documented error ("session_cost is unavailable in local mode… requires SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY") instead of a generic message; the operations catalog documents both behaviors. Verified against local Supabase via the otel-storage integration tests (ingest → RPC aggregation).

## Spec/Evidence
- `.specs/agent-user-feedback/claude-code-001.md`: A1 marked shipped, A3 marked fixed (same commits as the code).
- `src/index.ts` / `src/server-factory.ts` untouched (owned by the integration agent); no wiring there was needed — tb.vars lives entirely inside ExecuteTool.

## Tests
- `pnpm check:types` ✓, `pnpm check:lint` ✓, `pnpm build:local` ✓ (re-run after rebase onto post-#425/#408 main)
- `npx vitest run`: 954 passed, 2 failed — the 2 known pre-existing environmental failures in `src/__tests__/branch-workers.test.ts` (local Supabase edge runtime 503), untouched
- apps/web: `npx tsc --noEmit` ✓, vitest 81/81 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)