### PR TITLE
fix(auth): parse api-key prefix positionally, mint hex prefixes

### DIFF
--- a/apps/web/src/app/w/[workspaceSlug]/api-keys/actions.ts
+++ b/apps/web/src/app/w/[workspaceSlug]/api-keys/actions.ts
@@ -1,8 +1,8 @@
 "use server";
 
-import { randomBytes } from "node:crypto";
 import bcrypt from "bcryptjs";
 import { revalidatePath } from "next/cache";
+import { generateApiKey } from "@/lib/api-keys/generate";
 import { createClient } from "@/lib/supabase/server";
 import type { ApiKeyRow } from "@/lib/types/api-keys";
 
@@ -51,8 +51,7 @@ export async function createApiKeyAction(
     return { error: "Name must be 64 characters or fewer." };
   }
 
-  const keyPrefix = randomBytes(6).toString("base64url");
-  const plainKey = `tbx_${keyPrefix}_${randomBytes(24).toString("base64url")}`;
+  const { prefix: keyPrefix, plainKey } = generateApiKey();
   const keyHash = await bcrypt.hash(plainKey, 12);
 
   const { error: insertError } = await supabase.from("api_keys").insert({

--- a/apps/web/src/lib/api-keys/generate.test.ts
+++ b/apps/web/src/lib/api-keys/generate.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { generateApiKey, API_KEY_PREFIX_LENGTH } from "./generate";
+
+/**
+ * Regression tests for the api-key prefix alphabet defect.
+ *
+ * Prefixes were previously generated from base64url, whose alphabet
+ * includes `_` and `-`; the MCP server's split-on-`_` parsing made
+ * ~11.8% of issued keys unresolvable. Issuance must now use an
+ * underscore-free alphabet (hex) so keys stay trivially parseable as
+ * `tbx_<8-char prefix>_<secret>`.
+ */
+describe("generateApiKey", () => {
+  it("never produces an underscore or hyphen in the prefix (hex alphabet)", () => {
+    for (let i = 0; i < 500; i++) {
+      const { prefix } = generateApiKey();
+      expect(prefix).toMatch(/^[0-9a-f]{8}$/);
+    }
+  });
+
+  it("keeps the 8-char prefix length contract", () => {
+    const { prefix } = generateApiKey();
+    expect(API_KEY_PREFIX_LENGTH).toBe(8);
+    expect(prefix).toHaveLength(API_KEY_PREFIX_LENGTH);
+  });
+
+  it("embeds the stored prefix positionally after tbx_", () => {
+    const { prefix, plainKey } = generateApiKey();
+    expect(plainKey).toMatch(/^tbx_[0-9a-f]{8}_[A-Za-z0-9_-]{32}$/);
+    expect(plainKey.slice(4, 4 + API_KEY_PREFIX_LENGTH)).toBe(prefix);
+    expect(plainKey.charAt(4 + API_KEY_PREFIX_LENGTH)).toBe("_");
+  });
+});

--- a/apps/web/src/lib/api-keys/generate.ts
+++ b/apps/web/src/lib/api-keys/generate.ts
@@ -1,0 +1,31 @@
+import { randomBytes } from "node:crypto";
+
+/**
+ * Length of the random prefix segment (excludes the `tbx_` scheme).
+ * The MCP server resolves keys by taking exactly this many characters
+ * after `tbx_` and matching them against `api_keys.prefix`
+ * (src/auth/api-key.ts) — keep the two in sync.
+ */
+export const API_KEY_PREFIX_LENGTH = 8;
+
+export interface GeneratedApiKey {
+  /** Stored whole in `api_keys.prefix`; shown in the dashboard key list. */
+  prefix: string;
+  /** Full key handed to the user once: `tbx_<prefix>_<secret>`. */
+  plainKey: string;
+}
+
+/**
+ * Generates a new API key.
+ *
+ * The prefix uses hex — an underscore-free alphabet — so the key is
+ * unambiguously parseable as `tbx_<8-char prefix>_<secret>`. Earlier
+ * issuance used base64url for the prefix, whose alphabet includes `_`;
+ * combined with split-on-`_` parsing on the server, ~11.8% of issued
+ * keys could never resolve.
+ */
+export function generateApiKey(): GeneratedApiKey {
+  const prefix = randomBytes(API_KEY_PREFIX_LENGTH / 2).toString("hex");
+  const plainKey = `tbx_${prefix}_${randomBytes(24).toString("base64url")}`;
+  return { prefix, plainKey };
+}

--- a/src/auth/__tests__/api-key.test.ts
+++ b/src/auth/__tests__/api-key.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import bcrypt from 'bcryptjs';
+
+/**
+ * Regression tests for the api-key prefix parsing defect.
+ *
+ * Issuance historically generated the 8-char prefix from the base64url
+ * alphabet, which includes `_` and `-`. Resolution used to split the key
+ * on `_` and take parts[1], so any prefix containing `_` was truncated,
+ * the DB lookup missed, and the key 401'd everywhere (~11.8% of keys).
+ * Resolution must parse positionally: the prefix is exactly the 8
+ * characters after `tbx_`.
+ */
+
+interface FakeRow {
+  workspace_id: string;
+  key_hash: string;
+  status: string;
+  prefix: string;
+}
+
+const rows: FakeRow[] = [];
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({
+    from: (table: string) => ({
+      select: () => ({
+        eq: (column: string, value: string) => ({
+          single: async () => {
+            expect(table).toBe('api_keys');
+            expect(column).toBe('prefix');
+            const matches = rows.filter((r) => r.prefix === value);
+            if (matches.length !== 1) {
+              return { data: null, error: { message: 'no or multiple rows' } };
+            }
+            return { data: matches[0], error: null };
+          },
+        }),
+      }),
+    }),
+  }),
+}));
+
+const { resolveApiKeyToWorkspace, extractPrefixCandidates, API_KEY_PREFIX_LENGTH } =
+  await import('../api-key.js');
+
+async function seedKey(
+  prefix: string,
+  plainKey: string,
+  workspaceId: string,
+  status = 'active',
+): Promise<void> {
+  rows.push({
+    prefix,
+    workspace_id: workspaceId,
+    key_hash: await bcrypt.hash(plainKey, 4),
+    status,
+  });
+}
+
+describe('extractPrefixCandidates', () => {
+  it('parses an underscore-containing prefix positionally (positional candidate first)', () => {
+    expect(extractPrefixCandidates('tbx_ab_cdefg_scrt')).toEqual([ // gitleaks:allow
+      'ab_cdefg',
+      'ab',
+    ]);
+  });
+
+  it('parses a hyphen-containing prefix positionally and dedupes the legacy candidate', () => {
+    expect(extractPrefixCandidates('tbx_ab-cdefg_scrt')).toEqual(['ab-cdefg']); // gitleaks:allow
+  });
+
+  it('parses a hex prefix', () => {
+    expect(extractPrefixCandidates('tbx_a1b2c3d4_scrt')).toEqual(['a1b2c3d4']); // gitleaks:allow
+  });
+
+  it('falls back to split parsing for a non-8-char legacy prefix', () => {
+    expect(extractPrefixCandidates('tbx_abc123_scrt')).toEqual(['abc123']); // gitleaks:allow
+  });
+
+  it('returns no candidates when there is no prefix/secret separator', () => {
+    expect(extractPrefixCandidates('tbx_abcdefgh')).toEqual([]);
+  });
+
+  it('prefix length constant matches issuance (8 chars)', () => {
+    expect(API_KEY_PREFIX_LENGTH).toBe(8);
+  });
+});
+
+describe('resolveApiKeyToWorkspace', () => {
+  beforeEach(() => {
+    rows.length = 0;
+    process.env.SUPABASE_URL = 'http://localhost:54321';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-test';
+  });
+
+  it('resolves a key whose prefix contains an underscore (rescues existing keys)', async () => {
+    const key = 'tbx_ab_cdefg_scrt1'; // gitleaks:allow
+    await seedKey('ab_cdefg', key, 'ws-underscore');
+    await expect(resolveApiKeyToWorkspace(key)).resolves.toBe('ws-underscore');
+  });
+
+  it('resolves a key whose prefix contains a hyphen', async () => {
+    const key = 'tbx_ab-cdefg_scrt2'; // gitleaks:allow
+    await seedKey('ab-cdefg', key, 'ws-hyphen');
+    await expect(resolveApiKeyToWorkspace(key)).resolves.toBe('ws-hyphen');
+  });
+
+  it('resolves a new-format hex-prefix key', async () => {
+    const key = 'tbx_a1b2c3d4_scrt3'; // gitleaks:allow
+    await seedKey('a1b2c3d4', key, 'ws-hex');
+    await expect(resolveApiKeyToWorkspace(key)).resolves.toBe('ws-hex');
+  });
+
+  it('resolves a legacy key with a non-8-char prefix via the split fallback', async () => {
+    const key = 'tbx_abc123_scrt4'; // gitleaks:allow
+    await seedKey('abc123', key, 'ws-legacy');
+    await expect(resolveApiKeyToWorkspace(key)).resolves.toBe('ws-legacy');
+  });
+
+  it('rejects a key with a wrong secret', async () => {
+    await seedKey('a1b2c3d4', 'tbx_a1b2c3d4_real', 'ws-hex');
+    await expect(
+      resolveApiKeyToWorkspace('tbx_a1b2c3d4_wrong'),
+    ).rejects.toThrow('Invalid API key');
+  });
+
+  it('rejects an inactive key with a distinct error', async () => {
+    const key = 'tbx_a1b2c3d4_scrt3'; // gitleaks:allow
+    await seedKey('a1b2c3d4', key, 'ws-hex', 'revoked');
+    await expect(resolveApiKeyToWorkspace(key)).rejects.toThrow(
+      'API key is not active',
+    );
+  });
+
+  it('rejects keys without the tbx_ scheme', async () => {
+    await expect(resolveApiKeyToWorkspace('sk_live_nope_nope')).rejects.toThrow(
+      'Invalid API key format',
+    );
+  });
+
+  it('rejects unresolvable keys cleanly', async () => {
+    await expect(
+      resolveApiKeyToWorkspace('tbx_deadbeef_none'),
+    ).rejects.toThrow('Invalid API key');
+  });
+});

