### PR TITLE
fix(claims): close standing-facts write TOCTOU via assert-then-reconcile

### DIFF
--- a/.specs/agx/SPEC-AGX-SUBSTRATE.md
+++ b/.specs/agx/SPEC-AGX-SUBSTRATE.md
@@ -212,6 +212,22 @@ and supersede semantics are vitest-evidenced (`src/claims/__tests__/standing-fac
 Skill/handoff integrations are deliberately NOT built here — the shim is the reader/writer
 those artifacts adopt.
 
+Keyed uniqueness is RECONCILE-BASED, not constraint-based (fix, 2026-07-09): the claim store
+has no uniqueness constraint on the fact key, so two concurrent `write`s of one
+(workspace, key) can both pass the pre-check and both assert (the original TOCTOU). `write`
+is therefore assert-then-reconcile: after asserting, it re-queries live facts for the key and
+keeps the deterministic winner — oldest by (`createdAt`, claim id ascending) — retiring every
+other live claim via `tb.claims.invalidate` (the one handler transition that removes liveness
+without minting a new claim; handler `supersede` always creates a fresh replacement, which
+would itself be a new live duplicate). A writer whose own claim lost gets the same
+"already exists" error as a sequential duplicate write (first-writer-wins; `write` stays
+create-only), and the winner is never touched, so a key with a live fact can never reconcile
+to zero. `read`/`list` (and `supersede`, before flipping) run the same reconcile lazily when
+they observe >1 live fact for a key, so `list` never returns a duplicate key and pre-fix
+duplicates self-heal. Race and heal behavior is vitest-evidenced in the same test file.
+Follow-up if standing facts become load-bearing: a partial unique index on the fact key
+(live statuses only) upgrades uniqueness from reconcile-based to constraint-based.
+
 ## 5. Layer 2: Reactive Runbooks (EVOLVES the notebook subsystem)
 
 The prior Notebook Evidence Engine spec (`.specs/agentic-runbooks.md`, draft, largely

--- a/src/claims/__tests__/standing-facts.test.ts
+++ b/src/claims/__tests__/standing-facts.test.ts
@@ -5,7 +5,8 @@
  * claims handler and InMemoryClaimStorage.
  */
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Claim } from '../types.js';
 import { createClaimsHandler } from '../claims-handler.js';
 import { InMemoryClaimStorage } from '../in-memory-claim-storage.js';
 import {
@@ -21,7 +22,22 @@ const AGENT = 'agent-shim-test';
 function setup() {
   const storage = new InMemoryClaimStorage();
   const handler = createClaimsHandler(storage);
-  return { facts: createStandingFacts(handler), storage };
+  return { facts: createStandingFacts(handler), handler, storage };
+}
+
+const LIVE = new Set(['asserted', 'supported']);
+
+/** All fact claims (any status) for one key, via the handler's own query. */
+async function factClaims(
+  handler: ReturnType<typeof createClaimsHandler>,
+  workspaceId: string,
+  key: string,
+): Promise<Claim[]> {
+  const result = (await handler.handle(null, 'query', {
+    workspaceId,
+    text: `[fact:${key}]`,
+  })) as { claims: Claim[] };
+  return result.claims.filter(claim => claim.statement.startsWith(`[fact:${key}] `));
 }
 
 describe('standing-fact key encoding', () => {
@@ -138,5 +154,156 @@ describe('standing-facts round-trip (B11)', () => {
     await expect(
       facts.write('', { workspaceId: WORKSPACE, key: 'anon', statement: 'x' }),
     ).rejects.toThrow(/requires an agent identity/);
+  });
+});
+
+describe('keyed uniqueness under concurrency (reconcile-based)', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('concurrent duplicate writes: one winner, one already-exists rejection, one live fact', async () => {
+    // The winner tiebreak on equal-millisecond createdAt is the (random)
+    // claim id, so repeat the race to exercise both tiebreak outcomes.
+    for (let round = 0; round < 25; round++) {
+      const { facts, handler } = setup();
+
+      const results = await Promise.allSettled([
+        facts.write('agent-a', { workspaceId: WORKSPACE, key: 'race', statement: 'from a' }),
+        facts.write('agent-b', { workspaceId: WORKSPACE, key: 'race', statement: 'from b' }),
+      ]);
+
+      // Exactly one caller wins; the other gets write's create-only error.
+      const fulfilled = results.filter(
+        (result): result is PromiseFulfilledResult<{ claim: Claim }> =>
+          result.status === 'fulfilled',
+      );
+      const rejected = results.filter(
+        (result): result is PromiseRejectedResult => result.status === 'rejected',
+      );
+      expect(fulfilled).toHaveLength(1);
+      expect(rejected).toHaveLength(1);
+      expect((rejected[0]!.reason as Error).message).toMatch(/already exists.*use supersede/);
+
+      // Both asserts landed (claims are never hard-deleted), exactly one is
+      // still live, and it is the deterministic winner: oldest by
+      // (createdAt, claim id ascending).
+      const all = await factClaims(handler, WORKSPACE, 'race');
+      expect(all).toHaveLength(2);
+      const live = all.filter(claim => LIVE.has(claim.status));
+      expect(live).toHaveLength(1);
+      const expectedWinner = [...all].sort(
+        (a, b) => a.createdAt.localeCompare(b.createdAt) || a.id.localeCompare(b.id),
+      )[0]!;
+      expect(live[0]!.id).toBe(expectedWinner.id);
+      expect(fulfilled[0]!.value.claim.id).toBe(expectedWinner.id);
+
+      // Readers agree: read returns the winner, list has exactly one entry.
+      const read = await facts.read(WORKSPACE, 'race');
+      expect(read!.claim.id).toBe(expectedWinner.id);
+      const listed = await facts.list(WORKSPACE);
+      expect(listed.filter(fact => fact.key === 'race')).toHaveLength(1);
+    }
+  });
+
+  it('read heals duplicate live facts seeded by bypassing the shim (oldest wins)', async () => {
+    const { facts, handler } = setup();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-09T00:00:00.000Z'));
+    const older = (await handler.handle(AGENT, 'assert', {
+      workspaceId: WORKSPACE,
+      type: 'assumption',
+      statement: '[fact:dup-heal] older statement',
+    })) as Claim;
+    vi.setSystemTime(new Date('2026-07-09T00:00:01.000Z'));
+    const newer = (await handler.handle(AGENT, 'assert', {
+      workspaceId: WORKSPACE,
+      type: 'assumption',
+      statement: '[fact:dup-heal] newer statement',
+    })) as Claim;
+    vi.useRealTimers();
+
+    // Both live: the duplicate writes bypassed the shim entirely.
+    const before = await factClaims(handler, WORKSPACE, 'dup-heal');
+    expect(before.filter(claim => LIVE.has(claim.status))).toHaveLength(2);
+
+    // read converges on the oldest claim and retires the loser durably.
+    const read = await facts.read(WORKSPACE, 'dup-heal');
+    expect(read!.claim.id).toBe(older.id);
+    expect(read!.statement).toBe('older statement');
+
+    const after = await factClaims(handler, WORKSPACE, 'dup-heal');
+    const live = after.filter(claim => LIVE.has(claim.status));
+    expect(live).toHaveLength(1);
+    expect(live[0]!.id).toBe(older.id);
+    expect(after.find(claim => claim.id === newer.id)!.status).toBe('invalidated');
+  });
+
+  it('list heals duplicates and never returns two facts with the same key', async () => {
+    const { facts, handler } = setup();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-09T00:00:00.000Z'));
+    const older = (await handler.handle(AGENT, 'assert', {
+      workspaceId: WORKSPACE,
+      type: 'observation',
+      statement: '[fact:dup-list] keep me',
+    })) as Claim;
+    vi.setSystemTime(new Date('2026-07-09T00:00:01.000Z'));
+    await handler.handle(AGENT, 'assert', {
+      workspaceId: WORKSPACE,
+      type: 'observation',
+      statement: '[fact:dup-list] drop me',
+    });
+    vi.useRealTimers();
+    await facts.write(AGENT, { workspaceId: WORKSPACE, key: 'untouched', statement: 'fine' });
+
+    const listed = await facts.list(WORKSPACE);
+    expect(listed.map(fact => [fact.key, fact.statement])).toEqual([
+      ['dup-list', 'keep me'],
+      ['untouched', 'fine'],
+    ]);
+    expect(listed.find(fact => fact.key === 'dup-list')!.claim.id).toBe(older.id);
+
+    // The heal is persistent, not per-call filtering: one live claim remains.
+    const live = (await factClaims(handler, WORKSPACE, 'dup-list')).filter(claim =>
+      LIVE.has(claim.status),
+    );
+    expect(live).toHaveLength(1);
+    expect(live[0]!.id).toBe(older.id);
+  });
+
+  it('supersede heals duplicates first, so the replacement outranks stale losers', async () => {
+    const { facts, handler } = setup();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-09T00:00:00.000Z'));
+    await handler.handle(AGENT, 'assert', {
+      workspaceId: WORKSPACE,
+      type: 'assumption',
+      statement: '[fact:dup-supersede] v1 winner',
+    });
+    vi.setSystemTime(new Date('2026-07-09T00:00:01.000Z'));
+    await handler.handle(AGENT, 'assert', {
+      workspaceId: WORKSPACE,
+      type: 'assumption',
+      statement: '[fact:dup-supersede] v1 duplicate',
+    });
+    vi.useRealTimers();
+
+    const { current } = await facts.supersede(AGENT, {
+      workspaceId: WORKSPACE,
+      key: 'dup-supersede',
+      statement: 'v2',
+    });
+
+    // Without the pre-supersede heal, the newer duplicate would stay live
+    // and outrank the replacement (older createdAt) at the next reconcile.
+    const read = await facts.read(WORKSPACE, 'dup-supersede');
+    expect(read!.claim.id).toBe(current.claim.id);
+    expect(read!.statement).toBe('v2');
+    const live = (await factClaims(handler, WORKSPACE, 'dup-supersede')).filter(claim =>
+      LIVE.has(claim.status),
+    );
+    expect(live).toHaveLength(1);
+    expect(live[0]!.id).toBe(current.claim.id);
   });
 });

--- a/src/claims/standing-facts.ts
+++ b/src/claims/standing-facts.ts
@@ -25,6 +25,19 @@
  * lowercase [a-z0-9._-] so the case-insensitive substring match of
  * tb.claims.query finds exactly one key family; the closing `]` prevents
  * prefix collisions ("db" never matches "[fact:db-pool]").
+ *
+ * Keyed uniqueness is RECONCILE-BASED, not constraint-based: the claim
+ * store has no partial unique index on the fact key, so two concurrent
+ * `write`s of the same key can both pass the pre-check and both assert.
+ * `write` therefore asserts first and reconciles after: the DETERMINISTIC
+ * winner is the oldest live claim (createdAt, then claim id ascending);
+ * every other live claim for the key is retired, and a writer whose own
+ * claim lost gets the same "already exists" error a sequential duplicate
+ * write gets (first-writer-wins — write is create-only). `read`/`list`
+ * run the same reconcile lazily whenever they observe more than one live
+ * claim for a key, self-healing residual visibility windows and pre-fix
+ * duplicates. Reconcile never touches the winner, so a key that had a
+ * live fact can never end up with zero.
  */
 
 import type { Claim, ClaimType } from './types.js';
@@ -101,6 +114,37 @@ export function decodeFactStatement(
   return { key: match[1]!, statement: match[2]! };
 }
 
+/**
+ * Actor identity stamped on reconcile mutations that run inside the
+ * agent-less reads (`read`/`list`). The retirement is mechanical
+ * (duplicate cleanup), not an agent's judgment, so it gets a fixed
+ * system identity rather than borrowing whoever happened to read.
+ */
+const RECONCILE_ACTOR = 'standing-facts-reconcile';
+
+/**
+ * Deterministic winner order for duplicate live facts: oldest first
+ * (createdAt), claim id ascending as the tiebreak. Every reconciler —
+ * writer-side or reader-side, on any process — computes the same winner
+ * from the same set, so concurrent reconciles converge instead of
+ * fighting.
+ */
+function compareFactClaims(a: Claim, b: Claim): number {
+  return a.createdAt.localeCompare(b.createdAt) || a.id.localeCompare(b.id);
+}
+
+/**
+ * A reconcile loser whose retirement fails because a concurrent actor
+ * already moved it (retired via supersede, or a CAS conflict from a
+ * racing reconciler) is a benign race: the claim is no longer (or is
+ * about to stop being) a live duplicate, and the next read re-checks.
+ * Anything else — storage failure, missing claim — must propagate.
+ */
+function isBenignReconcileRace(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return /already superseded/.test(error.message) || /concurrent update/.test(error.message);
+}
+
 export function createStandingFacts(claims: ClaimsHandler): StandingFactsShim {
   function toFact(claim: Claim): StandingFact | null {
     const decoded = decodeFactStatement(claim.statement);
@@ -111,9 +155,8 @@ export function createStandingFacts(claims: ClaimsHandler): StandingFactsShim {
   /**
    * All live fact claims for a key. Query narrows by the encoded prefix
    * (case-insensitive substring), then the exact prefix + liveness are
-   * re-checked here. Multiple live claims for one key can only arise from
-   * writes that bypassed this shim; newest-first lets the reader converge
-   * on the latest assertion instead of failing.
+   * re-checked here. Sorted winner-first (oldest, id tiebreak): index 0
+   * is the claim reconcile keeps.
    */
   async function liveFactClaims(workspaceId: string, key: string): Promise<Claim[]> {
     const prefix = `[fact:${key}] `;
@@ -123,18 +166,53 @@ export function createStandingFacts(claims: ClaimsHandler): StandingFactsShim {
     })) as { claims: Claim[] };
     return result.claims
       .filter(claim => claim.statement.startsWith(prefix) && LIVE_STATUSES.has(claim.status))
-      .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+      .sort(compareFactClaims);
+  }
+
+  /**
+   * Collapse duplicate live facts for a key down to the deterministic
+   * winner; returns the winner (or null when the key has no live fact).
+   *
+   * Losers are retired through `tb.claims.invalidate` — the one
+   * ClaimsHandler transition that removes a claim from live status
+   * without minting a new claim (`tb.claims.supersede` always creates a
+   * fresh replacement, which would itself be a new live duplicate of the
+   * key). The winner is never touched, so reconcile can never leave the
+   * key with zero live facts. A partial unique index on the fact key is
+   * the constraint-based upgrade if standing facts become load-bearing.
+   */
+  async function reconcileLiveFacts(
+    actor: string,
+    workspaceId: string,
+    key: string,
+  ): Promise<Claim | null> {
+    const [winner, ...losers] = await liveFactClaims(workspaceId, key);
+    if (!winner) return null;
+    for (const loser of losers) {
+      try {
+        await claims.handle(actor, 'invalidate', { claimId: loser.id });
+      } catch (error) {
+        if (!isBenignReconcileRace(error)) throw error;
+      }
+    }
+    return winner;
+  }
+
+  function alreadyExistsError(key: string, workspaceId: string, claimId: string): Error {
+    return new Error(
+      `Standing fact "${key}" already exists in workspace ${workspaceId} ` +
+        `(claim ${claimId}); use supersede to revise it`,
+    );
   }
 
   return {
     async write(agentId, input) {
       const key = normalizeFactKey(input.key);
+      // Cheap pre-check for the friendly common-case error. NOT the
+      // guarantee: two concurrent writers can both pass it.
       const [existing] = await liveFactClaims(input.workspaceId, key);
       if (existing) {
-        throw new Error(
-          `Standing fact "${key}" already exists in workspace ${input.workspaceId} ` +
-            `(claim ${existing.id}); use supersede to revise it`,
-        );
+        throw alreadyExistsError(key, input.workspaceId, existing.id);
       }
       const claim = (await claims.handle(agentId, 'assert', {
         workspaceId: input.workspaceId,
@@ -142,12 +220,26 @@ export function createStandingFacts(claims: ClaimsHandler): StandingFactsShim {
         statement: encodeFactStatement(key, input.statement),
         ...(input.evidenceRefs !== undefined ? { evidenceRefs: input.evidenceRefs } : {}),
       })) as Claim;
+      // Assert-then-reconcile: re-query AFTER asserting so a concurrent
+      // duplicate is visible, then keep only the deterministic winner. If
+      // our own claim lost, reconcile already retired it — surface the
+      // same error a sequential duplicate write gets (first-writer-wins,
+      // matching write's create-only contract).
+      const winner = await reconcileLiveFacts(agentId, input.workspaceId, key);
+      if (winner && winner.id !== claim.id) {
+        throw alreadyExistsError(key, input.workspaceId, winner.id);
+      }
       return { key, statement: input.statement, claim };
     },
 
     async read(workspaceId, key) {
-      const [claim] = await liveFactClaims(workspaceId, normalizeFactKey(key));
-      return claim ? toFact(claim) : null;
+      const normalized = normalizeFactKey(key);
+      const live = await liveFactClaims(workspaceId, normalized);
+      if (live.length > 1) {
+        const winner = await reconcileLiveFacts(RECONCILE_ACTOR, workspaceId, normalized);
+        return winner ? toFact(winner) : null;
+      }
+      return live[0] ? toFact(live[0]) : null;
     },
 
     async list(workspaceId) {
@@ -155,9 +247,23 @@ export function createStandingFacts(claims: ClaimsHandler): StandingFactsShim {
         workspaceId,
         text: '[fact:',
       })) as { claims: Claim[] };
-      const facts: StandingFact[] = [];
+      const liveByKey = new Map<string, Claim[]>();
       for (const claim of result.claims) {
         if (!LIVE_STATUSES.has(claim.status)) continue;
+        const decoded = decodeFactStatement(claim.statement);
+        if (!decoded) continue;
+        const group = liveByKey.get(decoded.key);
+        if (group) group.push(claim);
+        else liveByKey.set(decoded.key, [claim]);
+      }
+      const facts: StandingFact[] = [];
+      for (const [key, group] of liveByKey) {
+        let claim: Claim | null = group.sort(compareFactClaims)[0]!;
+        if (group.length > 1) {
+          // Lazy heal: list never returns two facts with the same key.
+          claim = await reconcileLiveFacts(RECONCILE_ACTOR, workspaceId, key);
+        }
+        if (!claim) continue;
         const fact = toFact(claim);
         if (fact) facts.push(fact);
       }
@@ -166,7 +272,10 @@ export function createStandingFacts(claims: ClaimsHandler): StandingFactsShim {
 
     async supersede(agentId, input) {
       const key = normalizeFactKey(input.key);
-      const [existing] = await liveFactClaims(input.workspaceId, key);
+      // Heal duplicates BEFORE flipping: superseding the winner while a
+      // duplicate stayed live would leave that older duplicate outranking
+      // the fresh replacement at the next reconcile.
+      const existing = await reconcileLiveFacts(agentId, input.workspaceId, key);
       if (!existing) {
         throw new Error(
           `No live standing fact "${key}" in workspace ${input.workspaceId} to supersede; ` +


### PR DESCRIPTION
## Problem

`src/claims/standing-facts.ts` `write` was check-then-assert: two agents writing the same `(workspaceId, key)` concurrently both observed no existing live fact and both asserted, leaving duplicate live standing facts. `read` then silently picked one while `list` returned both.

## Fix (assert-then-reconcile, deterministic winner)

- **`write`**: keeps the cheap pre-check for the friendly sequential-duplicate error, asserts the new claim, then re-queries live facts for the key AFTER asserting. Winner = oldest by (`createdAt`, claim id ascending). Every live loser is retired; if the caller's own claim lost, it throws the same "already exists" error (first-writer-wins — `write` stays create-only). The winner is never touched, so reconcile can never leave a key with zero live facts.
- **`read` / `list`**: same reconcile runs lazily whenever >1 live fact is observed for a key — heals residual visibility windows and pre-fix duplicates; `list` never returns two facts with the same key.
- **`supersede`**: heals duplicates *before* flipping, so the fresh replacement is not outranked by a stale older duplicate at the next reconcile.
- Retirement failures are swallowed only for benign races (already superseded / concurrent-update CAS); everything else propagates.

**One deliberate adaptation from the approved design**: losers are retired via `tb.claims.invalidate`, not `tb.claims.supersede`. The ClaimsHandler `supersede` operation always mints a *new* replacement claim — it cannot point a loser at the existing winner, and its fresh replacement would itself be a new live duplicate of the key. `invalidate` is the only handler-mediated transition that removes liveness without minting a claim. All other design properties (deterministic oldest winner, first-writer-wins error, zero-live impossibility, benign-race swallowing) are implemented as specified.

## Tests

- Real-concurrency race (`Promise.allSettled`, 25 rounds to cover both id-tiebreak outcomes on equal-millisecond `createdAt`): exactly one winner, exactly one already-exists rejection, exactly one live fact = the oldest claim. **Red against the old implementation** (verified via `git stash`), green with the fix.
- Reader-side heal: duplicates seeded by bypassing the shim (direct `claims.assert` x2, fake timers for distinct `createdAt`) — `read`/`list` converge on the oldest and durably invalidate the loser.
- `supersede` pre-heal regression.
- Existing 9 shim tests untouched and green.

## Spec

SPEC-AGX-SUBSTRATE B11 delivery notes updated (same commit): keyed uniqueness is reconcile-based; a partial unique index on the fact key (live statuses only) is the named follow-up if standing facts become load-bearing.

## Gates

`pnpm check:types` ✅ · `pnpm check:lint` ✅ · `pnpm build:local` ✅ · `npx vitest run` — 944 passed, 2 failed: both `src/__tests__/branch-workers.test.ts` (known pre-existing local Supabase edge-runtime 503 environmental failures, untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)