--- a/src/auth/api-key.ts
+++ b/src/auth/api-key.ts
@@ -1,30 +1,72 @@
 import { createClient } from '@supabase/supabase-js';
 import bcrypt from 'bcryptjs';
 
+/** Length of the random prefix segment issued by the web app (excludes `tbx_`). */
+export const API_KEY_PREFIX_LENGTH = 8;
+
+const KEY_SCHEME = 'tbx_';
+
+/**
+ * Extracts the candidate `api_keys.prefix` values for an incoming key.
+ *
+ * Key format (issuance: apps/web/src/app/w/[workspaceSlug]/api-keys/actions.ts):
+ *   `tbx_<prefix:8><_><secret>`
+ *
+ * The prefix MUST be parsed positionally — it is exactly the 8 characters
+ * after `tbx_`. Historically issued prefixes used the base64url alphabet,
+ * which includes `_`, so splitting the key on `_` truncates ~11.8% of
+ * prefixes and made those keys unresolvable. The stored prefix was always
+ * the full 8 characters, so positional parsing rescues those keys.
+ *
+ * A legacy split-based candidate is kept as a defensive fallback for any
+ * hypothetical old-format key whose prefix segment is not 8 characters.
+ *
+ * @returns Candidate prefixes in lookup order (positional first), deduped.
+ */
+export function extractPrefixCandidates(providedKey: string): string[] {
+  const candidates: string[] = [];
+
+  // Positional parse: `tbx_` + exactly 8 chars + `_` separator + secret.
+  const positional = providedKey.slice(
+    KEY_SCHEME.length,
+    KEY_SCHEME.length + API_KEY_PREFIX_LENGTH,
+  );
+  if (
+    positional.length === API_KEY_PREFIX_LENGTH &&
+    providedKey.charAt(KEY_SCHEME.length + API_KEY_PREFIX_LENGTH) === '_'
+  ) {
+    candidates.push(positional);
+  }
+
+  // Legacy parse: second underscore-delimited segment.
+  const parts = providedKey.split('_');
+  if (parts.length >= 3 && parts[1] && !candidates.includes(parts[1])) {
+    candidates.push(parts[1]);
+  }
+
+  return candidates;
+}
+
 /**
  * Resolves an incoming API key (e.g., tbx_abc123...xyz) to a workspace ID.
- * 
- * 1. Extracts the prefix.
+ *
+ * 1. Extracts candidate prefixes (positional parse first, legacy split fallback).
  * 2. Queries the `api_keys` table using a Service Role key.
  * 3. Verifies the full key against the stored `key_hash` using bcrypt.
- * 
+ *
  * @param providedKey The raw API key provided by the client.
  * @returns The `workspace_id` associated with the key.
  * @throws Error if the key is invalid, inactive, or not found.
  */
 export async function resolveApiKeyToWorkspace(providedKey: string): Promise<string> {
-  if (!providedKey || !providedKey.startsWith('tbx_')) {
+  if (!providedKey || !providedKey.startsWith(KEY_SCHEME)) {
     throw new Error('Invalid API key format');
   }
 
-  // Extract the prefix (first 12 characters including 'tbx_')
-  // Format: tbx_prefix_rest_of_key (e.g., tbx_a1b2c3d4_...)
-  const parts = providedKey.split('_');
-  if (parts.length < 3) {
+  const candidates = extractPrefixCandidates(providedKey);
+  if (candidates.length === 0) {
     throw new Error('Invalid API key format');
   }
-  
-  const prefix = parts[1];
 
   const supabaseUrl = process.env.SUPABASE_URL;
   const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
@@ -41,24 +83,29 @@ export async function resolveApiKeyToWorkspace(providedKey: string): Promise<str
     }
   });
 
-  const { data, error } = await adminClient
-    .from('api_keys')
-    .select('workspace_id, key_hash, status')
-    .eq('prefix', prefix)
-    .single();
+  let failure = 'Invalid API key';
 
-  if (error || !data) {
-    throw new Error('Invalid API key');
+  for (const prefix of candidates) {
+    const { data, error } = await adminClient
+      .from('api_keys')
+      .select('workspace_id, key_hash, status')
+      .eq('prefix', prefix)
+      .single();
+
+    if (error || !data) {
+      continue; // No row for this candidate; try the next one.
+    }
+
+    if (data.status !== 'active') {
+      failure = 'API key is not active';
+      continue;
+    }
+
+    const isValid = await bcrypt.compare(providedKey, data.key_hash);
+    if (isValid) {
+      return data.workspace_id;
+    }
   }
 
-  if (data.status !== 'active') {
-    throw new Error('API key is not active');
-  }
-
-  const isValid = await bcrypt.compare(providedKey, data.key_hash);
-  if (!isValid) {
-    throw new Error('Invalid API key');
-  }
-
-  return data.workspace_id;
+  throw new Error(failure);
 }


### PR DESCRIPTION
Fixes #430 — live-verified during the rebuild acceptance run: ~1 in 8 web-issued API keys (P ≈ 11.8%) returned 401 on every request.

## Root cause

- **Issuance** (`apps/web/.../api-keys/actions.ts`) generated the 8-char prefix with `randomBytes(6).toString("base64url")` — an alphabet that includes `_` and `-`. The full 8-char prefix was stored correctly in `api_keys.prefix`; the key is `tbx_<prefix>_<secret>`.
- **Resolution** (`src/auth/api-key.ts`) did `providedKey.split('_')` and looked up `parts[1]`. Any `_` inside the prefix truncated the lookup value → DB miss → "Invalid API key".

## Fix (both sides)

1. **Resolution parses positionally**: the prefix is exactly the 8 characters after `tbx_` (`extractPrefixCandidates`). This immediately rescues all existing dead keys in prod — **no rotation needed**. The legacy split-based lookup is kept as a defensive fallback for any hypothetical old-format key; unresolvable keys are rejected cleanly.
2. **Issuance mints hex prefixes**: `randomBytes(4).toString("hex")` — underscore-free alphabet, same 8-char length and stored-prefix contract. Generation is extracted to `apps/web/src/lib/api-keys/generate.ts` so it is unit-testable.
3. **Regression tests both sides**: keys with `_` and `-` in the prefix resolve (`src/auth/__tests__/api-key.test.ts`, mocked Supabase + real bcrypt); issuance can no longer produce `_`/`-` in a prefix (`apps/web/src/lib/api-keys/generate.test.ts`, 500 samples).

Issuance verified against resolution invariants: the web action is the only `tbx_` key-minting path in the repo (`rg tbx_` across src/, scripts/, apps/, infra/).

## Gates

- `pnpm check:types` ✓, `pnpm check:lint` ✓, `pnpm build:local` ✓
- `npx vitest run`: 1043 passed, 2 failed — the two known pre-existing environmental failures in `src/__tests__/branch-workers.test.ts` (local Supabase edge runtime 503)
- `apps/web`: `npx tsc --noEmit` ✓; vitest 48 passed / 9 failed — all 9 failures pre-exist on origin/main unchanged (middleware/auth-callback/merge-route mock-hoisting failures, byte-identical with the diff stashed) and are untouched by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)